### PR TITLE
Fix saving networks keys in case more than one node is used

### DIFF
--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -125,11 +125,8 @@ class TwinDeploymentHandler {
   }
 
   async saveNetworks(twinDeployments: TwinDeployment[]) {
-    const savedNetworkNames: string[] = [];
     for (const twinDeployment of twinDeployments) {
       if (twinDeployment.network) {
-        if (savedNetworkNames.includes(twinDeployment.network.name)) continue;
-        savedNetworkNames.push(twinDeployment.network.name);
         if (twinDeployment.operation === Operations.delete) {
           await twinDeployment.network.save();
           continue;


### PR DESCRIPTION
### Description

Fix saving networks keys in case more than one node is used

### Related Issues

- #364 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
