### PR TITLE
improve timeouts

### DIFF
--- a/packages/grid_client/tests/modules/algorand.test.ts
+++ b/packages/grid_client/tests/modules/algorand.test.ts
@@ -266,4 +266,4 @@ afterEach(async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/modules/capacity_planner.test.ts
+++ b/packages/grid_client/tests/modules/capacity_planner.test.ts
@@ -214,4 +214,4 @@ test("TC1246 - Capacity Planner: Get Farm ID From Farm Name", async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/modules/contracts.test.ts
+++ b/packages/grid_client/tests/modules/contracts.test.ts
@@ -240,4 +240,4 @@ afterAll(async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/modules/gateways.test.ts
+++ b/packages/grid_client/tests/modules/gateways.test.ts
@@ -251,4 +251,4 @@ afterEach(async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/modules/kubernetes.test.ts
+++ b/packages/grid_client/tests/modules/kubernetes.test.ts
@@ -1,5 +1,3 @@
-import { setTimeout } from "timers/promises";
-
 import {
   AddWorkerModel,
   DeleteWorkerModel,
@@ -10,7 +8,7 @@ import {
   randomChoice,
 } from "../../src";
 import { config, getClient } from "../client_loader";
-import { bytesToGB, generateInt, log, RemoteRun, splitIP } from "../utils";
+import { bytesToGB, generateInt, k8sWait, log, RemoteRun, splitIP } from "../utils";
 
 jest.setTimeout(500000);
 
@@ -221,20 +219,7 @@ test("TC1231 - Kubernetes: Deploy a Kubernetes Cluster", async () => {
   const masterSSH = await RemoteRun(masterPlanetaryIp, user);
 
   //Wait until the cluster is ready
-  let reachable = false;
-  for (let i = 0; i < 40; i++) {
-    await masterSSH.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
-      const res = result.stdout;
-      if (res.includes(masterName.toLowerCase()) && res.includes(workerName.toLowerCase())) {
-        reachable = true;
-      }
-    });
-    if (reachable) {
-      break;
-    }
-    const wait = await setTimeout(5000, "Waiting for cluster to be ready");
-    log(wait);
-  }
+  await k8sWait(masterSSH, masterName, workerName, 5000);
 
   try {
     //Verify Master Resources(CPU)
@@ -503,23 +488,7 @@ test("TC1232 - Kubernetes: Add Worker", async () => {
   const masterSSH = await RemoteRun(masterPlanetaryIp, user);
 
   //Wait until the cluster is ready
-  let reachable = false;
-  for (let i = 0; i < 40; i++) {
-    await masterSSH.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
-      const res = result.stdout;
-      if (
-        res.includes(masterName.toLowerCase()) &&
-        res.includes(workerName.toLowerCase() && res.includes(newWorkerName.toLowerCase()))
-      ) {
-        reachable = true;
-      }
-    });
-    if (reachable) {
-      break;
-    }
-    const wait = await setTimeout(5000, "Waiting for cluster to be ready");
-    log(wait);
-  }
+  await k8sWait(masterSSH, masterName, workerName, 5000, newWorkerName);
 
   //Execute kubectl get nodes.
   try {

--- a/packages/grid_client/tests/modules/kvstore.test.ts
+++ b/packages/grid_client/tests/modules/kvstore.test.ts
@@ -61,4 +61,4 @@ afterEach(async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/modules/stellar.test.ts
+++ b/packages/grid_client/tests/modules/stellar.test.ts
@@ -268,4 +268,4 @@ afterEach(async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/modules/vm.test.ts
+++ b/packages/grid_client/tests/modules/vm.test.ts
@@ -570,4 +570,4 @@ afterEach(async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/modules/zdb.test.ts
+++ b/packages/grid_client/tests/modules/zdb.test.ts
@@ -181,4 +181,4 @@ afterEach(async () => {
 
 afterAll(async () => {
   return await gridClient.disconnect();
-});
+}, 10000);

--- a/packages/grid_client/tests/utils.ts
+++ b/packages/grid_client/tests/utils.ts
@@ -1,4 +1,5 @@
 import { default as md5 } from "crypto-js/md5";
+import { setTimeout } from "timers/promises";
 import { default as urlParser } from "url-parse";
 import { inspect } from "util";
 
@@ -54,4 +55,29 @@ async function returnRelay() {
   return relay;
 }
 
-export { log, generateHash, generateInt, splitIP, bytesToGB, RemoteRun, returnRelay };
+async function k8sWait(masterIP, masterName, workerName, waitTime, newWorkerName?) {
+  let reachable = false;
+  for (let i = 0; i < 40; i++) {
+    await masterIP.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
+      const res = result.stdout;
+      if (typeof newWorkerName !== "undefined") {
+        if (
+          res.includes(masterName.toLowerCase()) &&
+          res.includes(workerName.toLowerCase() && res.includes(newWorkerName.toLowerCase()))
+        ) {
+          reachable = true;
+        }
+      } else {
+        if (res.includes(masterName.toLowerCase()) && res.includes(workerName.toLowerCase())) {
+          reachable = true;
+        }
+      }
+    });
+    if (reachable) {
+      break;
+    }
+    setTimeout(waitTime, "Waiting for cluster to be ready");
+  }
+}
+
+export { log, generateHash, generateInt, splitIP, bytesToGB, RemoteRun, returnRelay, k8sWait };

--- a/packages/grid_client/tests/utils.ts
+++ b/packages/grid_client/tests/utils.ts
@@ -55,20 +55,20 @@ async function returnRelay() {
   return relay;
 }
 
-async function k8sWait(masterIP, masterName, workerName, waitTime, newWorkerName?) {
+async function k8sWait(k8sMasterIP, k8sMasterName, k8sWorkerName, waitTime, k8sNewWorkerName?) {
   let reachable = false;
   for (let i = 0; i < 40; i++) {
-    await masterIP.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
+    await k8sMasterIP.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
       const res = result.stdout;
-      if (typeof newWorkerName !== "undefined") {
+      if (typeof k8sNewWorkerName !== "undefined") {
         if (
-          res.includes(masterName.toLowerCase()) &&
-          res.includes(workerName.toLowerCase() && res.includes(newWorkerName.toLowerCase()))
+          res.includes(k8sMasterName.toLowerCase()) &&
+          res.includes(k8sWorkerName.toLowerCase() && res.includes(k8sNewWorkerName.toLowerCase()))
         ) {
           reachable = true;
         }
       } else {
-        if (res.includes(masterName.toLowerCase()) && res.includes(workerName.toLowerCase())) {
+        if (res.includes(k8sMasterName.toLowerCase()) && res.includes(k8sWorkerName.toLowerCase())) {
           reachable = true;
         }
       }
@@ -76,7 +76,7 @@ async function k8sWait(masterIP, masterName, workerName, waitTime, newWorkerName
     if (reachable) {
       break;
     }
-    setTimeout(waitTime, "Waiting for cluster to be ready");
+    setTimeout(waitTime);
   }
 }
 

--- a/packages/grid_client/tests/utils.ts
+++ b/packages/grid_client/tests/utils.ts
@@ -55,10 +55,10 @@ async function returnRelay() {
   return relay;
 }
 
-async function k8sWait(k8sMasterIP, k8sMasterName, k8sWorkerName, waitTime, k8sNewWorkerName?) {
+async function k8sWait(masterSSHClient, k8sMasterName, k8sWorkerName, waitTime, k8sNewWorkerName?) {
   let reachable = false;
   for (let i = 0; i < 40; i++) {
-    await k8sMasterIP.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
+    await masterSSHClient.execCommand("source /etc/profile && kubectl get nodes").then(async function (result) {
       const res = result.stdout;
       if (typeof k8sNewWorkerName !== "undefined") {
         if (


### PR DESCRIPTION
### Description

Improving timeouts in the grid client integration tests.

### Changes

- Added a timeout for the disconnect method, so that the test will not be stuck forever if it fails.
- Added a dynamic timeout for the k8s tests instead of having a static one, the timeout checks every 5 seconds if the master and worker/s are returned or not.
- Increased the default timeout of the k8s tests because sometimes the add worker test might exceed the current timeout while waiting for the added worker.
