### PR TITLE
explorer: remove unnecessary calls on destroy nodeFilter

### DIFF
--- a/packages/dashboard/src/explorer/components/NodeFilter.vue
+++ b/packages/dashboard/src/explorer/components/NodeFilter.vue
@@ -103,7 +103,6 @@ export default class InFilter extends Vue {
     });
     this.$store.commit("explorer/" + MutationTypes.CLEAR_NODES_FILTER_KEY, this.filterKey);
     this.$store.commit("explorer/" + MutationTypes.SET_NODES_TABLE_PAGE_NUMBER, 1);
-    this.$store.dispatch(ActionTypes.REQUEST_NODES);
   }
 }
 </script>


### PR DESCRIPTION
### Description
No need to fetch data after leaving the node page, just reset the filters and page number

### Changes

List of changes this PR includes

### Related Issues

- #49 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
