### PR TITLE
Hide Monitoring url in case the node is offline.

### DIFF
--- a/packages/dashboard/src/explorer/components/NodeUsedResources.vue
+++ b/packages/dashboard/src/explorer/components/NodeUsedResources.vue
@@ -43,7 +43,7 @@
     </v-row>
     <v-row justify="center">
       <v-progress-circular v-if="loader" indeterminate color="primary" :size="50" class="mt-10 mb-10" />
-      <v-btn v-if="!loader" class="mt-5 primary" @click="openGrafanaUrl">Monitoring url</v-btn>
+      <v-btn v-if="nodeStatus && !loader" class="mt-5 primary" @click="openGrafanaUrl">Monitoring url</v-btn>
     </v-row>
     <div class="d-flex justify-center mt-6" v-if="!loader && !resources.length">
       <v-alert dense type="error"> Failed to fetch node resources info. </v-alert>


### PR DESCRIPTION
### Description

Hide the Monitoring URL in case the node is offline.

### Changes

- hide the button if the node is offline

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/457

### Screenshot

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/40ddd973-9752-4ee5-8b62-ad28dc296e6c)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/02bb81a8-8598-4936-821c-9a5bedbbe108)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
