### PR TITLE
fix validating address on withdraw

### DIFF
--- a/packages/dashboard/src/portal/views/Swap.vue
+++ b/packages/dashboard/src/portal/views/Swap.vue
@@ -57,6 +57,8 @@
                 v-model="target"
                 :label="selectedName.toUpperCase() + ' Target Wallet Address'"
                 :error-messages="targetError"
+                :disabled="validatingAddress"
+                :loading="validatingAddress"
                 :rules="[() => !!target || 'This field is required', swapAddressCheck]"
               >
               </v-text-field>
@@ -82,7 +84,7 @@
             <v-btn
               class="primary white--text"
               @click="withdrawTFT(target, amount)"
-              :disabled="!isValidSwap"
+              :disabled="!isValidSwap || validatingAddress"
               :loading="loadingWithdraw"
               >Submit</v-btn
             >
@@ -153,6 +155,7 @@ export default class TransferView extends Vue {
   loadingWithdraw = false;
   targetError = "";
   server = new StellarSdk.Server(config.horizonUrl);
+  validatingAddress = false;
 
   mounted() {
     if (this.$api && this.$store.state.credentials.initialized) {
@@ -181,44 +184,49 @@ export default class TransferView extends Vue {
     this.$store.commit("UNSET_CREDENTIALS");
   }
 
-  async swapAddressCheck() {
-    if (this.target.length > 0) {
-      const isValid = StrKey.isValidEd25519PublicKey(this.target);
-      const blockedAddresses = [
-        "GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC",
-        "GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4",
-      ];
-      if (blockedAddresses.includes(this.target)) {
-        this.targetError = "Blocked Address";
-        return false;
-      }
-
-      if (!isValid || this.target.match(/\W/)) {
-        this.targetError = "invalid address";
-        return false;
-      }
-
-      if (this.selectedName == "stellar") {
-        try {
-          // check if the account provided exists on stellar
-          const account = await this.server.loadAccount(this.target);
-          // check if the account provided has the appropriate trustlines
-          const includes = account.balances.find(
-            (b: { asset_code: string; asset_issuer: string }) =>
-              b.asset_code === "TFT" && b.asset_issuer === config.tftAssetIssuer,
-          );
-          if (!includes) {
-            this.targetError = "Address does not have a valid trustline to TFT";
-            return false;
-          }
-        } catch (error) {
-          this.targetError = "Address not found";
-          return false;
-        }
-      }
-      this.targetError = "";
-      return true;
+  swapAddressCheck() {
+    if (!this.target) return true;
+    const isValid = StrKey.isValidEd25519PublicKey(this.target);
+    const blockedAddresses = [
+      "GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC",
+      "GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4",
+    ];
+    if (blockedAddresses.includes(this.target)) {
+      this.targetError = "Blocked Address";
+      return false;
     }
+    if (!isValid || this.target.match(/\W/)) {
+      this.targetError = "invalid address";
+      return false;
+    }
+    this.targetError = "";
+    this.validatingAddress = true;
+    this.isValidSwap = false;
+    if (this.selectedName == "stellar") this.validateAddress();
+    return true;
+  }
+  async validateAddress() {
+    try {
+      // check if the account provided exists on stellar
+      const account = await this.server.loadAccount(this.target);
+      // check if the account provided has the appropriate trustlines
+      const includes = account.balances.find(
+        (b: { asset_code: string; asset_issuer: string }) =>
+          b.asset_code === "TFT" && b.asset_issuer === config.tftAssetIssuer,
+      );
+      if (!includes) throw new Error("invalid trustline");
+    } catch (e) {
+      this.targetError =
+        (e as Error).message === "invalid trustline"
+          ? "Address does not have a valid trustline to TFT"
+          : "Address not found";
+      this.validatingAddress = false;
+      this.isValidSwap = false;
+      return;
+    }
+    this.targetError = "";
+    this.validatingAddress = false;
+    return;
   }
   public async withdrawTFT(target: string, amount: number) {
     this.loadingWithdraw = true;


### PR DESCRIPTION
### Description

the address field has an asynchronous function `swapAddressCheck` in its rules; the asynchronous part calls an endpoint to validate the entered address, my solution is to move this asynchronous part into a separate function and call it whenever the field is valid.

### Changes 

refactor the address validation logic




### Related Issues
- #50

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
