### PR TITLE
Clear profile manager fields when switching between Login and Connect

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -46,7 +46,7 @@
         @tab:change="
           () => {
             clearError();
-            passwordInput.validate(password);
+            clearFields();
           }
         "
       >
@@ -295,6 +295,15 @@ watch(
   m => {
     if (m) {
       nextTick().then(mounted);
+    } else {
+      nextTick().then(() => {
+        if (isStoredCredentials()) {
+          activeTab.value = 0;
+        } else {
+          activeTab.value = 1;
+        }
+        clearFields();
+      });
     }
   },
 );
@@ -410,6 +419,11 @@ const createAccountError = ref<string | null>(null);
 function clearError() {
   loginError.value = null;
   createAccountError.value = null;
+}
+
+function clearFields() {
+  password.value = "";
+  mnemonic.value = "";
 }
 
 async function activate(mnemonic: string) {


### PR DESCRIPTION
### Description

The current behavior of the profile manager does not clear the password and mnemonic fields when the user switches between the Login and Connect tabs or when the profile manager is closed. This can lead to confusion.

### Changes

- Adding a `clearFields` function on tab switching and profile manager closure.

These changes ensure that the profile manager fields are properly cleared to enhance user experience.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/518
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/510

### Screenshots/Video

- [Screencast from 12-06-23 10:50:10.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/4c5bf7d3-b80d-4186-bdb1-df05e33c0dcb)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
