### PR TITLE
Development dashboard dedicated node gpu

### DIFF
--- a/packages/dashboard/src/portal/components/NodeDetails.vue
+++ b/packages/dashboard/src/portal/components/NodeDetails.vue
@@ -155,7 +155,7 @@
       </v-card>
     </v-col>
 
-    <v-col :cols="3" class="my-4">
+    <v-col :cols="3">
       <v-card flat color="transparent" tag="div">
         <!-- Title -->
         <v-list-item>
@@ -166,20 +166,96 @@
             <v-list-item-title style="font-size: 20px"> Node Resources </v-list-item-title>
           </v-list-item-content>
         </v-list-item>
-        <v-sheet class="d-flex justify-center align-center" height="180">
+        <!-- <v-sheet class="d-flex justify-center align-center pt-0" height="180">
           <div v-if="loading" class="text-center">
             <v-progress-circular indeterminate></v-progress-circular>
             <p class="pt-2">Loading GPU details</p>
           </div>
-          <div v-else-if="nodeGPU === undefined" class="text-center">
+          <div v-else-if="nodeGPUitems === undefined || nodeGPUitems.length == 0" class="text-center">
             <v-alert class="ma-2" dense outlined type="error">
               Failed to receive node GPUs information
               <template v-slot:append>
                 <v-icon @click="loadGPUitems">mdi-reload</v-icon>
               </template>
             </v-alert>
-          </div>
-        </v-sheet>
+          </div> -->
+        <v-row>
+          <v-col cols="12">
+            <v-list>
+              <v-list-item>
+                <v-list-item-content style="max-width: fit-content">
+                  <v-tooltip top nudge-bottom="30">
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-list-item-title v-bind="attrs" v-on="on"
+                        >Card ID
+                        <v-chip
+                          lose-icon="mdi-delete"
+                          :color="gpuItem.contract ? 'warning' : 'success'"
+                          x-small
+                          class="mb-1"
+                          >{{ gpuItem.contract ? "Reserved" : "Available" }}</v-chip
+                        >
+                      </v-list-item-title>
+                    </template>
+                    <span>Card id that's used in a deployment</span>
+                  </v-tooltip>
+                </v-list-item-content>
+
+                <v-col class="pa-0 ml-2 mr-n2">
+                  <v-select
+                    v-if="nodeGPUitems.length > 1"
+                    append-outer-icon="mdi-content-copy"
+                    hide-details
+                    dense
+                    v-model="gpuItem"
+                    :items="nodeGPUitems"
+                    @input.native="gpuItem = $event.srcElement.value.value"
+                    @click:append-outer="copy(gpuItem.id)"
+                  />
+                  <v-text-field
+                    v-else
+                    :value="gpuItem.id"
+                    readonly
+                    hide-details
+                    class="mt-n2"
+                    dense
+                    append-outer-icon="mdi-content-copy"
+                    @click:append-outer="copy(gpuItem.id)"
+                    solo
+                  ></v-text-field>
+                </v-col>
+              </v-list-item>
+
+              <v-divider />
+              <v-list-item>
+                <v-list-item-content>
+                  <v-list-item-title> Vendor </v-list-item-title>
+                </v-list-item-content>
+                {{ gpuItem?.vendor }}
+              </v-list-item>
+              <v-divider />
+
+              <v-list-item>
+                <v-list-item-content>
+                  <v-list-item-title> Device </v-list-item-title>
+                </v-list-item-content>
+                {{ gpuItem?.device }}
+              </v-list-item>
+              <v-divider />
+              <v-list-item v-if="gpuItem.contract !== undefined">
+                <v-tooltip top nudge-bottom="30">
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-list-item-content v-bind="attrs" v-on="on">
+                      <v-list-item-title> Contract ID</v-list-item-title>
+                    </v-list-item-content>
+                  </template>
+                  <span>The contract id that reserves this GPU card</span>
+                </v-tooltip>
+                {{ gpuItem?.contract }}
+              </v-list-item>
+              <v-divider v-if="gpuItem.contract !== undefined" />
+            </v-list> </v-col
+        ></v-row>
       </v-card>
     </v-col>
   </v-row>
