### PR TITLE
Implemented the locked contract feature, added inside the playground.

### DIFF
--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -1,4 +1,4 @@
-import { Contracts } from "@threefold/tfchain_client";
+import { ContractLockOptions, Contracts } from "@threefold/tfchain_client";
 import { Decimal } from "decimal.js";
 
 import { ContractStates } from "../../modules";
@@ -148,6 +148,13 @@ class TFContracts extends Contracts {
       twinId: twinId,
       stateList: options.stateList,
     });
+  }
+
+  async contractLock(options: ContractLockOptions) {
+    const res = await super.contractLock(options);
+    const amountLocked = new Decimal(res.amountLocked);
+    res.amountLocked = amountLocked.div(10 ** 7).toNumber();
+    return res;
   }
 
   /**

--- a/packages/grid_client/src/modules/contracts.ts
+++ b/packages/grid_client/src/modules/contracts.ts
@@ -13,6 +13,7 @@ import {
   ContractConsumption,
   ContractGetByNodeIdAndHashModel,
   ContractGetModel,
+  ContractLockModel,
   ContractsByAddress,
   ContractsByTwinId,
   ContractState,
@@ -100,7 +101,7 @@ class Contracts {
 
   @expose
   @validateInput
-  async contractLock(options: ContractConsumption) {
+  async contractLock(options: ContractLockModel) {
     return this.client.contracts.contractLock(options);
   }
 

--- a/packages/grid_client/src/modules/contracts.ts
+++ b/packages/grid_client/src/modules/contracts.ts
@@ -100,6 +100,12 @@ class Contracts {
 
   @expose
   @validateInput
+  async contractLock(options: ContractConsumption) {
+    return this.client.contracts.contractLock(options);
+  }
+
+  @expose
+  @validateInput
   @checkBalance
   async update_node(options: NodeContractUpdateModel) {
     return (await this.client.contracts.updateNode(options)).apply();

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -341,6 +341,8 @@ class ContractConsumption {
   @Expose() @IsInt() @Min(1) id: number;
 }
 
+class ContractLockModel extends ContractConsumption {}
+
 class TwinCreateModel {
   @Expose() @IsString() @IsNotEmpty() relay: string;
 }
@@ -647,6 +649,7 @@ export {
   ContractsByTwinId,
   ContractsByAddress,
   ContractConsumption,
+  ContractLockModel,
   TwinCreateModel,
   TwinGetModel,
   TwinGetByAccountIdModel,

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -34,7 +34,7 @@
       <template #[`item.state`]="{ item }">
         <v-tooltip
           v-if="item && item.value.state === ContractStates.GracePeriod"
-          :text="'Click here to view the amount you need to charge in order to unlock the contract.'"
+          :text="'the number of tokens required to remove your contract from the grace period and restore functionality to your workloads.'"
           location="top center"
         >
           <template #activator="{ props }">
@@ -106,13 +106,13 @@
           <strong>Loading The Locked Amount...</strong>
         </p>
         <p v-else class="text-center">
-          Amount Locked <strong>{{ contractLocked?.amountLocked }}</strong>
+          Amount Locked <strong>{{ contractLocked?.amountLocked }} TFT</strong>
         </p>
         <br />
         <v-alert type="info" variant="tonal">
-          To unlock your contract from the grace period, please ensure that you fund your account with the displayed
-          amount. By doing so, you will meet the required balance and enable the contract to be released from the grace
-          period.
+          The contract is in a GracePeriod condition, which means that your workloads are suspended but not deleted; in
+          order to resume your workloads and restore their functionality, you must pay your account with the necessary
+          tokens.
         </v-alert>
       </v-card-text>
       <v-card-actions>
@@ -199,7 +199,8 @@ async function contractLockDetails(contractId: number) {
       contractLocked.value = data;
     })
     .catch(err => {
-      layout.value.setStatus("failed", normalizeError(err, `Failed to fetch the contract lock details.`));
+      layout.value.setStatus("failed", normalizeError(err, `Failed to fetch the contract ${contractId} lock details.`));
+      contractStateDialog.value = false;
     });
   loading.value = false;
 }

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -32,7 +32,22 @@
       </template>
 
       <template #[`item.state`]="{ item }">
-        <v-chip :color="getStateColor(item.value.state)">
+        <v-tooltip
+          v-if="item && item.value.state === ContractStates.GracePeriod"
+          :text="'Click here to view the amount you need to charge in order to unlock the contract.'"
+          location="top center"
+        >
+          <template #activator="{ props }">
+            <v-chip
+              @click.stop="contractLockDetails(item.value.contractId)"
+              v-bind="props"
+              :color="getStateColor(item.value.state)"
+            >
+              {{ item.value.state }}
+            </v-chip>
+          </template>
+        </v-tooltip>
+        <v-chip v-else :color="getStateColor(item.value.state)">
           {{ item.value.state }}
         </v-chip>
       </template>
@@ -82,6 +97,30 @@
       </v-card-actions>
     </v-card>
   </v-dialog>
+
+  <v-dialog width="70%" v-model="contractStateDialog">
+    <v-card>
+      <v-card-title class="text-h5">Contract lock Detalis</v-card-title>
+      <v-card-text>
+        <p v-if="loading" class="text-center">
+          <strong>Loading The Locked Amount...</strong>
+        </p>
+        <p v-else class="text-center">
+          Amount Locked <strong>{{ contractLocked?.amountLocked }}</strong>
+        </p>
+        <br />
+        <v-alert type="info" variant="tonal">
+          To unlock your contract from the grace period, please ensure that you fund your account with the displayed
+          amount. By doing so, you will meet the required balance and enable the contract to be released from the grace
+          period.
+        </v-alert>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="error" variant="tonal" @click="contractStateDialog = false"> Close </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script lang="ts" setup>
@@ -121,6 +160,8 @@ async function onMount() {
 }
 
 const loadingContractId = ref<number>();
+const contractLocked = ref<ContractLock>();
+
 async function onShowDetails(contractId: number) {
   loading.value = true;
   loadingContractId.value = contractId;
@@ -148,7 +189,23 @@ function getStateColor(state: ContractStates): string {
   }
 }
 
+async function contractLockDetails(contractId: number) {
+  contractStateDialog.value = true;
+  loading.value = true;
+  const grid = await getGrid(profileManager.profile!);
+  await grid?.contracts
+    .contractLock({ id: contractId })
+    .then((data: ContractLock) => {
+      contractLocked.value = data;
+    })
+    .catch(err => {
+      layout.value.setStatus("failed", normalizeError(err, `Failed to fetch the contract lock details.`));
+    });
+  loading.value = false;
+}
+
 const deletingDialog = ref(false);
+const contractStateDialog = ref(false);
 const deleting = ref(false);
 async function onDelete() {
   deletingDialog.value = false;
@@ -172,6 +229,8 @@ async function onDelete() {
 </script>
 
 <script lang="ts">
+import type { ContractLock } from "@threefold/tfchain_client";
+
 import ListTable from "../components/list_table.vue";
 import { normalizeError } from "../utils/helpers";
 

--- a/packages/tfchain_client/src/contracts.ts
+++ b/packages/tfchain_client/src/contracts.ts
@@ -12,6 +12,16 @@ interface NameContract {
   name: string;
 }
 
+export interface ContractLockOptions {
+  id: number;
+}
+
+export interface ContractLock {
+  amountLocked: number;
+  lockUpdated: number;
+  cycles: number;
+}
+
 interface NodeContract {
   nodeId: number;
   deploymentHash: string;
@@ -104,6 +114,12 @@ class QueryContracts {
   async getContractIdByNodeIdAndHash(options: QueryContractGetContractByIdAndHashOptions): Promise<number> {
     const res = await this.client.api.query.smartContractModule.contractIDByNodeIDAndHash(options.nodeId, options.hash);
     return res.toPrimitive() as number;
+  }
+
+  @checkConnection
+  async contractLock(options: ContractLockOptions): Promise<ContractLock> {
+    const res = await this.client.api.query.smartContractModule.contractLock(options.id);
+    return res.toPrimitive() as unknown as ContractLock;
   }
 
   @checkConnection


### PR DESCRIPTION
### Description

The locked contract amount feature has been implemented within the chain client. It has been called and exposed in the grid client, allowing it to be used in the playground. When the dialog is opened, the grid client is requested to retrieve the locked contract amount and display it to the end user. This enhancement enables users to easily view and interact with the locked contract amount information within the playground interface.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/12

### Screenshots
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/73ef12d8-eeae-4d06-ba04-a0ec18b79359)

on click

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/e5e013e9-c1ac-484a-87aa-4308c4b99fb2)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/72e49a60-3815-40eb-9d39-e7c5accad72b)



### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
