### PR TITLE
add dao result as accepted or rejected

### DIFF
--- a/packages/dashboard/src/portal/views/Dao.vue
+++ b/packages/dashboard/src/portal/views/Dao.vue
@@ -86,7 +86,7 @@
                       </v-btn>
                     </div>
                     <v-container class="px-12" v-if="proposal.ayesProgress > 0 || proposal.nayesProgress > 0">
-                      <v-row justify="center" class="pt-4">
+                      <v-row justify="center" v-if="proposal.end > Date.now()" class="pt-4">
                         <v-progress-linear
                           rounded
                           :value="proposal.ayesProgress"
@@ -127,6 +127,55 @@
                                   ? proposal.nayesProgress.toFixed(2)
                                   : proposal.nayesProgress
                               }}%</strong
+                            >
+                          </template>
+                        </v-progress-linear>
+                      </v-row>
+                      <v-row justify="center" v-else class="pt-4">
+                        <v-progress-linear
+                          v-if="proposal.ayesProgress > proposal.nayesProgress"
+                          rounded
+                          :value="100"
+                          height="20"
+                          :style="{
+                            width: '100%',
+                            marginRight: 'auto',
+                            backgroundColor: '#1982b1',
+                            color: '#fff',
+                          }"
+                        >
+                          <template>
+                            <strong>Accepted</strong>
+                            <span class="pl-2"
+                              >{{
+                                !!(proposal.ayesProgress % 1)
+                                  ? proposal.ayesProgress.toFixed(2)
+                                  : proposal.ayesProgress
+                              }}%</span
+                            >
+                          </template>
+                        </v-progress-linear>
+                        <v-progress-linear
+                          v-else-if="proposal.ayesProgress < proposal.nayesProgress"
+                          rounded
+                          :value="100"
+                          color="grey lighten-2"
+                          backgroundColor="#e0e0e0"
+                          height="20"
+                          :style="{
+                            width: '100%',
+                            marginRight: 'auto',
+                            color: '#333',
+                          }"
+                        >
+                          <template>
+                            <strong>Rejected</strong>
+                            <span class="pl-2"
+                              >{{
+                                !!(proposal.nayesProgress % 1)
+                                  ? proposal.nayesProgress.toFixed(2)
+                                  : proposal.nayesProgress
+                              }}%</span
                             >
                           </template>
                         </v-progress-linear>


### PR DESCRIPTION
### Description
The old way to show the results of the proposals is very confusing, the user should guess that the blue color means yes , and calculate the results based on the shown numbers and colors
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/53be3a65-9685-4771-b0e5-ce85d7ec068c)


### Changes

Now if the proposal is accepted the whole bar will be blue with `Accepted` and the percentage of `ayesProgress`
if not; the bar will be white with `Rejected` and the percentage of `nayesProgress`
![Screenshot from 2023-06-20 17-50-19](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/adda6831-5a78-449e-a216-848191b0b9a1)

### Related Issues

- #576

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