@@ -200,16 +276,36 @@ export default class NodeDetails extends Vue {
     farm: { id: string; name: string; farmCertType: string; pubIps: string };
   };
   loading = false;
-  nodeGPU: INodeGPU[] | undefined = [];
+  nodeGPUitems:
+    | {
+        text: string;
+        value: INodeGPU;
+
+        disabled: false;
+      }[]
+    | undefined = [];
+  gpuItem: INodeGPU | undefined = undefined;
+  error = false;
   gpuError = false;
   async loadGPUitems() {
     this.loading = true;
-    this.nodeGPU = await getNodeGPUs(this.node.nodeId);
-    console.log(this.nodeGPU);
+    const nodeGPU = await getNodeGPUs(this.node.nodeId);
     this.loading = false;
+    if (!nodeGPU) return;
+    this.nodeGPUitems = nodeGPU.map((item: INodeGPU) => {
+      return {
+        text: item.id,
+        value: item,
+        disabled: false,
+      };
+    });
+    this.gpuItem = this.nodeGPUitems[0].value;
   }
   async mounted() {
     await this.loadGPUitems();
+  }
+  copy(id: string) {
+    navigator.clipboard.writeText(id);
   }
 }
 </script>

--- a/packages/dashboard/src/portal/components/NodeDetails.vue
+++ b/packages/dashboard/src/portal/components/NodeDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="4">
+    <v-col :cols="3">
       <v-card flat color="transparent" tag="div">
         <!-- Title -->
         <v-list-item>
@@ -52,7 +52,7 @@
       </v-card>
     </v-col>
 
-    <v-col :cols="4">
+    <v-col :cols="3">
       <v-card flat color="transparent" tag="div">
         <!-- Title -->
         <v-list-item>
@@ -103,7 +103,7 @@
         </v-row>
       </v-card>
     </v-col>
-    <v-col :cols="4">
+    <v-col :cols="3">
       <v-card flat color="transparent" tag="div">
         <!-- Title -->
         <v-list-item>
@@ -154,19 +154,62 @@
         </v-row>
       </v-card>
     </v-col>
+
+    <v-col :cols="3" class="my-4">
+      <v-card flat color="transparent" tag="div">
+        <!-- Title -->
+        <v-list-item>
+          <v-list-item-icon>
+            <v-icon size="30" class="mr-2">mdi-harddisk</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title style="font-size: 20px"> Node Resources </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+        <v-sheet class="d-flex justify-center align-center" height="180">
+          <div v-if="loading" class="text-center">
+            <v-progress-circular indeterminate></v-progress-circular>
+            <p class="pt-2">Loading GPU details</p>
+          </div>
+          <div v-else-if="nodeGPU === undefined" class="text-center">
+            <v-alert class="ma-2" dense outlined type="error">
+              Failed to receive node GPUs information
+              <template v-slot:append>
+                <v-icon @click="loadGPUitems">mdi-reload</v-icon>
+              </template>
+            </v-alert>
+          </div>
+        </v-sheet>
+      </v-card>
+    </v-col>
   </v-row>
 </template>
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
+
+import { getNodeGPUs, INodeGPU } from "../lib/nodes";
+
 @Component({
   name: "NodeDetails",
 })
 export default class NodeDetails extends Vue {
   @Prop({ required: true }) node!: {
-    resources: { cru: string; hru: string; sru: string; mru: string };
+    nodeId: number;
+    resources: { cru: string; hru: string; sru: string; mru: string; gpu: number };
     location: { country: string; city: string; long: string; lat: string };
     farm: { id: string; name: string; farmCertType: string; pubIps: string };
   };
   loading = false;
+  nodeGPU: INodeGPU[] | undefined = [];
+  gpuError = false;
+  async loadGPUitems() {
+    this.loading = true;
+    this.nodeGPU = await getNodeGPUs(this.node.nodeId);
+    console.log(this.nodeGPU);
+    this.loading = false;
+  }
+  async mounted() {
+    await this.loadGPUitems();
+  }
 }
 </script>

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -113,6 +113,7 @@ export default class NodesTable extends Vue {
     { text: "MRU", value: "resources.mru", align: "center" },
     { text: "SRU", value: "resources.sru", align: "center" },
     { text: "HRU", value: "resources.hru", align: "center" },
+    { text: "GPU", value: "resources.gpu", align: "center" },
     { text: "Price (USD)", value: "discount", align: "center" },
     { text: "Actions", value: "actions", align: "center", sortable: false },
   ];
