### PR TITLE
Improve inputs validators experience

### DIFF
--- a/packages/playground/src/components/dynamic_tabs.vue
+++ b/packages/playground/src/components/dynamic_tabs.vue
@@ -10,8 +10,12 @@
         v-else-if="tab.imgPath"
         :style="{ filter: `brightness(${$vuetify.theme.global.name === 'light' ? 0.2 : 1})` }"
       />
+
       {{ tab.title }}
-      <v-chip color="error" v-if="forms[tabs.indexOf(tab)]?.invalid" class="ml-1">invalid</v-chip>
+      <v-chip v-if="forms[tabs.indexOf(tab)]?.pending" class="ml-1" color="info">
+        Validating <v-progress-circular indeterminate size="15" width="2" class="ml-1" />
+      </v-chip>
+      <v-chip color="error" v-else-if="forms[tabs.indexOf(tab)]?.invalid" class="ml-1"> Invalid </v-chip>
     </v-tab>
   </v-tabs>
 

--- a/packages/playground/src/components/form_validator.vue
+++ b/packages/playground/src/components/form_validator.vue
@@ -5,17 +5,18 @@
 <script lang="ts" setup>
 import { computed, provide, ref, watch } from "vue";
 
+import { ValidatorStatus } from "./input_validator.vue";
+
 defineProps<{ modelValue?: boolean }>();
 const emits = defineEmits<{ (events: "update:modelValue", value: boolean): void }>();
 
-const inputsValidation = ref<{ [uid: number]: boolean }>({});
+const inputsValidation = ref<{ [uid: number]: ValidatorStatus }>({});
 const inputsReset = {} as { [uid: number]: () => void };
-const valid = computed(() => {
-  return Object.values(inputsValidation.value).reduce((v, c) => {
-    return v && c;
-  }, true);
-});
+const valid = computed(() => Object.values(inputsValidation.value).every(c => c === ValidatorStatus.VALID));
 const invalid = computed(() => !valid.value);
+const pending = computed(() => {
+  return Object.values(inputsValidation.value).some(c => c === ValidatorStatus.PENDING);
+});
 
 watch(
   valid,
@@ -25,9 +26,8 @@ watch(
   { immediate: true },
 );
 
-function setValid(uid: number, value: boolean, reset: () => void): void {
+function setStatus(uid: number, value: ValidatorStatus): void {
   inputsValidation.value[uid] = value;
-  inputsReset[uid] = reset;
 }
 
 function unregister(uid: number): void {
@@ -36,7 +36,7 @@ function unregister(uid: number): void {
 }
 
 provide("form:validator", {
-  setValid,
+  setStatus,
   unregister,
 });
 
@@ -47,6 +47,7 @@ defineExpose({
   },
   valid,
   invalid,
+  pending,
 });
 </script>
 

--- a/packages/playground/src/types/index.ts
+++ b/packages/playground/src/types/index.ts
@@ -1,5 +1,7 @@
 import type { VDataTable } from "vuetify/lib/labs/components";
 
+import type { ValidatorStatus } from "@/components/input_validator.vue";
+
 import type * as validators from "../utils/validators";
 
 export interface K8SWorker {
@@ -89,7 +91,7 @@ export interface solutionFlavor {
 }
 
 export interface FormValidatorService {
-  setValid(uid: number, value: boolean, reset: () => void): void;
+  setStatus(uid: number, value: ValidatorStatus): void;
   unregister(uid: number): void;
 }
 


### PR DESCRIPTION
## Changes
- Remove initial `invalid` status
- Add new status `pending` shown to the user as :curly_loop: `validating`

### Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/286

https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/42d1559a-e50e-4c62-9aaf-e3d12da2d8b4