### PR TITLE
Enhancing the profile manager to selectively show the password tab, contingent upon the presence of securely hashed credentials stored in the local storage.

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -51,103 +51,104 @@
         "
       >
         <VContainer>
-          <FormValidator v-model="isValidForm">
-            <VTooltip
-              v-if="activeTab === 1"
-              text="Mnemonic are your private key. They are used to represent you on the ThreeFold Grid. You can paste existing mnemonic or click the 'Create Account' button to create an account and generate mnemonic."
-              location="bottom"
-              max-width="700px"
-            >
-              <template #activator="{ props: tooltipProps }">
-                <PasswordInputWrapper #="{ props: passwordInputProps }">
-                  <InputValidator
-                    :value="mnemonic"
-                    :rules="[
-                      validators.required('Mnemonic is required.'),
-                      v => (validateMnemonic(v) ? undefined : { message: `Mnemonic doesn't seem to be valid.` }),
-                    ]"
-                    :async-rules="[validateMnInput]"
-                    valid-message="Mnemonic is valid."
-                    #="{ props: validationProps }"
-                  >
-                    <div v-bind="tooltipProps" v-show="!profileManager.profile" class="d-flex">
-                      <VTextField
-                        class="mb-2"
-                        label="Mnemonic"
-                        placeholder="Please insert your mnemonic"
-                        autofocus
-                        v-model="mnemonic"
-                        v-bind="{ ...passwordInputProps, ...validationProps }"
-                        :disabled="creatingAccount || activating"
-                      />
-                      <VBtn
-                        class="mt-2 ml-3"
-                        color="secondary"
-                        variant="tonal"
-                        :disabled="isValidForm"
-                        :loading="creatingAccount"
-                        @click="createNewAccount"
-                      >
-                        generate account
-                      </VBtn>
-                    </div>
-                  </InputValidator>
-                </PasswordInputWrapper>
-              </template>
-            </VTooltip>
-
-            <v-alert type="error" variant="tonal" class="mb-4" v-if="createAccountError && activeTab === 1">
-              {{ createAccountError }}
-            </v-alert>
-
-            <PasswordInputWrapper #="{ props: passwordInputProps }">
-              <InputValidator
-                :value="password"
-                :rules="[
-                  validators.required('Password is required.'),
-                  validators.minLength('Password must be at least 6 characters.', 6),
-                  validatePassword,
-                ]"
-                #="{ props: validationProps }"
-                ref="passwordInput"
+          <form @submit.prevent="activeTab === 0 ? login() : storeAndLogin()">
+            <FormValidator v-model="isValidForm">
+              <VTooltip
+                v-if="activeTab === 1"
+                text="Mnemonic are your private key. They are used to represent you on the ThreeFold Grid. You can paste existing mnemonic or click the 'Create Account' button to create an account and generate mnemonic."
+                location="bottom"
+                max-width="700px"
               >
-                <v-tooltip
-                  location="bottom"
-                  text="used to encrypt your mnemonic on your local system, and is used to login from the same device."
+                <template #activator="{ props: tooltipProps }">
+                  <PasswordInputWrapper #="{ props: passwordInputProps }">
+                    <InputValidator
+                      :value="mnemonic"
+                      :rules="[
+                        validators.required('Mnemonic is required.'),
+                        v => (validateMnemonic(v) ? undefined : { message: `Mnemonic doesn't seem to be valid.` }),
+                      ]"
+                      :async-rules="[validateMnInput]"
+                      valid-message="Mnemonic is valid."
+                      #="{ props: validationProps }"
+                    >
+                      <div v-bind="tooltipProps" v-show="!profileManager.profile" class="d-flex">
+                        <VTextField
+                          class="mb-2"
+                          label="Mnemonic"
+                          placeholder="Please insert your mnemonic"
+                          autofocus
+                          v-model="mnemonic"
+                          v-bind="{ ...passwordInputProps, ...validationProps }"
+                          :disabled="creatingAccount || activating"
+                        />
+                        <VBtn
+                          class="mt-2 ml-3"
+                          color="secondary"
+                          variant="tonal"
+                          :disabled="isValidForm"
+                          :loading="creatingAccount"
+                          @click="createNewAccount"
+                        >
+                          generate account
+                        </VBtn>
+                      </div>
+                    </InputValidator>
+                  </PasswordInputWrapper>
+                </template>
+              </VTooltip>
+
+              <v-alert type="error" variant="tonal" class="mb-4" v-if="createAccountError && activeTab === 1">
+                {{ createAccountError }}
+              </v-alert>
+
+              <PasswordInputWrapper #="{ props: passwordInputProps }">
+                <InputValidator
+                  :value="password"
+                  :rules="[
+                    validators.required('Password is required.'),
+                    validators.minLength('Password must be at least 6 characters.', 6),
+                    validatePassword,
+                  ]"
+                  #="{ props: validationProps }"
+                  ref="passwordInput"
                 >
-                  <template #activator="{ props: tooltipProps }">
-                    <div v-bind="tooltipProps">
-                      <VTextField
-                        label="Password"
-                        :autofocus="activeTab === 0"
-                        v-model="password"
-                        @keydown.enter="onKeyDown"
-                        v-bind="{ ...passwordInputProps, ...validationProps }"
-                        :disabled="creatingAccount || activating"
-                      />
-                    </div>
-                  </template>
-                </v-tooltip>
-              </InputValidator>
-            </PasswordInputWrapper>
+                  <v-tooltip
+                    location="bottom"
+                    text="used to encrypt your mnemonic on your local system, and is used to login from the same device."
+                  >
+                    <template #activator="{ props: tooltipProps }">
+                      <div v-bind="tooltipProps">
+                        <VTextField
+                          label="Password"
+                          :autofocus="activeTab === 0"
+                          v-model="password"
+                          v-bind="{ ...passwordInputProps, ...validationProps }"
+                          :disabled="creatingAccount || activating"
+                        />
+                      </div>
+                    </template>
+                  </v-tooltip>
+                </InputValidator>
+              </PasswordInputWrapper>
 
