### PR TITLE
Fix wireguard error

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -54,12 +54,6 @@
               />
               <CopyReadonlyInput label="WireGuard IP" :data="contract.interfaces[0].ip" />
               <CopyReadonlyInput label="WireGuard Config" textarea :data="data.wireguard" v-if="data.wireguard" />
-              <CopyReadonlyInput
-                v-else-if="data[0].wireguard"
-                label="WireGuard Config"
-                textarea
-                :data="data[0].wireguard"
-              />
               <CopyReadonlyInput label="Flist" :data="contract.flist" v-if="contract.flist" />
               <template v-if="environments !== false">
                 <template v-for="key of Object.keys(contract.env)" :key="key">


### PR DESCRIPTION
### Description

remove unnecessary wireguard field. Wireguard always will be in data directly, so no need to get it from data[0].wireguard

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/542

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
