### PR TITLE
Added monitoring url for the hosting node

### DIFF
--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -4,9 +4,10 @@
       <div class="content" v-if="!loading">
         <v-row>
           <v-col v-if="node">
-            <NodeUsedResources :nodeStatistics="nodeStatistics" :nodeStatus="node.status" />
+            <NodeUsedResources :nodeStatistics="nodeStatistics" :nodeStatus="node.status" :grafanaUrl="grafanaUrl" />
           </v-col>
         </v-row>
+
         <v-row>
           <v-col :cols="screen_max_700.matches ? 12 : screen_max_1200.matches ? 6 : 4" v-if="node">
             <NodeDetails :node="node" :nodeStatistics="nodeStatistics" />
@@ -53,6 +54,7 @@ import { DocumentNode } from "graphql";
 import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
 import { ICountry, INode, INodeStatistics } from "../graphql/api";
+import { GrafanaStatistics } from "../utils/getMetricsUrl";
 import mediaMatcher from "../utils/mediaMatcher";
 import CountryDetails from "./CountryDetails.vue";
 import FarmDetails from "./FarmDetails.vue";
@@ -82,6 +84,7 @@ export default class Details extends Vue {
   @Prop() nodeId: any;
 
   loading = false;
+  grafanaUrl = "";
 
   data: any = {};
 
@@ -113,7 +116,6 @@ export default class Details extends Vue {
           res[key] = res[key][0];
           return res;
         }, data);
-
         // update with the data from grid proxy
         if (this.nodeId) {
           this.data.node = await fetch(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}`).then(res =>
@@ -129,6 +131,8 @@ export default class Details extends Vue {
             console.log(error);
           }
           this.data.node.status = this.data.node.status === "up";
+          const grafana: GrafanaStatistics = new GrafanaStatistics(this.data.node, this.data.twin.accountId);
+          this.grafanaUrl = grafana.getUrl();
         }
       })
       .catch(() => {

--- a/packages/dashboard/src/explorer/components/NodeUsedResources.vue
+++ b/packages/dashboard/src/explorer/components/NodeUsedResources.vue
@@ -43,6 +43,7 @@
     </v-row>
     <v-row justify="center">
       <v-progress-circular v-if="loader" indeterminate color="primary" :size="50" class="mt-10 mb-10" />
+      <v-btn v-if="!loader" class="mt-5 primary" @click="openGrafanaUrl">Monitoring url</v-btn>
     </v-row>
     <div class="d-flex justify-center mt-6" v-if="!loader && !resources.length">
       <v-alert dense type="error"> Failed to fetch node resources info. </v-alert>
@@ -58,6 +59,7 @@ import { INodeStatistics } from "../graphql/api";
 export default class NodeUsedResources extends Vue {
   @Prop({ required: true }) nodeStatistics!: INodeStatistics;
   @Prop({ required: true }) nodeStatus!: boolean;
+  @Prop({ required: true }) grafanaUrl!: string;
   resources: any[] = [];
   loader = false;
 
@@ -76,6 +78,10 @@ export default class NodeUsedResources extends Vue {
         name: i.toUpperCase(),
       };
     });
+  }
+
+  openGrafanaUrl() {
+    window.open(this.grafanaUrl, "_blank");
   }
   created() {
     if (this.nodeStatus && this.nodeStatistics) {

--- a/packages/dashboard/src/explorer/utils/getMetricsUrl.ts
+++ b/packages/dashboard/src/explorer/utils/getMetricsUrl.ts
@@ -1,0 +1,55 @@
+import config from "@/portal/config";
+
+import { INode } from "../graphql/api";
+
+export type GrafanaArgsType = {
+  orgID: number;
+  network: string;
+  farmID: number;
+  twinID: number;
+  accountID: string;
+};
+
+export class GrafanaStatistics {
+  public args: GrafanaArgsType = {
+    orgID: 2,
+    network: config.network,
+    twinID: 0,
+    farmID: 0,
+    accountID: "",
+  };
+
+  constructor(node: INode, accountID: string) {
+    this.args.twinID = node.twinId;
+    this.args.farmID = node.farmId;
+    this.args.accountID = accountID;
+    this.updateNetwork();
+  }
+
+  public getUrl(): string {
+    const orgId = `orgId=${this.args.orgID}`;
+    const network = `var-network=${this.args.network}`;
+    const farmID = `var-farm=${this.args.farmID}`;
+    const nodeID = `var-node=${this.args.accountID}`;
+
+    const urlArgs = `${orgId}&refresh=30s&${network}&${farmID}&${nodeID}&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B`;
+    return `https://metrics.grid.tf/d/rYdddlPWkfqwf/zos-host-metrics?${urlArgs}`;
+  }
+
+  public updateNetwork() {
+    switch (this.args.network) {
+      case "dev":
+        this.args.network = "development";
+        break;
+      case "qa":
+        this.args.network = "qa";
+        break;
+      case "test":
+        this.args.network = "testing";
+        break;
+      case "main":
+        this.args.network = "production";
+        break;
+    }
+  }
+}


### PR DESCRIPTION
### Description

Generated a  monitoring URL for the hosting node.

### Changes
In order to accomplish this, I have made the following updates:
* Created a new class called GrafanaStatistics within the getMetricsUrl file. This class includes a few methods:
  - `updateNetwork`: Updates the network name to align with the `Grafana` network names.
  - `getUrl`: Generates a new link for the node based on its ID.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/247

### Screenshots
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/9232805f-701b-4b27-a1d4-abf4f9625b01)
- on click
- - ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/ce3295aa-286c-4482-8007-fe3352282937)



### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
