### PR TITLE
grid client: Fix storing redundant keys

### DIFF
--- a/packages/grid_client/src/primitives/network.ts
+++ b/packages/grid_client/src/primitives/network.ts
@@ -588,7 +588,8 @@ PersistentKeepalive = 25\nEndpoint = ${endpoint}`;
 
   async _save(network): Promise<void> {
     const path = PATH.join(this.getNetworksPath(), this.name, "info.json");
-    await this.backendStorage.dump(path, network);
+    const current = await this.backendStorage.load(path);
+    if (JSON.stringify(current) !== JSON.stringify(network)) await this.backendStorage.dump(path, network);
   }
 
   async delete(): Promise<void> {


### PR DESCRIPTION
### Description

- check the network key if it has the same content before storing the new info
- add a check to not store the same network twin after the deployment is done
- don't return the contract that contains only the network workload as it's already handled by the deployer.

### Related Issues

- #199 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
