### PR TITLE
Use the statistics endpoint to get nodes used resources.

### DIFF
--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -48,6 +48,7 @@
 </template>
 
 <script lang="ts">
+import axios from "axios";
 import { DocumentNode } from "graphql";
 import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
@@ -119,9 +120,11 @@ export default class Details extends Vue {
             res.json(),
           );
           try {
-            this.data.nodeStatistics = await fetch(
-              `${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`,
-            ).then(res => res.json());
+            this.data.nodeStatistics = await (
+              await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`, {
+                timeout: 3000,
+              })
+            ).data;
           } catch (error) {
             console.log(error);
           }

--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -122,7 +122,7 @@ export default class Details extends Vue {
           try {
             this.data.nodeStatistics = await (
               await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`, {
-                timeout: 3000,
+                timeout: 5000,
               })
             ).data;
           } catch (error) {

--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -4,7 +4,7 @@
       <div class="content" v-if="!loading">
         <v-row>
           <v-col v-if="node">
-            <NodeUsedResources :node="node" />
+            <NodeUsedResources :nodeStatistics="nodeStatistics" :nodeStatus="node.status" />
           </v-col>
         </v-row>
         <v-row>

--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -118,9 +118,13 @@ export default class Details extends Vue {
           this.data.node = await fetch(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}`).then(res =>
             res.json(),
           );
-          this.data.nodeStatistics = await fetch(
-            `${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`,
-          ).then(res => res.json());
+          try {
+            this.data.nodeStatistics = await fetch(
+              `${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`,
+            ).then(res => res.json());
+          } catch (error) {
+            console.log(error);
+          }
           this.data.node.status = this.data.node.status === "up";
         }
       })

--- a/packages/dashboard/src/explorer/components/NodeUsedResources.vue
+++ b/packages/dashboard/src/explorer/components/NodeUsedResources.vue
@@ -78,7 +78,7 @@ export default class NodeUsedResources extends Vue {
     });
   }
   created() {
-    if (this.nodeStatus) {
+    if (this.nodeStatus && this.nodeStatistics) {
       const resources = this.getNodeUsedResources();
       if (resources) {
         this.resources = resources;

--- a/packages/dashboard/src/explorer/components/NodeUsedResources.vue
+++ b/packages/dashboard/src/explorer/components/NodeUsedResources.vue
@@ -52,25 +52,22 @@
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
 
-import { INode } from "../graphql/api";
+import { INodeStatistics } from "../graphql/api";
 
 @Component({})
 export default class NodeUsedResources extends Vue {
-  @Prop({ required: true }) node!: INode;
+  @Prop({ required: true }) nodeStatistics!: INodeStatistics;
+  @Prop({ required: true }) nodeStatus!: boolean;
   resources: any[] = [];
   loader = false;
-
-  get nodeStatus(): boolean {
-    return this.node.status;
-  }
 
   getNodeUsedResources() {
     this.loader = true;
 
     return ["cru", "sru", "hru", "mru"].map((i, idx) => {
       const value =
-        this.node.capacity.total_resources[i] != 0
-          ? (this.node.capacity.used_resources[i] / this.node.capacity.total_resources[i]) * 100
+        this.nodeStatistics.total[i] != 0
+          ? ((this.nodeStatistics.used[i] + this.nodeStatistics.system[i]) / this.nodeStatistics.total[i]) * 100
           : NaN; // prettier-ignore, validate if the total is zero so the usage is set to NaN else do the division
       this.loader = false;
       return {

--- a/packages/dashboard/src/explorer/graphql/api.ts
+++ b/packages/dashboard/src/explorer/graphql/api.ts
@@ -101,8 +101,18 @@ export interface INodeStatisticsUser {
   workloads: number;
 }
 
+export interface INodeResources {
+  [key: string]: number;
+  cru: number;
+  hru: number;
+  mru: number;
+  sru: number;
+}
 export interface INodeStatistics {
   users: INodeStatisticsUser;
+  system: INodeResources;
+  total: INodeResources;
+  used: INodeResources;
 }
 
 export const PublicConfigType = gql`


### PR DESCRIPTION
### Description

The statistics endpoint provides more accurate data about the used resources of the node.

### Changes

- Add the `INodeResources` interface
- Modify the `INodeStatistics` interface
- use Axios to fetch statistics with timeout 3ms
- Handle fetching statistics errors if the node is `up`

### Related Issues

- #188 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
