### PR TITLE
Edit disk name in full vm

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -36,11 +36,7 @@
               <CopyReadonlyInput
                 v-for="disk of contract.mounts"
                 :key="disk.name"
-                :label="
-                  contract.metadata.includes('fullvm') && contract.mounts.indexOf(disk) > 0
-                    ? 'Disk'
-                    : 'Disk( ' + disk.mountPoint + ' ) GB'
-                "
+                :label="getDiskLabel(contract, disk)"
                 :data="Math.ceil(disk.size / (1024 * 1024 * 1024))"
               />
               <CopyReadonlyInput label="WireGuard IP" :data="contract.interfaces[0].ip" />
@@ -199,6 +195,13 @@ function getType(key: string): string {
 
   return "text";
 }
+
+function getDiskLabel(contract: any, disk: Disk) {
+  if (contract.metadata.includes("fullvm") && contract.mounts.indexOf(disk) > 0) {
+    return "Disk";
+  }
+  return "Disk( " + disk.mountPoint + " ) GB";
+}
 </script>
 
 <script lang="ts">
@@ -206,6 +209,7 @@ import { useProfileManager } from "@/stores/profile_manager";
 import { GrafanaStatistics } from "@/utils/getMetricsUrl";
 import { getGrid } from "@/utils/grid";
 
+import type { Disk } from "../utils/deploy_vm";
 import CopyReadonlyInput from "./copy_readonly_input.vue";
 import { HighlightDark, HighlightLight } from "./highlight_themes";
 

--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -36,7 +36,11 @@
               <CopyReadonlyInput
                 v-for="disk of contract.mounts"
                 :key="disk.name"
-                :label="'Disk( ' + disk.mountPoint + ' ) GB'"
+                :label="
+                  contract.metadata.includes('fullvm') && contract.mounts.indexOf(disk) > 0
+                    ? 'Disk'
+                    : 'Disk( ' + disk.mountPoint + ' ) GB'
+                "
                 :data="Math.ceil(disk.size / (1024 * 1024 * 1024))"
               />
               <CopyReadonlyInput label="WireGuard IP" :data="contract.interfaces[0].ip" />


### PR DESCRIPTION
### Description

Remove additional disk path in Fullvm

### Changes
- Change the disk label in fullvm (if it's not the default) to "Disk", other than that, include disk path in the label

Fullvm Deployment

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/1d368c5d-b643-4041-a111-6e4f61cdde70)


Kubernetes Deployment

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/886004ba-096a-4bfb-b2b7-a10824e35b7b)



### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/290

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
