### PR TITLE
Make calculator more clear to user with some tooltips

### DIFF
--- a/packages/dashboard/src/calculator/views/Calculator.vue
+++ b/packages/dashboard/src/calculator/views/Calculator.vue
@@ -47,7 +47,7 @@
                     v-on="on"
                   ></v-text-field>
                 </template>
-                <span>The GB of memory</span>
+                <span>The Memory in GB</span>
               </v-tooltip>
             </v-col>
           </v-row>

--- a/packages/dashboard/src/calculator/views/Calculator.vue
+++ b/packages/dashboard/src/calculator/views/Calculator.vue
@@ -17,12 +17,12 @@
         <div class="card">
           <v-row>
             <v-col cols="5" class="mx-auto">
-              <v-tooltip right>
+              <v-tooltip offset="5" top>
                 <template v-slot:activator="{ on, attrs }">
                   <v-text-field
                     placeholder="Enter number of CPUs"
                     :rules="[...inputValidators, cruCheck]"
-                    label="CRU"
+                    label="CPU"
                     suffix="vCores"
                     v-model="CRU"
                     outlined
@@ -30,16 +30,16 @@
                     v-on="on"
                   ></v-text-field>
                 </template>
-                <span>CPU</span>
+                <span>Number of virtual cores</span>
               </v-tooltip>
             </v-col>
             <v-col cols="5" class="mx-auto">
-              <v-tooltip right>
+              <v-tooltip top>
                 <template v-slot:activator="{ on, attrs }">
                   <v-text-field
                     placeholder="Memory"
                     :rules="[...inputValidators, mruCheck]"
-                    label="MRU"
+                    label="RAM"
                     suffix="GB"
                     v-model="MRU"
                     outlined
@@ -47,18 +47,18 @@
                     v-on="on"
                   ></v-text-field>
                 </template>
-                <span>RAM</span>
+                <span>The GB of memory</span>
               </v-tooltip>
             </v-col>
           </v-row>
           <v-row>
             <v-col cols="5" class="mx-auto">
-              <v-tooltip right>
+              <v-tooltip top>
                 <template v-slot:activator="{ on, attrs }">
                   <v-text-field
                     placeholder="SSD Storage"
                     :rules="[...inputValidators, diskCheck(SRU)]"
-                    label="SRU"
+                    label="Disk SSD"
                     suffix="GB"
                     v-model="SRU"
                     outlined
@@ -66,16 +66,16 @@
                     v-on="on"
                   ></v-text-field>
                 </template>
-                <span>SSD</span>
+                <span>The SSD capacity storage</span>
               </v-tooltip>
             </v-col>
             <v-col cols="5" class="mx-auto">
-              <v-tooltip right>
+              <v-tooltip top>
                 <template v-slot:activator="{ on, attrs }">
                   <v-text-field
                     placeholder="HDD Storage"
                     :rules="[...inputValidators, diskCheck(HRU)]"
-                    label="HRU"
+                    label="Disk HDD"
                     suffix="GB"
                     v-model="HRU"
                     outlined
@@ -83,7 +83,7 @@
                     v-on="on"
                   ></v-text-field>
                 </template>
-                <span>HDD</span>
+                <span>The HDD capacity storage</span>
               </v-tooltip>
             </v-col>
           </v-row>

--- a/packages/dashboard/src/calculator/views/Calculator.vue
+++ b/packages/dashboard/src/calculator/views/Calculator.vue
@@ -89,15 +89,32 @@
           </v-row>
           <v-row>
             <v-col cols="2" class="mx-auto">
-              <v-switch label="With a Public IP (V4)" @change="IPV4Toggle" />
+              <v-tooltip bottom nudge-right="40">
+                <template v-slot:activator="{ on, attrs }">
+                  <div v-on="on" v-bind="attrs">
+                    <v-switch hide-details label="With a Public IP (V4)" @change="IPV4Toggle" />
+                  </div> </template
+                ><span
+                  >An Internet Protocol version 4 address that is globally unique and accessible over the internet</span
+                >
+              </v-tooltip>
             </v-col>
             <v-col cols="2" class="mx-auto">
