### PR TITLE
Add ipv4 in the calculator module in the grid client

### DIFF
--- a/packages/grid_client/scripts/calculator.ts
+++ b/packages/grid_client/scripts/calculator.ts
@@ -8,6 +8,7 @@ async function main() {
     mru: 1, // GB
     sru: 25,
     hru: 100,
+    ipv4u: false,
     balance: 1,
   };
 

--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -99,6 +99,15 @@ class GridClient {
     if (!isConnecting) {
       await this.tfclient.connect();
       try {
+        this.twinId = await this.tfclient.twins.getMyTwinId();
+        if (!this.twinId) {
+          throw Error(`Couldn't find a user for the provided mnemonic on ${this.clientOptions.network} network.`);
+        }
+      } catch (e) {
+        console.log(e);
+        throw Error(`Couldn't find a user for the provided mnemonic on ${this.clientOptions.network} network.`);
+      }
+      try {
         await this.rmbClient.connect();
       } catch (e) {
         throw Error(e.message);
@@ -117,16 +126,6 @@ class GridClient {
         };
         window.onunload = this.disconnect;
       }
-    }
-
-    try {
-      this.twinId = await this.tfclient.twins.getMyTwinId();
-      if (!this.twinId) {
-        throw Error(`Couldn't find a user for the provided mnemonic on ${this.clientOptions.network} network.`);
-      }
-    } catch (e) {
-      console.log(e);
-      throw Error(`Couldn't find a user for the provided mnemonic on ${this.clientOptions.network} network.`);
     }
     this._connect();
     GridClient.connecting.delete(key);

--- a/packages/grid_client/src/modules/calculator.ts
+++ b/packages/grid_client/src/modules/calculator.ts
@@ -47,21 +47,17 @@ class Calculator {
   @validateInput
   private async pricing(options: CalculatorModel) {
     const price = await this.getPrices();
-    const CU = await this.calCU({ cru: options.cru, mru: options.mru });
-    const SU = await this.calSU({ hru: options.hru, sru: options.sru });
-    const musd_month = (CU * +price?.cu.value + SU * +price?.su.value) * 24 * 30;
+    const cu = await this.calCU({ cru: options.cru, mru: options.mru });
+    const su = await this.calSU({ hru: options.hru, sru: options.sru });
+    const ipv4u = options.ipv4u ? 1 : 0;
+    const musd_month = (cu * +price?.cu.value + su * +price?.su.value + ipv4u * price?.ipu.value) * 24 * 30;
     return { musd_month: musd_month, dedicatedDiscount: price.discountForDedicationNodes };
   }
   @expose
   @validateInput
   async calculate(options: CalculatorModel) {
     let balance = 0;
-    const pricing = await this.pricing({
-      cru: options.cru,
-      mru: options.mru,
-      hru: options.hru,
-      sru: options.sru,
-    });
+    const pricing = await this.pricing(options);
 
     // discount for Dedicated Nodes
     const discount = pricing.dedicatedDiscount;
@@ -117,12 +113,13 @@ class Calculator {
 
   async calculateWithMyBalance(options: CalculatorModel) {
     const balances = await this.client.balances.getMyBalance();
-    const balance = balances["free"];
+    const balance = balances.free;
     const calculate = await this.calculate({
       cru: options.cru,
       mru: options.mru,
       hru: options.hru,
       sru: options.sru,
+      ipv4u: options.ipv4u,
       balance: balance,
     });
     return calculate;

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -560,7 +560,8 @@ class CalculatorModel {
   @Expose() @IsNumber() @IsNotEmpty() @Min(0) mru: number; // GB
   @Expose() @IsNumber() @IsNotEmpty() @Min(0) sru: number; // GB
   @Expose() @IsNumber() @IsNotEmpty() @Min(0) hru: number; // GB
-  @Expose() @IsOptional() @IsNumber() @Min(0) balance?: number; // GB
+  @Expose() @IsBoolean() @IsNotEmpty() ipv4u: boolean;
+  @Expose() @IsOptional() @IsNumber() @Min(0) balance?: number;
 }
 
 class CUModel {

--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -106,6 +106,11 @@ const props = defineProps({
     type: String,
     required: false,
   },
+  ivp4: {
+    type: Boolean,
+    required: false,
+    default: () => false,
+  },
 });
 const emits = defineEmits<{ (event: "mount"): void; (event: "back"): void }>();
 const baseUrl = import.meta.env.BASE_URL;
@@ -195,9 +200,16 @@ const tft = ref<number>();
 const costLoading = ref(false);
 const shouldUpdateCost = ref(false);
 watch(
-  () => [props.cpu, props.memory, props.disk],
+  () => [props.cpu, props.memory, props.disk, props.ivp4],
   debounce((value, oldValue) => {
-    if (oldValue && value[0] === oldValue[0] && value[1] === oldValue[1] && value[2] === oldValue[2]) return;
+    if (
+      oldValue &&
+      value[0] === oldValue[0] &&
+      value[1] === oldValue[1] &&
+      value[2] === oldValue[2] &&
+      value[3] === oldValue[3]
+    )
+      return;
     shouldUpdateCost.value = true;
   }, 500),
   { immediate: true },
@@ -220,6 +232,7 @@ async function loadCost(profile: { mnemonic: string }) {
     sru: typeof props.disk === "number" ? props.disk : 0,
     mru: typeof props.disk === "number" ? (props.memory ?? 0) / 1024 : 0,
     hru: 0,
+    ipv4u: props.ivp4,
   });
   usd.value = sharedPrice;
   tft.value = parseFloat((usd.value / (await grid!.calculator.tftPrice())).toFixed(2));

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -4,6 +4,7 @@
     :cpu="cpu"
     :memory="memory"
     :disk="disks.reduce((total, disk) => total + disk.size, diskSize + 2)"
+    :ivp4="ipv4"
     title-image="images/icons/vm.png"
   >
     <template #title> Deploy a Full Virtual Machine </template>

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -5,6 +5,7 @@
     :cpu="cpu"
     :memory="memory"
     :disk="disks.reduce((total, disk) => total + disk.size, rootFsSize)"
+    :ivp4="ipv4"
     title-image="images/icons/vm.png"
   >
     <template #title>Deploy a Micro Virtual Machine </template>

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -4,6 +4,7 @@
     :cpu="cpu"
     :memory="memory"
     :disk="storage + (type === 'indexer' ? 50 : 0)"
+    :ipv4="ipv4"
     title-image="images/icons/algorand.png"
   >
     <template #title>Deploy a Algorand Instance </template>

--- a/packages/playground/src/weblets/tf_caprover.vue
+++ b/packages/playground/src/weblets/tf_caprover.vue
@@ -10,6 +10,7 @@
         leader.solution?.disk ?? 0 + rootFs(leader.solution?.cpu ?? 0, leader.solution?.memory ?? 0),
       )
     "
+    :ivp4="true"
     title-image="images/icons/caprover.png"
   >
     <template #title>Deploy Caprover</template>

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -6,6 +6,7 @@
     :disk="
       workers.reduce((disk, worker) => disk + worker.diskSize + worker.rootFsSize, master.diskSize + master.rootFsSize)
     "
+    :ivp4="master.ipv4"
     title-image="images/icons/kubernetes.png"
   >
     <template #title>Deploy a Kubernetes</template>

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -1,5 +1,5 @@
 <template>
-  <weblet-layout ref="layout" :cpu="cpu" :memory="memory" :disk="32" title-image="images/icons/vm.png">
+  <weblet-layout ref="layout" :cpu="cpu" :memory="memory" :disk="32" ivp4 title-image="images/icons/vm.png">
     <template #title>Deploy a Node Pilot</template>
     <template #subtitle>
       Deploy a new Node Pilot on the Threefold Grid

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -1,5 +1,12 @@
 <template>
-  <weblet-layout ref="layout" :cpu="cpu" :memory="memory" :disk="rootFsSize" title-image="images/icons/presearch.png">
+  <weblet-layout
+    ref="layout"
+    :cpu="cpu"
+    :memory="memory"
+    :disk="rootFsSize"
+    :ipv4="ipv4"
+    title-image="images/icons/presearch.png"
+  >
     <template #title>Deploy a Presearch Instance</template>
     <template #subtitle
       >Presearch is a community-powered, decentralized search engine that provides better results while protecting your

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -4,6 +4,7 @@
     :cpu="solution?.cpu"
     :memory="solution?.memory"
     :disk="solution?.disk"
+    :ipv4="ipv4"
     title-image="images/icons/subsquid.png"
   >
     <template #title>Deploy a Subsquid Instance </template>

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -4,6 +4,7 @@
     :cpu="solution?.cpu"
     :memory="solution?.memory"
     :disk="(solution?.disk ?? 0) + 10 + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0)"
+    :ivp4="ipv4"
     title-image="images/icons/umbrel.png"
   >
     <template #title>Deploy an Umbrel Instance </template>


### PR DESCRIPTION
### Description

- Add ipv4 in the calculator module in the grid client
- check if the chain has twin id for the provided mnemonics before connecting to rmb relays

### Changes

List of changes this PR includes

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/321
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/251

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
