### PR TITLE
remove unnecessary prop in NodeDetails

### DIFF
--- a/packages/dashboard/src/portal/components/NodeDetails.vue
+++ b/packages/dashboard/src/portal/components/NodeDetails.vue
@@ -167,7 +167,6 @@ export default class NodeDetails extends Vue {
     location: { country: string; city: string; long: string; lat: string };
     farm: { id: string; name: string; farmCertType: string; pubIps: string };
   };
-  @Prop({ required: true }) byteToGB!: any;
   loading = false;
 }
 </script>

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -71,7 +71,7 @@
           <strong style="color: #f44336">Failed to retrieve Node details</strong>
         </td>
         <td :colspan="headers.length" v-else>
-          <NodeDetails :node="item" :convert="convert" />
+          <NodeDetails :node="item" />
         </td>
       </template>
     </v-data-table>


### PR DESCRIPTION
### Description

the prop byteToGB is not used
also, remove the invalid prop passed to the NodeDetails in  NodesTable
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/d1709e99-b4fe-4b38-a056-8b510f94d5d8)



### Related Issues

- #503 
- #46

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