-              <v-switch
-                label="Use current balance"
-                :disabled="!$store.state.credentials.account.address"
-                @change="getCurrentBalance"
-                v-model="useCurrentBalance"
-              />
+              <v-tooltip bottom nudge-left="20">
+                <template v-slot:activator="{ on, attrs }">
+                  <div v-on="on" v-bind="attrs">
+                    <v-switch
+                      hide-details
+                      label="Use current balance"
+                      :disabled="!$store.state.credentials.account.address"
+                      @change="getCurrentBalance"
+                      v-model="useCurrentBalance"
+                    />
+                  </div>
+                </template>
+                <span v-if="!$store.state.credentials.account.address">You should select/create an account first</span>
+                <span v-else>Use current balance to calculate the discount</span>
+              </v-tooltip>
             </v-col>
             <v-col cols="5" class="mx-auto">
               <v-tooltip top>
@@ -127,13 +144,21 @@
           :key="price.price"
           :style="{ color: price.color, background: price.backgroundColor }"
         >
-          <span class="price">
-            <span class="name">
-              {{ price.label !== undefined ? price.label + " " : " " }}
-              {{ price.packageName != "none" ? price.packageName + " Package" : "" }}</span
-            >
-            : ${{ price.price }}/month, {{ price.TFTs }} TFT/month
-          </span>
+          <v-tooltip bottom nudge-bottom="12">
+            <template v-slot:activator="{ on, attrs }">
+              <span class="price">
+                <p>
+                  Cost of reservation on a
+                  <span class="name">{{ price.label !== undefined ? price.label + " " : " " }}</span>
+                </p>
+                <span class="package"> {{ price.packageName != "none" ? price.packageName + " Package: " : "" }}</span>
+                ${{ price.price }}/month, {{ price.TFTs }} TFT/month
+                <span class="pl-2" dark right v-bind="attrs" v-on="on">
+                  <i class="fa-solid fa-circle-info"></i>
+                </span> </span
+            ></template>
+            <span>{{ price.info }}</span>
+          </v-tooltip>
         </div>
       </div>
     </v-card>
@@ -153,6 +178,7 @@ type priceType = {
   packageName: any;
   backgroundColor: string;
   TFTs: any;
+  info: string;
 };
 
 @Component({
@@ -267,20 +293,22 @@ export default class Calculator extends Vue {
 
       this.prices = [
         {
-          label: "Dedicated Node Price",
+          label: "Dedicated Node",
           price: `${dedicatedPrice}`,
           color: this.discountPackages[dedicatedPackage].color,
           packageName: dedicatedPackage,
           backgroundColor: this.discountPackages[dedicatedPackage].backgroundColor,
           TFTs: (+dedicatedPrice / this.TFTPrice).toFixed(2),
+          info: "A user can reserve an entire node then use it exclusively to deploy solutions",
         },
         {
-          label: "Shared Node Price",
+          label: "Shared Node",
           price: `${sharedPrice}`,
           color: "#868686",
           packageName: sharedPackage,
           backgroundColor: this.discountPackages[sharedPackage].backgroundColor,
           TFTs: (+sharedPrice / this.TFTPrice).toFixed(2),
+          info: "Shared Nodes allow several users to host various workloads on a single node",
         },
       ];
     } else {
@@ -421,6 +449,9 @@ export default class Calculator extends Vue {
 }
 
 .name {
+  font-weight: 900;
+}
+.package {
   font-weight: 900;
   text-transform: capitalize;
 }


### PR DESCRIPTION
### Description
If the user logged in with the account, the user will be able to use the current balance to calculate the discount.
if the user toggled the switch again the input value will be reset to the amount entered before the balance.

[Screencast from 15 يون, 2023 EEST 05:52:10 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/fcb837a2-de01-4855-a5b0-a4f452c3e43d)

#### Add use current balance switch 
If the user logged in with the account, the user will be able to use the current balance to calculate the discount.
if the user toggled the switch again the input value will be reset to the amount entered before the balance.
### Related Issues
- #590

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
