### PR TITLE
Add disks page description, change deploy btn 

### DIFF
--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -131,7 +131,9 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid || networkError"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="tabs?.invalid || networkError">
+        Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -99,6 +99,7 @@
       </template>
 
       <template #disks>
+        <div class="text-subtitle-1 text-medium-emphasis">Add disks to your deployment</div>
         <ExpandableLayout v-model="disks" @add="addDisk" #="{ index }">
           <p class="text-h6 mb-4">Disk #{{ index + 1 }}</p>
           <input-validator

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -153,7 +153,15 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" :disabled="tabs?.invalid || networkError" @click="deploy">Deploy</v-btn>
+      <v-btn
+        class="mr-1"
+        color="primary"
+        variant="tonal"
+        width="90.75px"
+        :disabled="tabs?.invalid || networkError"
+        @click="deploy"
+        >Deploy</v-btn
+      >
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -119,6 +119,7 @@
       </template>
 
       <template #disks>
+        <div class="text-subtitle-1 text-medium-emphasis">Add disks to your deployment</div>
         <ExpandableLayout v-model="disks" @add="addDisk" #="{ index }">
           <p class="text-h6 mb-4">Disk #{{ index + 1 }}</p>
           <input-validator

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -140,7 +140,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_caprover.vue
+++ b/packages/playground/src/weblets/tf_caprover.vue
@@ -93,7 +93,7 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -50,7 +50,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -77,7 +77,7 @@
       </template>
     </d-tabs>
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -93,7 +93,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -72,7 +72,7 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn variant="tonal" color="primary" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn variant="tonal" color="primary" width="90.75px" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -60,7 +60,7 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -63,7 +63,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -93,7 +93,7 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -69,7 +69,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -77,7 +77,9 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" :disabled="tabs?.invalid || networkError" @click="deploy"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" :disabled="tabs?.invalid || networkError" @click="deploy">
+        Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -63,7 +63,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -103,7 +103,7 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -81,7 +81,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -94,7 +94,7 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" width="90.75px" @click="deploy" :disabled="!valid"> Deploy </v-btn>
     </template>
   </weblet-layout>
 </template>


### PR DESCRIPTION
### Changes
- set the width of deploy btn to be as the `add` button
- add description to disks page 

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/a8aab74d-4928-4a9b-863f-b87da2774d6c)




List of changes this PR includes

### Related Issues
- #530 
- #531 

### Checklist

- [x] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
