### PR TITLE
Update validation logic for the node filter

### DIFF
--- a/packages/dashboard/src/explorer/utils/validations.ts
+++ b/packages/dashboard/src/explorer/utils/validations.ts
@@ -30,8 +30,8 @@ export function inputValidation(value: string, key: string): string {
   let errorMsg = "";
 
   if (numericFields.includes(key)) {
-    if (isNaN(+value) || specialChars.test(value) || +value < 0 || value.includes("e")) {
-      errorMsg = "This field must be a number.";
+    if (isNaN(+value) || specialChars.test(value) || +value <= 0 || value.includes("e")) {
+      errorMsg = "This field must be a number and larger than 0.";
       return errorMsg;
     }
   } else if (countryFields.includes(key)) {

--- a/packages/dashboard/src/explorer/utils/validations.ts
+++ b/packages/dashboard/src/explorer/utils/validations.ts
@@ -31,7 +31,7 @@ export function inputValidation(value: string, key: string): string {
 
   if (numericFields.includes(key)) {
     if (isNaN(+value) || specialChars.test(value) || +value <= 0 || value.includes("e")) {
-      errorMsg = "This field must be a number and larger than 0.";
+      errorMsg = "This field must be a number larger than 0.";
       return errorMsg;
     }
   } else if (countryFields.includes(key)) {


### PR DESCRIPTION
### Description

A validation check in the earlier code prevented numbers lower than 0 from being used. Only values larger than 0 should be permitted in the number fields.

In the new code, the condition +value < 0 in the old version has been changed to +value <= 0. This ensures that negative values and zero are considered invalid for the field.

The updated error message reflects the new validation rules and states: "This field must be a number larger than 0."

### Related Issues

- #42 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
