### PR TITLE
Fix gridclient tests

### DIFF
--- a/packages/grid_client/tests/modules/gateways.test.ts
+++ b/packages/grid_client/tests/modules/gateways.test.ts
@@ -131,7 +131,7 @@ test("TC1237 - Gateways: Expose a VM Over Gateway", async () => {
   log(res);
 
   //Contracts Assertions
-  expect(res.contracts.created).toHaveLength(2);
+  expect(res.contracts.created).toHaveLength(1);
   expect(res.contracts.updated).toHaveLength(0);
   expect(res.contracts.deleted).toHaveLength(0);
 

--- a/packages/grid_client/tests/modules/kubernetes.test.ts
+++ b/packages/grid_client/tests/modules/kubernetes.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
 const ipRegex = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/;
 
 // Skipped until this issue is fixed: https://github.com/threefoldtech/tf-images/issues/133
-test.skip("TC1231 - Kubernetes: Deploy a Kubernetes Cluster (https://github.com/threefoldtech/tf-images/issues/133)", async () => {
+test("TC1231 - Kubernetes: Deploy a Kubernetes Cluster", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)
      Test Cases: TC1231 - Kubernetes: Deploy a Kubernetes Cluster
@@ -243,7 +243,7 @@ test.skip("TC1231 - Kubernetes: Deploy a Kubernetes Cluster (https://github.com/
     });
 
     //Execute kubectl get nodes.
-    await masterSSH.execCommand("kubectl get nodes").then(async function (result) {
+    await masterSSH.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
       log(result.stdout);
       expect(result.stdout).toContain(masterName.toLowerCase());
       expect(result.stdout).toContain(workerName.toLowerCase());
@@ -279,7 +279,7 @@ test.skip("TC1231 - Kubernetes: Deploy a Kubernetes Cluster (https://github.com/
 });
 
 // Skipped until this issue is fixed: https://github.com/threefoldtech/tf-images/issues/133
-test.skip("TC1232 - Kubernetes: Add Worker (https://github.com/threefoldtech/tf-images/issues/133)", async () => {
+test("TC1232 - Kubernetes: Add Worker", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)
      Test Cases: TC1232 - Kubernetes: Add Worker
@@ -498,7 +498,7 @@ test.skip("TC1232 - Kubernetes: Add Worker (https://github.com/threefoldtech/tf-
 
   //Execute kubectl get nodes.
   try {
-    await masterSSH.execCommand("kubectl get nodes").then(async function (result) {
+    await masterSSH.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
       log(result.stdout);
       expect(result.stdout).toContain(masterName.toLowerCase());
       expect(result.stdout).toContain(workerName.toLowerCase());

--- a/packages/grid_client/tests/modules/kubernetes.test.ts
+++ b/packages/grid_client/tests/modules/kubernetes.test.ts
@@ -23,7 +23,6 @@ beforeAll(async () => {
 //Private IP Regex
 const ipRegex = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/;
 
-// Skipped until this issue is fixed: https://github.com/threefoldtech/tf-images/issues/133
 test("TC1231 - Kubernetes: Deploy a Kubernetes Cluster", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)
@@ -278,7 +277,6 @@ test("TC1231 - Kubernetes: Deploy a Kubernetes Cluster", async () => {
   }
 });
 
-// Skipped until this issue is fixed: https://github.com/threefoldtech/tf-images/issues/133
 test("TC1232 - Kubernetes: Add Worker", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)

--- a/packages/grid_client/tests/modules/qsfs.test.ts
+++ b/packages/grid_client/tests/modules/qsfs.test.ts
@@ -291,7 +291,7 @@ test("TC1234 - QSFS: Deploy QSFS underneath a VM", async () => {
 });
 
 // Skipped until this issue is fixed: https://github.com/threefoldtech/tf-images/issues/133
-test.skip("TC1235 - QSFS: Deploy QSFS Underneath a Kubernetes Cluster (https://github.com/threefoldtech/tf-images/issues/133)", async () => {
+test("TC1235 - QSFS: Deploy QSFS Underneath a Kubernetes Cluster", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)
      Test Cases: TC1235 - QSFS: Deploy QSFS Underneath a Kubernetes Cluster
@@ -613,7 +613,7 @@ test.skip("TC1235 - QSFS: Deploy QSFS Underneath a Kubernetes Cluster (https://g
     });
 
     //Execute kubectl get nodes.
-    await masterSSH.execCommand("kubectl get nodes").then(async function (result) {
+    await masterSSH.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
       log(result.stdout);
       expect(result.stdout).toContain(masterName.toLowerCase());
       expect(result.stdout).toContain(workerName.toLowerCase());

--- a/packages/grid_client/tests/modules/qsfs.test.ts
+++ b/packages/grid_client/tests/modules/qsfs.test.ts
@@ -212,7 +212,7 @@ test("TC1234 - QSFS: Deploy QSFS underneath a VM", async () => {
   log(res);
 
   //VM Contract Assertions
-  expect(res.contracts.created).toHaveLength(2);
+  expect(res.contracts.created).toHaveLength(1);
   expect(res.contracts.updated).toHaveLength(0);
   expect(res.contracts.deleted).toHaveLength(0);
 
@@ -290,7 +290,6 @@ test("TC1234 - QSFS: Deploy QSFS underneath a VM", async () => {
   }
 });
 
-// Skipped until this issue is fixed: https://github.com/threefoldtech/tf-images/issues/133
 test("TC1235 - QSFS: Deploy QSFS Underneath a Kubernetes Cluster", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)
@@ -536,7 +535,7 @@ test("TC1235 - QSFS: Deploy QSFS Underneath a Kubernetes Cluster", async () => {
   log(res);
 
   //K8s Contracts Assertions
-  expect(res.contracts.created).toHaveLength(4);
+  expect(res.contracts.created).toHaveLength(2);
   expect(res.contracts.updated).toHaveLength(0);
   expect(res.contracts.deleted).toHaveLength(0);
 


### PR DESCRIPTION
### Description

- Removed `test.skip` from k8s tests and edited the `Kubectl get nodes` command according to https://github.com/threefoldtech/tfgrid-sdk-ts/issues/15#issuecomment-1562687744
- Fixed contract assertion for qsfs tests and gateway test
