### PR TITLE
Add build for http server too

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  docker-image:
+  docker-image-grid-client:
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -70,4 +70,36 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GRID3_CLIENT_VERSION=${{ steps.meta.outputs.version }}
+            GRID_VERSION=${{ steps.meta.outputs.version }}
+
+  docker-image-grid-http-server:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/threefoldtech/grid_http_server
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: packages/grid_http_server
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GRID_VERSION=${{ steps.meta.outputs.version }}

--- a/packages/grid_client/Dockerfile
+++ b/packages/grid_client/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ARG GRID3_CLIENT_VERSION
-RUN apk add nodejs npm curl && npm install --global yarn && yarn add @threefold/grid_client@${GRID3_CLIENT_VERSION}
+ARG GRID_VERSION
+RUN apk add nodejs npm curl && npm install --global yarn && yarn add @threefold/grid_client@${GRID_VERSION}
 
 ENTRYPOINT [ "yarn" ]

--- a/packages/grid_http_server/Dockerfile
+++ b/packages/grid_http_server/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+ARG GRID_VERSION
+RUN apk add nodejs npm curl && npm install --global yarn && yarn add @threefold/grid_http_server@${GRID_VERSION}
+
+ENTRYPOINT [ "yarn" ]


### PR DESCRIPTION
This completes #183:
- Another docker image is published containing the package grid_http_server
