### PR TITLE
Allow hex secret to being used in the tfchain client

### DIFF
--- a/packages/tfchain_client/src/utils.ts
+++ b/packages/tfchain_client/src/utils.ts
@@ -12,4 +12,9 @@ export function checkConnection(target: any, propertyKey: string | symbol, descr
   };
 }
 
-export { isEnvNode };
+function isValidSeed(seed: string) {
+  const hexRegex = /^[0-9a-fA-F]+$/;
+  return hexRegex.test(seed) ? true : false;
+}
+
+export { isEnvNode, isValidSeed };


### PR DESCRIPTION
### Description

- Allow hex secret to being used in the tfchain client

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/219

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
