### PR TITLE
Enhance deleting grace Period contracts UX 

### DIFF
--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -84,9 +84,7 @@
   <v-dialog width="70%" v-model="deletingDialog">
     <v-card>
       <v-card-title class="text-h5 mt-2"> Are you sure you want to delete the following contracts? </v-card-title>
-      <v-alert class="ma-4" density="compact" type="warning" variant="tonal"
-        >Deleting contracts may take a while to complete.</v-alert
-      >
+      <v-alert class="ma-4" type="warning" variant="tonal">Deleting contracts may take a while to complete.</v-alert>
       <v-card-text>
         <v-chip class="ma-1" color="primary" label v-for="c in selectedContracts" :key="c.contractId">
           {{ c.contractId }}

--- a/packages/tfchain_client/src/client.ts
+++ b/packages/tfchain_client/src/client.ts
@@ -317,7 +317,7 @@ class Client extends QueryClient {
         if (this.keypair) {
           await extrinsic.signAndSend(this.keypair, { nonce }, callback);
         } else if (this.extSigner) {
-          extrinsic.signAndSend(this.address, { nonce, signer: this.extSigner.signer }, callback);
+          await extrinsic.signAndSend(this.address, { nonce, signer: this.extSigner.signer }, callback);
         }
       } catch (e) {
         reject(e);

--- a/packages/tfchain_client/src/client.ts
+++ b/packages/tfchain_client/src/client.ts
@@ -315,7 +315,7 @@ class Client extends QueryClient {
       try {
         const nonce = await this.api.rpc.system.accountNextIndex(this.address);
         if (this.keypair) {
-          extrinsic.signAndSend(this.keypair, { nonce }, callback);
+          await extrinsic.signAndSend(this.keypair, { nonce }, callback);
         } else if (this.extSigner) {
           extrinsic.signAndSend(this.address, { nonce, signer: this.extSigner.signer }, callback);
         }
@@ -335,7 +335,7 @@ class Client extends QueryClient {
           section = resultSections[0];
         throw Error(
           `Failed to apply ${JSON.stringify(extrinsic.method.toHuman())} due to error: ${
-            Object.keys(this.api.errors[section])[+e]
+            Object.keys(this.api.errors[section])[+e] ?? e
           }`,
         );
       });


### PR DESCRIPTION
### Description

In case the user only has 0.01 tft <deleting contract fee> the contract will go on with the deleting process, but will stuck while deleting its keys, and then it needs to reload the page, now this case is handled if it fails while deleting some keys will show an error message.

### Changes
- await `signAndSend` function in `_applyExtrinsic`
- add an error notification to inform the user there are some keys not deleted.
- add an alert that deleting contracts may take a while 

### screen record 

[Screencast from 2023-06-06 16-41-08.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/eb1fc885-9bd7-445b-bfae-21829c4de58d)

### Related Issues

-#463

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
