### PR TITLE
Add bottom padding in main page to avoid chat button overlap

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -68,7 +68,7 @@
       </v-toolbar>
 
       <DeploymentListManager>
-        <v-container fluid>
+        <v-container fluid :style="{ paddingBottom: '100px' }">
           <div class="d-flex align-center">
             <v-btn
               color="primary"


### PR DESCRIPTION
## Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/358

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/e3672edc-7aec-43bd-b7a0-18a371869ac1)