-            <v-alert type="error" variant="tonal" class="mt-2 mb-4" v-if="loginError">
-              {{ loginError }}
-            </v-alert>
-          </FormValidator>
+              <v-alert type="error" variant="tonal" class="mt-2 mb-4" v-if="loginError">
+                {{ loginError }}
+              </v-alert>
+            </FormValidator>
 
-          <div class="d-flex justify-center">
-            <VBtn
-              color="primary"
-              variant="tonal"
-              @click="activeTab === 0 ? login() : storeAndLogin()"
-              :loading="activating"
-              :disabled="!isValidForm || creatingAccount"
-              size="large"
-            >
-              {{ activeTab === 0 ? "Login" : "Store and login" }}
-            </VBtn>
-          </div>
+            <div class="d-flex justify-center">
+              <VBtn
+                type="submit"
+                color="primary"
+                variant="tonal"
+                :loading="activating"
+                :disabled="!isValidForm || creatingAccount"
+                size="large"
+              >
+                {{ activeTab === 0 ? "Login" : "Store and login" }}
+              </VBtn>
+            </div>
+          </form>
         </VContainer>
       </DTabs>
 
@@ -266,6 +267,7 @@ import { validateMnemonic } from "bip39";
 import Cryptr from "cryptr";
 import md5 from "md5";
 import { onMounted, type Ref, ref, watch } from "vue";
+import { nextTick } from "vue";
 import { generateKeyPair } from "web-ssh-keygen";
 
 import { useProfileManager } from "../stores";
@@ -287,17 +289,11 @@ const props = defineProps({
 });
 defineEmits<{ (event: "update:modelValue", value: boolean): void }>();
 
-let mountedTimeout: any;
 watch(
   () => props.modelValue,
   m => {
     if (m) {
-      if (mountedTimeout) {
-        clearTimeout(mountedTimeout);
-      }
-      mountedTimeout = setTimeout(() => {
-        mounted();
-      });
+      nextTick().then(mounted);
     }
   },
 );
@@ -321,17 +317,8 @@ function mounted() {
   }
 }
 
-function onKeyDown() {
-  if (password.value.length >= 6) {
-    if (activeTab.value === 0) [login()];
-    else {
-      storeAndLogin();
-    }
-  }
-}
-
 function getCredentials() {
-  const getCredentials = localStorage.getItem("wallet");
+  const getCredentials = localStorage.getItem(WALLET_KEY);
   let credentials: Credentials = {};
 
   if (getCredentials) {
@@ -345,12 +332,12 @@ function setCredentials(passwordHash: string, mnemonicHash: string): Credentials
     passwordHash: passwordHash,
     mnemonicHash: mnemonicHash,
   };
-  localStorage.setItem("wallet", JSON.stringify(credentials));
+  localStorage.setItem(WALLET_KEY, JSON.stringify(credentials));
   return credentials;
 }
 
 function isStoredCredentials() {
-  return localStorage.getItem("wallet") ? true : false;
+  return localStorage.getItem(WALLET_KEY) ? true : false;
 }
 
 function getTabs() {
@@ -390,6 +377,9 @@ const balance = ref<Balance>();
 const activeTab = ref(0);
 const password = ref("");
 const passwordInput = ref() as Ref<{ validate(value: string): Promise<boolean> }>;
+
+const version = 1;
+const WALLET_KEY = "wallet.v" + version;
 
 let interval: any;
 watch(
@@ -523,7 +513,7 @@ function storeAndLogin() {
 
 function validatePassword(value: string) {
   if (activeTab.value === 0) {
-    if (!localStorage.getItem("wallet")) {
+    if (!localStorage.getItem(WALLET_KEY)) {
       return { message: "We couldn't find a matching wallet for this password. Please connect your wallet first." };
     }
     if (getCredentials().passwordHash !== md5(password.value)) {

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -145,7 +145,7 @@
                 :disabled="!isValidForm || creatingAccount"
                 size="large"
               >
-                {{ activeTab === 0 ? "Login" : "Store and login" }}
+                {{ activeTab === 0 ? "Login" : "Connect" }}
               </VBtn>
             </div>
           </form>

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -358,10 +358,10 @@ function getTabs() {
   if (isStoredCredentials()) {
     tabs = [
       { title: "Login", value: "login" },
-      { title: "Connect", value: "register" },
+      { title: "Connect your Wallet", value: "register" },
     ];
   } else {
-    tabs = [{ title: "Connect", value: "register" }];
+    tabs = [{ title: "Connect your Wallet", value: "register" }];
   }
   return tabs;
 }


### PR DESCRIPTION
### Description

It enhances the profile manager to selectively show the password tab, contingent upon the presence of securely hashed credentials stored in the local storage.

### Changes
- created a new interface named Credentials that includes `passwordHash` and `mnemonicHash` fields to represent securely hashed credentials.
- added new helper functions to manage the `Credentials` interface like `getCredentials`, `setCredentials` and `isStoredCredentials` to facilitate the handling and retrieval of stored credentials.
- Implemented a key-down function to enable `login` or `connect` functions when the Enter key is pressed on the password input, provided there are no validation errors.
- Change the `Store and login` button text to `Connect`

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/488
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/519

### Screenshots
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/9582ec05-046a-455e-a6aa-3178c67ba48d)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/2a8daacd-90c4-4e3b-8783-8bba3986a259)

*Update*
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/dc53893c-e1f7-4bba-b469-d457c5dc0f72)




### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
