### PR TITLE
Fix deleting k8s workers and machines

### DIFF
--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -460,7 +460,6 @@ class TwinDeploymentHandler {
       nameExtrinsics = nameExtrinsics.concat(extrinsics.nameExtrinsics);
       deletedExtrinsics = deletedExtrinsics.concat(extrinsics.deletedExtrinsics);
     }
-    events.emit("logs", "Creating contracts");
     const extrinsicResults: Contract[] = await this.tfclient.applyAllExtrinsics<Contract>([
       ...nodeExtrinsics,
       ...nameExtrinsics,


### PR DESCRIPTION
### Description

after splitting the network into separate deployment, the deployments of the machine now doesn't have network workloads to update/delete the keys of the network deployment. so it was need to be loaded from the machine workload

### Related Issues

- #280 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
