### PR TITLE
rmb direct client: Set the public key on the twin if it doesn't match the generated one

### DIFF
--- a/packages/rmb_direct_client/lib/client.ts
+++ b/packages/rmb_direct_client/lib/client.ts
@@ -105,8 +105,8 @@ class Client {
       if (!this.twin) {
         throw new Error({ message: "twin does not exist, please create a twin first" });
       }
-      if (!this.twin.pk) {
-        const pk = generatePublicKey(this.mnemonics);
+      const pk = generatePublicKey(this.mnemonics);
+      if (this.twin.pk !== pk) {
         await applyExtrinsic(setPublicKey, [this.mnemonics, pk, this.api!, this.relayUrl, this.keypairType]);
         this.twin.pk = pk;
       }


### PR DESCRIPTION
### Related Issues

- #88 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