@@ -175,7 +176,6 @@ export default class NodesTable extends Vue {
       this.pageNumber,
       this.pageSize,
     );
-
     this.nodes = dNodes;
     this.count = parseInt(count as string);
     this.loading = false;

--- a/packages/dashboard/src/portal/lib/nodes.ts
+++ b/packages/dashboard/src/portal/lib/nodes.ts
@@ -172,6 +172,12 @@ export interface ITab {
   value: "rentable" | "rented" | "mine";
   index: number;
 }
+export interface INodeGPU {
+  id: string;
+  vendor: string;
+  device: string;
+  contract?: number;
+}
 
 export function generateReceipt(doc: jsPDF, node: nodeInterface) {
   doc.setFontSize(15);
@@ -286,6 +292,20 @@ export async function getNodeMintingFixupReceipts(nodeId: number) {
   );
 
   return nodeReceipts;
+}
+export async function getNodeGPUs(nodeId: number): Promise<INodeGPU[] | undefined> {
+  let nodeGPUs: INodeGPU[] | undefined;
+
+  try {
+    nodeGPUs = await (
+      await axios.get(`${config.gridproxyUrl}/nodes/${nodeId}/gpu`, {
+        timeout: 5000,
+      })
+    ).data;
+  } catch (err) {
+    nodeGPUs = undefined;
+  }
+  return nodeGPUs;
 }
 
 export async function getNodeUsedResources(nodeId: string) {

--- a/packages/dashboard/src/portal/lib/nodes.ts
+++ b/packages/dashboard/src/portal/lib/nodes.ts
@@ -467,7 +467,7 @@ export async function getDNodes(
     discount: any;
     applyedDiscount: { first: any; second: any };
     location: { country: any; city: any; long: any; lat: any };
-    resources: { cru: any; mru: any; hru: any; sru: any };
+    resources: { cru: any; mru: any; hru: any; sru: any; gpu: number };
     farm: { id: string; name?: string; farmCertType?: string; pubIps?: string };
     rentContractId: any;
     rentedByTwinId: any;
@@ -499,6 +499,7 @@ export async function getDNodes(
         mru: node.total_resources.mru,
         hru: node.total_resources.hru,
         sru: node.total_resources.sru,
+        gpu: node.num_gpu,
       },
       usedResources: {
         cru: node.used_resources.cru,


### PR DESCRIPTION
### Description

support GPU details in dedicated nodes, now the user sees the amount of GPU cards on each node in the `GPU` column,
and if the user needs more details and expands the node, will see a GPU card/s section that can list all cards and their details.

- loading gpu details, also if an error happens while fetching the GPU URL

  [Screencast from 22 يون, 2023 EEST 07:19:29 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/756bd508-2dfe-4be6-89ee-80a4cff57b30)
 
- single card details 
  ![Screenshot from 2023-06-25 12-22-27](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/ef0bbe35-0161-49fe-978b-cd317b2a3c1a)

- multiple cards details 
  
  [Screencast from 25 يون, 2023 EEST 12:32:14 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/38f21788-36b4-4b2e-8e18-b8642ea1e217)
 

### Related Issues

- #690 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
