### PR TITLE
grid client: Fix relay hostname in module docs

### DIFF
--- a/packages/grid_client/docs/module.md
+++ b/packages/grid_client/docs/module.md
@@ -14,7 +14,7 @@ Module should be:
 ### Twins
 
 **Note:** Each network has its own relay. So, the relay would be
-"wss://relay.${network}.grid.tf" in all networks except for main. It would be "wss://relay.grid.tf".
+"relay.${network}.grid.tf" in all networks except for main. It would be "relay.grid.tf".
 
 - **Create**
 
@@ -1051,7 +1051,7 @@ single master and multiple workers.
   It will create a new account on tfchain.
 
   **Note:** Each network has its own relay. So, the relay would be
-  "wss://relay.${network}.grid.tf" in all networks except for main. It would be "wss://relay.grid.tf".
+  "relay.${network}.grid.tf" in all networks except for main. It would be "relay.grid.tf".
 
   cmd: `twinserver.tfchain.create`
 

--- a/packages/grid_http_server/README.md
+++ b/packages/grid_http_server/README.md
@@ -73,6 +73,12 @@ You can also use another configuration file by using `--config` or `-c` option.
 
 ## Usage
 
+All APIs supported can be executed by sending a post request to the server. To execute a method on a module, the module name followed by the method name should be sent on the request endpoint to be like `http://localhost:3000/{module}/{method}` and the arguments should be sent in request's body.
+
+There is a ping endpoint as well to make sure that the server is up and running `http://localhost:3000/ping`
+
+### Example
+
 This is an example of getting a twin.
 Put the following content in a file `test_twin.ts`
 

--- a/packages/grid_http_server/src/server.ts
+++ b/packages/grid_http_server/src/server.ts
@@ -97,7 +97,7 @@ class HttpServer {
   }
 }
 
-if (!(config.network && config.mnemonic && config.storeSecret)) {
+if (!(config.network && config.mnemonic)) {
   throw new Error(`Invalid config. Please fill the config.json file with the correct data`);
 }
 

--- a/packages/grid_http_server/src/server.ts
+++ b/packages/grid_http_server/src/server.ts
@@ -83,7 +83,7 @@ class HttpServer {
 
   run() {
     // ping-pong the server
-    this.server.use("/ping", (req, res, next) => res.status(404).json("pong"));
+    this.server.use("/ping", (req, res, next) => res.status(200).json("pong"));
 
     /** Error handling */
     this.server.use((req, res, next) => {

--- a/packages/grid_rmb_server/src/server.ts
+++ b/packages/grid_rmb_server/src/server.ts
@@ -53,7 +53,7 @@ class Server {
   }
 }
 
-if (!(config.network && config.mnemonic && config.storeSecret)) {
+if (!(config.network && config.mnemonic)) {
   throw new Error(`Invalid config. Please fill the config.json file with the correct data`);
 }
 


### PR DESCRIPTION
### Description

- Fix relay hostname in module docs
- Fix the status code of ping endpoint on the http server
- Add http server usage
- Make the http and rmb servers able to run without setting the store secret

### Related Issues

- #7 
- #9 
- #175 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
