### PR TITLE
update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: lerna run build --no-private
       - name: Publish
-        run: lerna publish from-package --yes
+        run: lerna publish from-package --no-private --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,18 +26,11 @@ jobs:
           cache: "yarn"
 
       - name: Install
-        run: yarn
+        run: yarn --pure-lockfile
       - name: Build
         run: lerna run build --no-private
       - name: Publish
-        run: |
-          yarn workspace @threefold/tfchain_client publish
-          yarn workspace @threefold/rmb_direct_client publish
-          yarn workspace @threefold/rmb_peer_client publish
-          yarn workspace @threefold/rmb_peer_server publish
-          yarn workspace @threefold/grid_client publish
-          yarn workspace @threefold/grid_http_server publish
-          yarn workspace @threefold/grid_rmb_server publish
+        run: lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
### Description

now we are using the lerna publish command, but it may fail if the yarn command leads to some changes in the yarn.lock so we add a `--pure-lockfile` to prevent yarn from creating a lock file, this shouldn't happen in this repo but the flag added to make sure the workflow will pass in that edge case.
I tested this workflow on a test mono repo and it works fine. 
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/f3f7dc7b-3c9b-48e5-9bf6-f08963e6f75d)



