### PR TITLE
Sync display data on dedicated nodes table with node explorer 

### DIFF
--- a/packages/dashboard/src/explorer/views/Nodes.vue
+++ b/packages/dashboard/src/explorer/views/Nodes.vue
@@ -141,10 +141,10 @@ export default class Nodes extends Vue {
     { text: "Farm ID", value: "farmId", align: "center", customAlign: "text-center" },
     { text: "Total Public IPs", value: "totalPublicIPs", align: "center", customAlign: "text-center" },
     { text: "Free Public IPs", value: "freePublicIPs", align: "center", customAlign: "text-center" },
-    { text: "HRU", value: "hru", align: "center", customAlign: "text-center", description: "Total HDD" },
-    { text: "SRU", value: "sru", align: "center", customAlign: "text-center", description: "Total SSD" },
-    { text: "MRU", value: "mru", align: "center", customAlign: "text-center", description: "Total Memory" },
     { text: "CRU", value: "cru", align: "center", customAlign: "text-center", description: "Total Cores" },
+    { text: "MRU", value: "mru", align: "center", customAlign: "text-center", description: "Total Memory" },
+    { text: "SRU", value: "sru", align: "center", customAlign: "text-center", description: "Total SSD" },
+    { text: "HRU", value: "hru", align: "center", customAlign: "text-center", description: "Total HDD" },
     { text: "Up Time", value: "uptime", align: "center", customAlign: "text-center" },
     { text: "Status", value: "status", align: "center", customAlign: "text-center" },
   ];

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -109,10 +109,10 @@ export default class NodesTable extends Vue {
   headers = [
     { text: "Node ID", value: "nodeId", align: "center" },
     { text: "Location", value: "location.country", align: "center" },
-    { text: "HRU (TB)", value: "resources.hru", align: "center" },
-    { text: "SRU (GB)", value: "resources.sru", align: "center" },
-    { text: "MRU (GB)", value: "resources.mru", align: "center" },
     { text: "CRU", value: "resources.cru", align: "center" },
+    { text: "MRU (GB)", value: "resources.mru", align: "center" },
+    { text: "SRU (GB)", value: "resources.sru", align: "center" },
+    { text: "HRU (TB)", value: "resources.hru", align: "center" },
     { text: "Price (USD)", value: "discount", align: "center" },
     { text: "Actions", value: "actions", align: "center", sortable: false },
   ];

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -26,7 +26,7 @@
         {{ byteToGB(item.resources.sru) }}
       </template>
       <template v-slot:[`item.resources.hru`]="{ item }">
-        {{ byteToGB(item.resources.hru) }}
+        {{ byteToTB(item.resources.hru) }}
       </template>
       <template v-slot:[`item.actions`]="{ item }">
         <NodeActionBtn :nodeId="item.nodeId" :status="item.rentStatus" @node-status-changed="onStatusUpdate()" />
@@ -83,7 +83,7 @@ import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
 import NodeActionBtn from "../components/NodeActionBtn.vue";
 import NodeDetails from "../components/NodeDetails.vue";
-import { getDNodes, getFarmDetails, ITab } from "../lib/nodes";
+import { byteToTB, getDNodes, getFarmDetails, ITab } from "../lib/nodes";
 import { byteToGB } from "../lib/nodes";
 
 @Component({
@@ -109,10 +109,10 @@ export default class NodesTable extends Vue {
   headers = [
     { text: "Node ID", value: "nodeId", align: "center" },
     { text: "Location", value: "location.country", align: "center" },
-    { text: "CRU", value: "resources.cru", align: "center" },
-    { text: "HRU (GB)", value: "resources.hru", align: "center" },
-    { text: "MRU (GB)", value: "resources.mru", align: "center" },
+    { text: "HRU (TB)", value: "resources.hru", align: "center" },
     { text: "SRU (GB)", value: "resources.sru", align: "center" },
+    { text: "MRU (GB)", value: "resources.mru", align: "center" },
+    { text: "CRU", value: "resources.cru", align: "center" },
     { text: "Price (USD)", value: "discount", align: "center" },
     { text: "Actions", value: "actions", align: "center", sortable: false },
   ];
@@ -183,6 +183,10 @@ export default class NodesTable extends Vue {
 
   byteToGB(capacity: number) {
     return byteToGB(capacity);
+  }
+
+  byteToTB(capacity: number) {
+    return byteToTB(capacity);
   }
 }
 </script>

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -20,13 +20,13 @@
       @item-expanded="getDNodeDetails"
     >
       <template v-slot:[`item.resources.mru`]="{ item }">
-        {{ byteToGB(item.resources.mru) }}
+        {{ convert(item.resources.mru) }}
       </template>
       <template v-slot:[`item.resources.sru`]="{ item }">
-        {{ byteToGB(item.resources.sru) }}
+        {{ convert(item.resources.sru) }}
       </template>
       <template v-slot:[`item.resources.hru`]="{ item }">
-        {{ byteToTB(item.resources.hru) }}
+        {{ convert(item.resources.hru) }}
       </template>
       <template v-slot:[`item.actions`]="{ item }">
         <NodeActionBtn :nodeId="item.nodeId" :status="item.rentStatus" @node-status-changed="onStatusUpdate()" />
@@ -71,7 +71,7 @@
           <strong style="color: #f44336">Failed to retrieve Node details</strong>
         </td>
         <td :colspan="headers.length" v-else>
-          <NodeDetails :node="item" :byteToGB="byteToGB" />
+          <NodeDetails :node="item" :convert="convert" />
         </td>
       </template>
     </v-data-table>
@@ -81,10 +81,10 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
+import toTeraOrGigaOrPeta from "../../explorer/filters/toTeraOrGigaOrPeta";
 import NodeActionBtn from "../components/NodeActionBtn.vue";
 import NodeDetails from "../components/NodeDetails.vue";
-import { byteToTB, getDNodes, getFarmDetails, ITab } from "../lib/nodes";
-import { byteToGB } from "../lib/nodes";
+import { getDNodes, getFarmDetails, ITab } from "../lib/nodes";
 
 @Component({
   name: "NodesTable",
@@ -110,9 +110,9 @@ export default class NodesTable extends Vue {
     { text: "Node ID", value: "nodeId", align: "center" },
     { text: "Location", value: "location.country", align: "center" },
     { text: "CRU", value: "resources.cru", align: "center" },
-    { text: "MRU (GB)", value: "resources.mru", align: "center" },
-    { text: "SRU (GB)", value: "resources.sru", align: "center" },
-    { text: "HRU (TB)", value: "resources.hru", align: "center" },
+    { text: "MRU", value: "resources.mru", align: "center" },
+    { text: "SRU", value: "resources.sru", align: "center" },
+    { text: "HRU", value: "resources.hru", align: "center" },
     { text: "Price (USD)", value: "discount", align: "center" },
     { text: "Actions", value: "actions", align: "center", sortable: false },
   ];
@@ -181,12 +181,8 @@ export default class NodesTable extends Vue {
     this.loading = false;
   }
 
-  byteToGB(capacity: number) {
-    return byteToGB(capacity);
-  }
-
-  byteToTB(capacity: number) {
-    return byteToTB(capacity);
+  convert(capacity: number) {
+    return toTeraOrGigaOrPeta(capacity.toString());
   }
 }
 </script>

--- a/packages/dashboard/src/portal/lib/nodes.ts
+++ b/packages/dashboard/src/portal/lib/nodes.ts
@@ -227,9 +227,6 @@ export function byteToGB(capacity: number) {
   return (capacity / 1024 / 1024 / 1024).toFixed(2);
 }
 
-export function byteToTB(capacity: number) {
-  return (capacity / (1024 * 1024 * 1024 * 1024)).toFixed(2);
-}
 export async function createRentContract(
   api: apiInterface,
   address: string,

--- a/packages/dashboard/src/portal/lib/nodes.ts
+++ b/packages/dashboard/src/portal/lib/nodes.ts
@@ -224,7 +224,11 @@ export function generateReceipt(doc: jsPDF, node: nodeInterface) {
   return doc;
 }
 export function byteToGB(capacity: number) {
-  return (capacity / 1024 / 1024 / 1024).toFixed(0);
+  return (capacity / 1024 / 1024 / 1024).toFixed(2);
+}
+
+export function byteToTB(capacity: number) {
+  return (capacity / (1024 * 1024 * 1024 * 1024)).toFixed(2);
 }
 export async function createRentContract(
   api: apiInterface,


### PR DESCRIPTION
### Description

Make the dedicated nodes table display the data as the explorer table.
- now dedicated nodes table 
    ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/248111fe-22ef-4416-b21e-4f728d872a20)
- the explorer 
   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/f5fa15af-4220-4ab3-814f-f61e447710f6)


### Changes

- change the order to cru, mru, sru, hru in both tables
- set the values to be Fixed(2)
- set HRU to be in TB

### Related Issues

- #46 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
