### PR TITLE
add contracts list info to the router

### DIFF
--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -105,7 +105,7 @@ const router = createRouter({
     {
       path: "/contractslist",
       component: () => import("../views/contracts_list.vue"),
-      meta: { title: "Contracts List" },
+      meta: { title: "Contracts List", info: { page: "info/contracts_list.md" } },
     },
     {
       path: "/:pathMatch(.*)*",


### PR DESCRIPTION
### Description

Fixes the help page of contracts list (it wasn't registered in the router)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/64129/3417f37b-67e0-4d6c-beed-75a0f8f9f2d8)

### Related Issues

[#contracts list](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/672)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
