### PR TITLE
Fix error index in case of it has zeros at the end

### DIFF
--- a/packages/tfchain_client/src/client.ts
+++ b/packages/tfchain_client/src/client.ts
@@ -285,7 +285,8 @@ class Client extends QueryClient {
           events.forEach(({ phase, event: { data, method, section } }) => {
             console.log(`phase: ${phase}, section: ${section}, method: ${method}, data: ${data}`);
             if (section === SYSTEM && method === ExtrinsicState.ExtrinsicFailed) {
-              const errorIndex = parseInt(data.toJSON()[0].module.error.replace(/0+$/g, ""));
+              const [dispatchError, _] = data;
+              const errorIndex = dispatchError.asModule.error[0];
               reject(errorIndex);
             } else if (
               resultSections.includes(section) &&


### PR DESCRIPTION
### Description

in case the error index has zeros at the end, these zeros got dropped and the error index became irrelevant

### Related Issues

#273 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
