### PR TITLE
Fix deployment order in case of adding instance to the deployment

### DIFF
--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -506,11 +506,12 @@ class BaseModule {
         break;
       }
     }
-    finalTwinDeployments.push(twinDeployment);
+    // pop and push the network deployment first before push the added machine to the list
     const networkTwinDeployment = twinDeployments.pop();
     if (networkTwinDeployment) {
       finalTwinDeployments.push(networkTwinDeployment);
     }
+    finalTwinDeployments.push(twinDeployment);
     const contracts = await this.twinDeploymentHandler.handle(finalTwinDeployments);
     await this.save(deployment_name, contracts);
     return { contracts: contracts };


### PR DESCRIPTION

### Description

- Fix the order to add the network first in the deployment list while adding a machine to the deployment

### Related Issues

- #426 
- #281 
- #274

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
