### PR TITLE
Add tooltip to Serial number in farms nodes

### DIFF
--- a/packages/dashboard/src/portal/components/FarmNodesTable.vue
+++ b/packages/dashboard/src/portal/components/FarmNodesTable.vue
@@ -44,7 +44,7 @@
               <template v-slot:activator="{ on, attrs }">
                 <v-icon medium v-on="on" v-bind="attrs"> mdi-information </v-icon>
               </template>
-              <span>silver boxes default serial number</span>
+              <span>The manufacturer didn't provide a proper serial number</span>
             </v-tooltip>
           </p>
         </template>

--- a/packages/dashboard/src/portal/components/FarmNodesTable.vue
+++ b/packages/dashboard/src/portal/components/FarmNodesTable.vue
@@ -37,6 +37,18 @@
             {{ item.nodeId }}
           </p>
         </template>
+        <template v-slot:[`item.serialNumber`]="{ item }">
+          <p class="text-center mt-1 mb-0">
+            {{ item.serialNumber }}
+            <v-tooltip right v-if="item.serialNumber === `Default string`">
+              <template v-slot:activator="{ on, attrs }">
+                <v-icon medium v-on="on" v-bind="attrs"> mdi-information </v-icon>
+              </template>
+              <span>silver boxes default serial number</span>
+            </v-tooltip>
+          </p>
+        </template>
+
         <template v-slot:[`item.status`]="{ item }">
           <p class="text-center mt-1 mb-0">
             <v-chip :color="getStatus(item).color">{{ getStatus(item).status }}</v-chip>


### PR DESCRIPTION
### Description

Adding a tooltip to explain why the serial number is "Default string"

### Related Issues

- #48 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
