### PR TITLE
Added Grafana Node Statistics url inside deployment data modal.

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -48,6 +48,7 @@
                 :data="data[0].wireguard"
               />
               <CopyReadonlyInput label="Flist" :data="contract.flist" v-if="contract.flist" />
+              <CopyReadonlyInput label="Grafana Node Statistics" :data="grafanaURL" />
               <template v-if="environments !== false">
                 <template v-for="key of Object.keys(contract.env)" :key="key">
                   <template v-if="(environments[key] || !(key in environments)) && contract.env[key]">
@@ -122,6 +123,7 @@ defineEmits<{ (event: "close"): void }>();
 
 const showType = ref(props.onlyJson ? 1 : 0);
 const activeTab = ref(0);
+const grafanaURL = ref("");
 const contracts = computed(() => {
   if (!props.data) return [];
   if ("masters" in props.data) return [...props.data.masters, ...props.data.workers];
@@ -130,6 +132,7 @@ const contracts = computed(() => {
 const contract = computed(() => contracts.value?.[activeTab.value] ?? {});
 const code = computed(() => JSON.stringify(props.data || {}, undefined, 2));
 const html = computed(() => hljs.highlight(code.value, { language: "json" }).value);
+const profileManager = useProfileManager();
 
 function copy() {
   navigator.clipboard.writeText(code.value);
@@ -159,6 +162,19 @@ function getValue(key: string) {
   return transform(value);
 }
 
+async function getGrafanaUrl() {
+  const grid = await getGrid(profileManager.profile!);
+  if (grid) {
+    const grafana = new GrafanaStatistics(grid, props.data);
+    grafana.getUrl().then(res => {
+      console.log("res: ", res);
+      grafanaURL.value = res;
+    });
+  }
+  return grafanaURL.value;
+}
+getGrafanaUrl();
+
 function _transform(value: string): any {
   const v = value.toLowerCase();
   if (v === "true" || v === "false") {
@@ -183,6 +199,10 @@ function getType(key: string): string {
 </script>
 
 <script lang="ts">
+import { useProfileManager } from "@/stores/profile_manager";
+import { GrafanaStatistics } from "@/utils/getMetricsUrl";
+import { getGrid } from "@/utils/grid";
+
 import CopyReadonlyInput from "./copy_readonly_input.vue";
 import { HighlightDark, HighlightLight } from "./highlight_themes";
 

--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -48,7 +48,7 @@
                 :data="data[0].wireguard"
               />
               <CopyReadonlyInput label="Flist" :data="contract.flist" v-if="contract.flist" />
-              <CopyReadonlyInput label="Grafana Node Statistics" :data="grafanaURL" />
+              <CopyReadonlyInput label="Monitoring URL" :data="grafanaURL" />
               <template v-if="environments !== false">
                 <template v-for="key of Object.keys(contract.env)" :key="key">
                   <template v-if="(environments[key] || !(key in environments)) && contract.env[key]">
@@ -167,7 +167,6 @@ async function getGrafanaUrl() {
   if (grid) {
     const grafana = new GrafanaStatistics(grid, props.data);
     grafana.getUrl().then(res => {
-      console.log("res: ", res);
       grafanaURL.value = res;
     });
   }

--- a/packages/playground/src/utils/getMetricsUrl.ts
+++ b/packages/playground/src/utils/getMetricsUrl.ts
@@ -1,0 +1,72 @@
+import type { GridClient } from "@threefold/grid_client";
+
+import type { Machine } from "./deploy_vm";
+
+export interface IGrafanaArgs {
+  orgID: number;
+  network: string;
+  farmID: number;
+  accountID: string;
+}
+
+export class GrafanaStatistics implements IGrafanaArgs {
+  public orgID = 2;
+  public network = "";
+  public farmID = 0;
+  public accountID = "";
+  public grid: GridClient;
+  public deployment: any;
+
+  constructor(grid: GridClient, deployment: any) {
+    this.grid = grid;
+    this.deployment = deployment;
+    this.network = grid.clientOptions?.network || "dev";
+  }
+
+  async setAccountID() {
+    await this.grid.twins.get({ id: this.deployment[0].nodeId }).then(res => {
+      this.accountID = res.accountId;
+    });
+  }
+
+  async setfarmID() {
+    await this.grid.nodes.getRent({ nodeId: this.deployment[0].nodeId }).then(res => {
+      this.farmID = res.farmId;
+    });
+  }
+
+  async getUrl() {
+    await this.setfarmID();
+    await this.setAccountID();
+    this.updateNetwork();
+    const orgId = `orgId=${this.orgID}`;
+    const network = `var-network=${this.network}`;
+    const farmID = `var-farm=${this.farmID}`;
+    const nodeID = `var-node=${this.accountID}`;
+
+    const urlArgs = `${orgId}&refresh=30s&${network}&${farmID}&${nodeID}&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B`;
+    const url = `https://metrics.grid.tf/d/rYdddlPWkfqwf/zos-host-metrics?${urlArgs}`;
+    return url;
+  }
+
+  public updateNetwork() {
+    if (this.network.length) {
+      switch (this.network) {
+        case "dev":
+          this.network = "development";
+          break;
+        case "qa":
+          this.network = "qa";
+          break;
+        case "test":
+          this.network = "testing";
+          break;
+        case "main":
+          this.network = "production";
+          break;
+      }
+    } else {
+      throw Error("Can not get the network from the GridClient Options");
+    }
+  }
+}


### PR DESCRIPTION
### Description

Added Grafana Node Statistics url inside the deployment data modal.

### Changes

* one more text field to the deployment data modal
* Created a new class called GrafanaStatistics within the getMetricsUrl file. This class includes a few methods:
  - `updateNetwork`: Updates the network name to align with the `Grafana` network names.
  - `getUrl`: Generates a new link for the node based on its ID.
  - setAccountID: Request to get the node account id from the grid client then set it into the `IGrafanaArgs`
  -  setfarmID: Request to get the farm id from the grid client then set it into the `IGrafanaArgs`

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/247

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/d2f0f279-a6ba-4de4-b223-21398cb111ce)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/8c139659-f955-4859-8c7d-439b10ac354a)




### Checklist

- [ ] Tests included
- [ ] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
