### PR TITLE
Enhance GPU section in explorer

### DIFF
--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -1,6 +1,6 @@
 <template>
   <v-bottom-sheet v-model="open" persistent no-click-animation @click:outside="$emit('close-sheet')">
-    <v-sheet class="text-center" height="90vh">
+    <v-sheet :class="{ 'text-center': true, loading: loading }" height="90vh">
       <div class="content" v-if="!loading">
         <v-row>
           <v-col v-if="node">
@@ -45,9 +45,11 @@
           </v-col>
         </v-row>
       </div>
-      <div v-if="loading" class="pt-10 mt-auto align-center">
-        <v-progress-circular indeterminate color="primary" :size="100" />
-        <p class="pt-4">Loading Node {{ nodeId ?? "" }} details</p>
+      <div v-if="loading" class="d-flex align-self-center justify-center" style="height: 100%">
+        <div class="align-self-center">
+          <v-progress-circular indeterminate color="primary" :size="100" />
+          <p class="pt-4">Loading Node {{ nodeId ?? "" }} details</p>
+        </div>
       </div>
     </v-sheet>
   </v-bottom-sheet>
@@ -90,7 +92,7 @@ export default class Details extends Vue {
   @Prop({ required: true }) variables!: { [key: string]: any };
   @Prop() nodeId: any;
 
-  loading = true;
+  loading = false;
   grafanaUrl = "";
   interfaces = undefined;
   data: any = {};
@@ -146,7 +148,7 @@ export default class Details extends Vue {
         /* pass */
       })
       .finally(() => {
-        this.loading = true;
+        this.loading = false;
       });
   }
   destroyed() {
@@ -175,5 +177,8 @@ export default class Details extends Vue {
   will-change: transform;
   height: 100%;
   padding: 20px;
+}
+.loading {
+  cursor: wait;
 }
 </style>

--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -45,7 +45,7 @@
           </v-col>
         </v-row>
       </div>
-      <div v-if="loading" class="d-flex align-self-center justify-center" style="height: 100%">
+      <div v-if="loading" class="d-flex justify-center" style="height: 100%">
         <div class="align-self-center">
           <v-progress-circular indeterminate color="primary" :size="100" />
           <p class="pt-4">Loading Node {{ nodeId ?? "" }} details</p>

--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -40,16 +40,13 @@
             <InterfacesDetails :interfaces="interfaces" />
           </v-col>
 
-          <v-col :cols="screen_max_700.matches ? 12 : screen_max_1200.matches ? 6 : 4" v-if="node && nodeGPU">
-            <GPUDetails :nodeGPU="nodeGPU" />
+          <v-col
+            :cols="screen_max_700.matches ? 12 : screen_max_1200.matches ? 6 : 4"
+            v-if="node && (nodeGPU || gpuError)"
+          >
+            <GPUDetails :nodeGPU="nodeGPU" :nodeId="nodeId" />
           </v-col>
-          <v-snackbar :timeout="2000" :value="gpuError" color="transparent" text>
-            <v-alert class="ma-2" dense outlined type="error"> Failed to receive node GPUs information </v-alert>
-          </v-snackbar>
         </v-row>
-      </div>
-      <div v-if="loading" class="pt-10">
-        <v-progress-circular indeterminate color="primary" :size="100" />
       </div>
     </v-sheet>
   </v-bottom-sheet>
@@ -132,21 +129,7 @@ export default class Details extends Vue {
           this.data.node = await fetch(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}`).then(res =>
             res.json(),
           );
-
-          if (this.data.node.num_gpu) {
-            try {
-              this.nodeGPU = await (
-                await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/gpu`, {
-                  timeout: 5000,
-                })
-              ).data;
-              this.gpuError = false;
-            } catch (error) {
-              this.gpuError = true;
-              this.nodeGPU = undefined;
-            }
-          }
-
+          await this.loadGpuDetails(94);
           try {
             this.data.nodeStatistics = await (
               await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`, {
@@ -168,7 +151,20 @@ export default class Details extends Vue {
         this.loading = false;
       });
   }
-
+  async loadGpuDetails(nodeId: number) {
+    if (!this.data.node.num_gpu) return;
+    try {
+      this.nodeGPU = await (
+        await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${94}/gpu`, {
+          timeout: 5000,
+        })
+      ).data;
+      this.gpuError = false;
+    } catch (error) {
+      this.gpuError = true;
+      this.nodeGPU = undefined;
+    }
+  }
   destroyed() {
     this.screen_max_1200.destry();
     this.screen_max_700.destry();

--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -129,7 +129,7 @@ export default class Details extends Vue {
           this.data.node = await fetch(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}`).then(res =>
             res.json(),
           );
-          await this.loadGpuDetails(94);
+          await this.loadGpuDetails(this.nodeId);
           try {
             this.data.nodeStatistics = await (
               await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`, {
@@ -155,7 +155,7 @@ export default class Details extends Vue {
     if (!this.data.node.num_gpu) return;
     try {
       this.nodeGPU = await (
-        await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${94}/gpu`, {
+        await axios.get(`${window.configs.APP_GRIDPROXY_URL}/nodes/${nodeId}/gpu`, {
           timeout: 5000,
         })
       ).data;

--- a/packages/dashboard/src/explorer/components/DetailsV2.vue
+++ b/packages/dashboard/src/explorer/components/DetailsV2.vue
@@ -45,6 +45,10 @@
           </v-col>
         </v-row>
       </div>
+      <div v-if="loading" class="pt-10 mt-auto align-center">
+        <v-progress-circular indeterminate color="primary" :size="100" />
+        <p class="pt-4">Loading Node {{ nodeId ?? "" }} details</p>
+      </div>
     </v-sheet>
   </v-bottom-sheet>
 </template>
@@ -86,7 +90,7 @@ export default class Details extends Vue {
   @Prop({ required: true }) variables!: { [key: string]: any };
   @Prop() nodeId: any;
 
-  loading = false;
+  loading = true;
   grafanaUrl = "";
   interfaces = undefined;
   data: any = {};
@@ -142,7 +146,7 @@ export default class Details extends Vue {
         /* pass */
       })
       .finally(() => {
-        this.loading = false;
+        this.loading = true;
       });
   }
   destroyed() {

--- a/packages/dashboard/src/explorer/components/GPUDetails.vue
+++ b/packages/dashboard/src/explorer/components/GPUDetails.vue
@@ -89,7 +89,7 @@
           </div>
           <div v-else class="text-center">
             <v-alert class="ma-2" dense outlined type="error">
-              Failed to receive node GPUs information
+              Failed to get node GPUs' information
               <template v-slot:append>
                 <v-icon class="ml-2 mt-1" @click="loadGpuDetails">mdi-reload</v-icon>
               </template>

--- a/packages/dashboard/src/explorer/components/GPUDetails.vue
+++ b/packages/dashboard/src/explorer/components/GPUDetails.vue
@@ -108,20 +108,10 @@ import { INodeGPU } from "../graphql/api";
 
 @Component({})
 export default class GPUDetails extends Vue {
-  @Prop({ required: true }) nodeGPU!: INodeGPU[] | null;
   @Prop({ required: true }) nodeId!: number;
-  nodeGPUitems =
-    this.$props.nodeGPU != null
-      ? this.$props.nodeGPU.map((item: INodeGPU) => {
-          return {
-            text: item.id,
-            value: item,
-            disabled: false,
-          };
-        })
-      : null;
-  gpuItem = this.$props.nodeGPU ? this.$props.nodeGPU[0] : null;
-  loading = false;
+  nodeGPUitems: { text: string; value: INodeGPU; disabled: false }[] | null = null;
+  gpuItem: INodeGPU | null = null;
+  loading = true;
   copy(id: string) {
     navigator.clipboard.writeText(id);
   }
@@ -129,7 +119,7 @@ export default class GPUDetails extends Vue {
     this.loading = true;
     await getNodeGPUs(this.nodeId)
       .then(result => {
-        if (result == null) return;
+        if (!result) return;
         this.nodeGPUitems = result?.map((item: INodeGPU) => {
           return {
             text: item.id,
@@ -145,6 +135,9 @@ export default class GPUDetails extends Vue {
       .finally(() => {
         this.loading = false;
       });
+  }
+  async mounted() {
+    await this.loadGpuDetails();
   }
 }
 </script>


### PR DESCRIPTION
### Description
- move all GPU-related logic to the `GPUDetails` component and use `getNodeGPUs`  from `portal/lib/nodes` to fetch gpu details
- add gpu loading indicator to gpu section 
- add error and retry btn to gpu section in case of failure 
![Screenshot from 2023-06-26 14-53-53](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/5e3b1bc6-8730-4bfb-9b22-b58720455609)



[Screencast from 26 يون, 2023 EEST 12:07:45 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/0ecc09a3-1ae5-4d25-b320-f70b55c17011)

### Related Issues

- #465
- #723

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
