### PR TITLE
Displaying the tft-price swap one second after mounting the page

### DIFF
--- a/packages/dashboard/src/Dashboard.vue
+++ b/packages/dashboard/src/Dashboard.vue
@@ -284,11 +284,6 @@ export default class Dashboard extends Vue {
 
   async updated() {
     this.accounts = this.$store.state.portal.accounts;
-    if (this.$api && this.$route.path == "/") {
-      this.loadingAPI = false;
-    } else if (this.$route.path !== "/") {
-      this.loadingAPI = false;
-    }
   }
 
   async unmounted() {

--- a/packages/dashboard/src/portal/components/TftSwapPrice.vue
+++ b/packages/dashboard/src/portal/components/TftSwapPrice.vue
@@ -38,17 +38,8 @@ export default class TftSwapPrice extends Vue {
 
   async mounted() {
     this.loading = true;
-
-    if (!this.$api) {
-      // In other pages the api takes more time to load, we wait on it one sec.
-      setTimeout(async () => {
-        this.prices[1].amount = await this.getTFTPrice();
-        this.loading = false;
-      }, 1000);
-    } else {
-      this.prices[1].amount = await this.getTFTPrice();
-      this.loading = false;
-    }
+    this.prices[1].amount = await this.getTFTPrice();
+    this.loading = false;
   }
 
   async priceSwap() {

--- a/packages/dashboard/src/portal/components/TftSwapPrice.vue
+++ b/packages/dashboard/src/portal/components/TftSwapPrice.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <div class="d-flex ml-5">
-      <div class="d-flex" style="align-items: center">
+      <div v-if="!loading" class="d-flex" style="align-items: center">
         <p>{{ prices[0].amount }} {{ prices[0].currency }}</p>
         <v-tooltip>
           <template v-slot:activator="{ on, attrs }">
@@ -30,13 +30,25 @@ type SwapPrice = {
 export default class TftSwapPrice extends Vue {
   $api: any;
   swaped = false;
+  loading = false;
   prices: SwapPrice[] = [
-    { currency: "TFT", amount: 1 },
+    { currency: "TFT", amount: 0 },
     { currency: "USD", amount: 0 },
   ];
 
   async mounted() {
-    this.prices[1].amount = await this.getTFTPrice();
+    this.loading = true;
+
+    if (!this.$api) {
+      // In other pages the api takes more time to load, we wait on it one sec.
+      setTimeout(async () => {
+        this.prices[1].amount = await this.getTFTPrice();
+        this.loading = false;
+      }, 1000);
+    } else {
+      this.prices[1].amount = await this.getTFTPrice();
+      this.loading = false;
+    }
   }
 
   async priceSwap() {


### PR DESCRIPTION
### Description

After refreshing the nodes page there is an error appears in the console, while, if refreshed the main page there are no errors
implemented a small fix to wait on the API one second after mounting the page

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/419

### Checklist

- [ ] Tests included
- [ ] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
