### PR TITLE
handle null nodeStatistics values

### DIFF
--- a/packages/dashboard/src/explorer/components/NodeDetails.vue
+++ b/packages/dashboard/src/explorer/components/NodeDetails.vue
@@ -96,21 +96,21 @@
           </v-list-item>
           <v-divider />
 
-          <v-list-item>
+          <v-list-item v-if="nodeStatistics?.users.workloads">
             <v-list-item-content>
               <v-list-item-title> Number of Workloads </v-list-item-title>
             </v-list-item-content>
             {{ nodeStatistics.users.workloads }}
           </v-list-item>
-          <v-divider />
+          <v-divider v-if="nodeStatistics?.users.workloads" />
 
-          <v-list-item>
+          <v-list-item v-if="nodeStatistics?.users.workloads">
             <v-list-item-content>
               <v-list-item-title> Number of Deployments </v-list-item-title>
             </v-list-item-content>
             {{ nodeStatistics.users.deployments }}
           </v-list-item>
-          <v-divider />
+          <v-divider v-if="nodeStatistics?.users.workloads" />
 
           <v-list-item v-if="zosVersion">
             <v-list-item-content>


### PR DESCRIPTION
### Description

some times nodeStatistics values are null, so it will cause an error that will hide nodeDetails section,
no it handled by v-if 


### Related Issues

- #41 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
