### PR TITLE
Add search capabilities in dedicated nodes page

### DIFF
--- a/packages/dashboard/src/Dashboard.vue
+++ b/packages/dashboard/src/Dashboard.vue
@@ -216,6 +216,7 @@ import FundsCard from "./portal/components/FundsCard.vue";
 import TftSwapPrice from "./portal/components/TftSwapPrice.vue";
 import WelcomeWindow from "./portal/components/WelcomeWindow.vue";
 import { connect } from "./portal/lib/connect";
+import { MutationTypes } from "./portal/store/mutations";
 import { accountInterface } from "./portal/store/state";
 
 interface SidenavItem {
@@ -258,7 +259,7 @@ export default class Dashboard extends Vue {
     this.accounts = this.$store.state.portal.accounts;
     if (this.$route.path === "/" && !this.$api) {
       Vue.prototype.$api = await connect();
-      if (this.$api) this.$store.commit("portal/setApi", { api: this.$api });
+      if (this.$api) this.$store.commit(`portal/${MutationTypes.SET_API}`, this.$api);
       this.loadingAPI = false;
     }
     const theme = localStorage.getItem("dark_theme");

--- a/packages/dashboard/src/explorer/graphql/api.ts
+++ b/packages/dashboard/src/explorer/graphql/api.ts
@@ -72,6 +72,7 @@ export interface INode {
   version: number;
   gridVersion: number;
   nodeId: number;
+  applyedDiscount?: { first: string; second: string };
   farmId: number;
   twinId: number;
   cityId?: number;
@@ -81,12 +82,14 @@ export interface INode {
   sru?: string;
   cru?: string;
   mru?: string;
+  price?: string;
+  discount?: any;
   capacity: Capacity;
   publicConfig?: IPublicConfig;
   uptime?: number;
   created: number;
   farmingPolicyId: number;
-  location: Location;
+  location: ILocation;
   country?: string;
   city?: string;
   interfaces: Interfaces[];

--- a/packages/dashboard/src/explorer/graphql/api.ts
+++ b/packages/dashboard/src/explorer/graphql/api.ts
@@ -99,6 +99,7 @@ export interface INode {
   countryFullName: string;
   num_gpu: number;
   extra_fee: number;
+  farm?: IFarm;
 }
 
 export interface INodeGPU {

--- a/packages/dashboard/src/explorer/store/mutations.ts
+++ b/packages/dashboard/src/explorer/store/mutations.ts
@@ -31,7 +31,7 @@ interface ISetNodeFilter {
   value: any;
 }
 
-function fillNodesFields(state: IState, node: any, farms: any): INode {
+export function fillNodesFields(state: IState, node: any, farms: any): INode {
   return {
     id: node.id,
     createdAt: node.createdAt,
@@ -75,7 +75,7 @@ function fillNodesFields(state: IState, node: any, farms: any): INode {
     ],
     status: node.status,
     certificationType: node.certificationType,
-    farmingPolicyName: state.policies[node.farmingPolicyId],
+    farmingPolicyName: state.policies ? state.policies[node.farmingPolicyId] : "",
     countryFullName: node.country && node.country?.length == 2 ? byInternet(node.country)?.country : node.country,
   };
 }

--- a/packages/dashboard/src/portal/Portal.vue
+++ b/packages/dashboard/src/portal/Portal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <router-view style="padding: 6% 5% 5% 10%; margin: 4% 0" />
+    <router-view style="padding: 3%; margin: 4% 0" />
     <VotePopup v-if="$store.state.credentials.twin.id" />
   </v-container>
 </template>

--- a/packages/dashboard/src/portal/components/Layout.vue
+++ b/packages/dashboard/src/portal/components/Layout.vue
@@ -8,7 +8,7 @@
       <br />
     </div>
     <v-row>
-      <v-col :cols="screen_max_1400 ? 12 : 3" :order="screen_max_1400 ? 1 : undefined" v-if="!noFilter">
+      <v-col :cols="screen_max_1400 ? 12 : 2" :order="screen_max_1400 ? 1 : undefined" v-if="!noFilter">
         <h3>Filters</h3>
         <br />
         <v-row>
@@ -23,7 +23,7 @@
           <slot name="active-filters"></slot>
         </section>
       </v-col>
-      <v-col :cols="screen_max_1400 ? 12 : 9" class="table-container">
+      <v-col :cols="screen_max_1400 ? 12 : 10" class="table-container">
         <slot name="node-table"></slot>
       </v-col>
     </v-row>

--- a/packages/dashboard/src/portal/components/Layout.vue
+++ b/packages/dashboard/src/portal/components/Layout.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-container>
+    <div v-if="pageName">
+      <h1>
+        {{ pageName }}
+      </h1>
+      <v-divider />
+      <br />
+    </div>
+    <v-row>
+      <v-col :cols="screen_max_1400 ? 12 : 3" :order="screen_max_1400 ? 1 : undefined" v-if="!noFilter">
+        <h3>Filters</h3>
+        <br />
+        <v-row>
+          <slot name="filters"></slot>
+        </v-row>
+        <v-row class="mt-2 mb-2 mr-2" justify="end">
+          <slot name="apply-filters"></slot>
+        </v-row>
+        <br />
+        <v-divider />
+        <section class="filter-container" ref="container">
+          <slot name="active-filters"></slot>
+        </section>
+      </v-col>
+      <v-col :cols="screen_max_1400 ? 12 : 9" class="table-container">
+        <slot name="node-table"></slot>
+      </v-col>
+    </v-row>
+    <slot name="details"></slot>
+    <slot></slot>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+
+@Component({})
+export default class Layout extends Vue {
+  @Prop({ required: false }) pageName!: string;
+  @Prop({ default: false }) noFilter!: boolean;
+
+  private _screen_max_1400?: MediaQueryList;
+  screen_max_1400 = false;
+
+  private _resizePanel() {
+    const panel = this.$refs.container as HTMLElement;
+    if (panel) {
+      const maxHeight = this.screen_max_1400 ? 350 : panel.offsetTop + 20;
+      panel.style.maxHeight = `calc(100vh - ${maxHeight}px)`;
+    }
+  }
+
+  mounted() {
+    this._screen_max_1400 = window.matchMedia("(max-width: 1400px)");
+    this.screen_max_1400 = this._screen_max_1400.matches;
+    this._screen_max_1400.onchange = e => {
+      this.screen_max_1400 = e.matches;
+      this._resizePanel();
+    };
+
+    this._resizePanel();
+  }
+
+  destroyed() {
+    if (!this._screen_max_1400) return;
+    this._screen_max_1400.onchange = null;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.filter-container {
+  padding-right: 10px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  will-change: transform;
+  min-height: 100px;
+}
+
+.table-container {
+  white-space: nowrap;
+}
+</style>

--- a/packages/dashboard/src/portal/components/LayoutFilters.vue
+++ b/packages/dashboard/src/portal/components/LayoutFilters.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-combobox
+    :value="value"
+    @input="$emit('input', $event)"
+    :items="items"
+    chips
+    solo
+    multiple
+    label="Please choose some filters."
+    placeholder="Please choose some filters."
+  >
+    <template v-slot:selection="{ attrs, item, select, selected }">
+      <!-- prettier-ignore -->
+      <v-chip
+          v-bind="attrs"
+          :input-value="selected"
+          close
+          @click="select"
+          @click:close="$emit('input', value.filter((x) => x !== item))"
+          color="primary"
+        >
+          {{ item }}
+        </v-chip>
+    </template>
+  </v-combobox>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+
+@Component({
+  name: "LayoutFilters",
+})
+export default class LayoutFilters extends Vue {
+  @Prop({ required: true }) value!: string[];
+  @Prop({ required: true }) items!: string[];
+}
+</script>

--- a/packages/dashboard/src/portal/components/NodeDetails.vue
+++ b/packages/dashboard/src/portal/components/NodeDetails.vue
@@ -28,7 +28,7 @@
                 <v-list-item-content>
                   <v-list-item-title> Disk (HDD) </v-list-item-title>
                 </v-list-item-content>
-                {{ node.resources.hru | toTeraOrGigaOrPeta }}
+                {{ node.resources.hru }}
               </v-list-item>
               <v-divider />
 
@@ -36,7 +36,7 @@
                 <v-list-item-content>
                   <v-list-item-title> Disk (SSD) </v-list-item-title>
                 </v-list-item-content>
-                {{ node.resources.sru | toTeraOrGigaOrPeta }}
+                {{ node.resources.sru }}
               </v-list-item>
               <v-divider />
 
@@ -44,7 +44,7 @@
                 <v-list-item-content>
                   <v-list-item-title> Memory </v-list-item-title>
                 </v-list-item-content>
-                {{ node.resources.mru | toTeraOrGigaOrPeta }}
+                {{ node.resources.mru }}
               </v-list-item>
             </v-list>
           </v-col>

--- a/packages/dashboard/src/portal/components/NodeFilter.vue
+++ b/packages/dashboard/src/portal/components/NodeFilter.vue
@@ -58,7 +58,7 @@ export default class InFilter extends Vue {
   }
 
   remove(index: number): void {
-    this.$store.dispatch("explorer/removeFilterItem", { filterKey: this.filterKey, index });
+    this.$store.dispatch("portal/removeFilterItem", { filterKey: this.filterKey, index });
     // this.$store.dispatch(ActionTypes.REQUEST_NODES);
   }
 

--- a/packages/dashboard/src/portal/components/NodeFilter.vue
+++ b/packages/dashboard/src/portal/components/NodeFilter.vue
@@ -42,11 +42,6 @@ export default class InFilter extends Vue {
     }
   }
 
-  remove(index: number): void {
-    this.$store.dispatch(`portal/removeFilterItem`, { filterKey: this.filterKey, index });
-    this.$store.dispatch(`portal/${ActionTypes.REQUEST_DEDICATED_NODES}`);
-  }
-
   validated(value: string, key: string): string | null {
     if (!value) {
       this.setItem("");
@@ -60,6 +55,10 @@ export default class InFilter extends Vue {
       this.invalid = true;
     }
     return this.errorMsg;
+  }
+
+  destroyed() {
+    this.$store.commit("portal/" + MutationTypes.CLEAR_DEDICATED_NODES_FILTER_KEY, this.filterKey);
   }
 }
 </script>

--- a/packages/dashboard/src/portal/components/NodeFilter.vue
+++ b/packages/dashboard/src/portal/components/NodeFilter.vue
@@ -10,14 +10,13 @@
       type="text"
       :rules="[validated(item, filterKey)]"
     />
-    <!-- <v-alert dense type="error" v-if="errorMsg">
-      {{ errorMsg }}
-    </v-alert> -->
   </v-card>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
+
+import { inputValidation } from "@/explorer/utils/validations";
 
 import { ActionTypes } from "../store/actions";
 import { MutationTypes } from "../store/mutations";
@@ -32,46 +31,31 @@ export default class InFilter extends Vue {
   invalid = false;
   errorMsg: string | null = null;
 
-  created() {
-    console.log("Created...");
-  }
-
-  destroyed() {
-    console.log("Destroyed...");
-  }
-
   setItem(value: string) {
-    console.log("Set item value: ", value);
-
     this.$store.commit("portal/" + MutationTypes.SET_DEDICATED_NODES_FILTER, {
       key: this.filterKey,
       value: [value],
     });
 
-    this.$store.dispatch("portal/" + ActionTypes.REQUEST_DEDICATED_NODES);
-
     if (!this.invalid) {
-      // add the current filter key to the query.
       // load nodes with the changes
-      // this.$store.dispatch(ActionTypes.REQUEST_NODES);
+      // add the current filter key to the query.
+      this.$store.dispatch("portal/" + ActionTypes.REQUEST_DEDICATED_NODES);
     }
   }
 
   remove(index: number): void {
     this.$store.dispatch("portal/removeFilterItem", { filterKey: this.filterKey, index });
-    // this.$store.dispatch(ActionTypes.REQUEST_NODES);
+    this.$store.dispatch("portal/" + ActionTypes.REQUEST_DEDICATED_NODES);
   }
 
   validated(value: string, key: string): string | null {
-    console.log("key: ", key);
-    console.log("value: ", value);
-
     if (!value) {
       // reset filter
       this.setItem("");
       return (this.errorMsg = "");
     }
-    // this.errorMsg = inputValidation(value, key);
+    this.errorMsg = inputValidation(value, key);
     if (!this.errorMsg) {
       this.invalid = false;
       this.setItem(value);

--- a/packages/dashboard/src/portal/components/NodeFilter.vue
+++ b/packages/dashboard/src/portal/components/NodeFilter.vue
@@ -32,26 +32,23 @@ export default class InFilter extends Vue {
   errorMsg: string | null = null;
 
   setItem(value: string) {
-    this.$store.commit("portal/" + MutationTypes.SET_DEDICATED_NODES_FILTER, {
+    this.$store.commit(`portal/${MutationTypes.SET_DEDICATED_NODES_FILTER}`, {
       key: this.filterKey,
-      value: [value],
+      value: value,
     });
 
     if (!this.invalid) {
-      // load nodes with the changes
-      // add the current filter key to the query.
-      this.$store.dispatch("portal/" + ActionTypes.REQUEST_DEDICATED_NODES);
+      this.$store.dispatch(`portal/${ActionTypes.REQUEST_DEDICATED_NODES}`);
     }
   }
 
   remove(index: number): void {
-    this.$store.dispatch("portal/removeFilterItem", { filterKey: this.filterKey, index });
-    this.$store.dispatch("portal/" + ActionTypes.REQUEST_DEDICATED_NODES);
+    this.$store.dispatch(`portal/removeFilterItem`, { filterKey: this.filterKey, index });
+    this.$store.dispatch(`portal/${ActionTypes.REQUEST_DEDICATED_NODES}`);
   }
 
   validated(value: string, key: string): string | null {
     if (!value) {
-      // reset filter
       this.setItem("");
       return (this.errorMsg = "");
     }

--- a/packages/dashboard/src/portal/components/NodeFilter.vue
+++ b/packages/dashboard/src/portal/components/NodeFilter.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-card flat color="transparent">
+    <v-subheader>{{ label.toLocaleUpperCase() }}</v-subheader>
+    <v-text-field
+      v-model="item"
+      chips
+      clearable
+      :label="placeholder"
+      solo
+      type="text"
+      :rules="[validated(item, filterKey)]"
+    />
+    <!-- <v-alert dense type="error" v-if="errorMsg">
+      {{ errorMsg }}
+    </v-alert> -->
+  </v-card>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+
+import { ActionTypes } from "../store/actions";
+import { MutationTypes } from "../store/mutations";
+
+@Component({})
+export default class InFilter extends Vue {
+  @Prop({ required: true }) label!: string;
+  @Prop({ required: true }) placeholder!: string;
+  @Prop({ required: true }) filterKey!: string;
+  @Prop() value?: string[];
+  item = "";
+  invalid = false;
+  errorMsg: string | null = null;
+
+  created() {
+    console.log("Created...");
+  }
+
+  destroyed() {
+    console.log("Destroyed...");
+  }
+
+  setItem(value: string) {
+    console.log("Set item value: ", value);
+
+    this.$store.commit("portal/" + MutationTypes.SET_DEDICATED_NODES_FILTER, {
+      key: this.filterKey,
+      value: [value],
+    });
+
+    this.$store.dispatch("portal/" + ActionTypes.REQUEST_DEDICATED_NODES);
+
+    if (!this.invalid) {
+      // add the current filter key to the query.
+      // load nodes with the changes
+      // this.$store.dispatch(ActionTypes.REQUEST_NODES);
+    }
+  }
+
+  remove(index: number): void {
+    this.$store.dispatch("explorer/removeFilterItem", { filterKey: this.filterKey, index });
+    // this.$store.dispatch(ActionTypes.REQUEST_NODES);
+  }
+
+  validated(value: string, key: string): string | null {
+    console.log("key: ", key);
+    console.log("value: ", value);
+
+    if (!value) {
+      // reset filter
+      this.setItem("");
+      return (this.errorMsg = "");
+    }
+    // this.errorMsg = inputValidation(value, key);
+    if (!this.errorMsg) {
+      this.invalid = false;
+      this.setItem(value);
+    } else {
+      this.invalid = true;
+    }
+    return this.errorMsg;
+  }
+}
+</script>

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -91,6 +91,8 @@ export default class NodesTable extends Vue {
   @Prop({ required: true }) tab!: ITab;
   @Prop({ required: true }) twinId: any;
   @Prop({ required: true }) trigger!: string;
+  @Prop({ required: true }) filterKeys!: string;
+
   $api: any;
   expanded: any = [];
   loading = true;
@@ -122,6 +124,11 @@ export default class NodesTable extends Vue {
 
   @Watch("trigger", { immediate: true }) onTab() {
     this.getNodes();
+  }
+
+  @Watch("filterKeys") async filterRequest(value: string) {
+    console.log(this.filterKeys);
+    console.log("filterKeys | value: ", value);
   }
 
   async mounted() {

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -176,10 +176,10 @@ export default class NodesTable extends Vue {
   // reload the nodes table
   async requestNodes() {
     if (this.$api) {
-      this.$store.commit("portal/" + MutationTypes.SET_API, this.$api);
-      this.$store.commit("portal/" + MutationTypes.SET_TWIN_ID, this.twinId);
-      this.$store.commit("portal/" + MutationTypes.SET_TAB_QUERY, this.tab.query);
-      await this.$store.dispatch(ActionTypes.REQUEST_DEDICATED_NODES);
+      this.$store.commit(`portal/${MutationTypes.SET_API}`, this.$api);
+      this.$store.commit(`portal/${MutationTypes.SET_TWIN_ID}`, this.twinId);
+      this.$store.commit(`portal/${MutationTypes.SET_TAB_QUERY}`, this.tab.query);
+      await this.$store.dispatch(`portal/${ActionTypes.REQUEST_DEDICATED_NODES}`);
     }
   }
 

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -130,10 +130,9 @@ export default class NodesTable extends Vue {
     this.expanded = this.expanded.length ? [] : this.expanded;
   }
 
-  @Watch("filterKeys") async filterRequest(value: string) {
+  @Watch("filterKeys") async filterRequest() {
     this.requestNodes();
-    console.log(this.filterKeys);
-    console.log("filterKeys | value: ", value);
+    this.expanded = this.expanded.length ? [] : this.expanded;
   }
 
   async mounted() {

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -1,78 +1,80 @@
 <template>
   <v-container>
-    <v-data-table
-      :headers="headers"
-      :items="$store.getters['portal/getDedicatedNodes']"
-      :server-items-length="$store.getters['portal/getDedicatedNodesCount']"
-      :single-expand="true"
-      :expanded.sync="expanded"
-      show-expand
-      :disable-sort="true"
-      item-key="nodeId"
-      class="elevation-1"
-      :loading="$store.getters['portal/getTableLoad']"
-      :page.sync="page"
-      loading-text="loading dedicated nodes ..."
-      :items-per-page="pageSize"
-      :footer-props="{
-        'items-per-page-options': [5, 10, 15, 50],
-      }"
-      @update:options="onUpdateOptions($event.page, $event.itemsPerPage)"
-      @item-expanded="getDNodeDetails"
-    >
-      <template v-slot:[`item.mru`]="{ item }">
-        {{ convert(item.mru) }}
-      </template>
-      <template v-slot:[`item.sru`]="{ item }">
-        {{ convert(item.sru) }}
-      </template>
-      <template v-slot:[`item.hru`]="{ item }">
-        {{ convert(item.hru) }}
-      </template>
-      <template v-slot:[`item.actions`]="{ item }">
-        <NodeActionBtn :nodeId="item.nodeId" :status="item.rentStatus" @node-status-changed="onStatusUpdate()" />
-      </template>
-      <template v-slot:[`item.discount`]="{ item }">
-        <v-tooltip bottom color="primary" close-delay="1000">
-          <template v-slot:activator="{ on, attrs }">
-            <span v-bind="attrs" v-on="on">{{ item.discount + (item.extraFee ? item.extraFee / 1000 : 0) }} *</span>
-          </template>
-          <span
-            >Discounts: <br />
-            <ul>
-              <li>
-                You receive {{ item.applyedDiscount.first }}% discount if you reserve an entire
-                <a
-                  target="_blank"
-                  href="https://manual.grid.tf/dashboard/portal/dashboard_portal_dedicated_nodes.html#billing--pricing"
-                  style="color: blue"
-                  >node</a
-                >
-              </li>
-              <li>
-                You're receiving {{ item.applyedDiscount.second }}% discount as per the
-                <a target="_blank" href="https://manual.grid.tf/cloud/cloudunits_pricing.html#discount-levels">
-                  <p style="color: blue; display: inline">discount levels</p>
-                </a>
-              </li>
-            </ul>
-          </span>
-        </v-tooltip>
-      </template>
-      <template v-slot:expanded-item="{ headers, item }">
-        <td :colspan="headers.length" v-if="dNodeLoading" style="text-align: center">
-          <div class="pa-1">
-            <v-progress-circular indeterminate model-value="20" :width="3"></v-progress-circular>
-          </div>
-        </td>
-        <td :colspan="headers.length" v-else-if="dNodeError" style="text-align: center">
-          <strong style="color: #f44336">Failed to retrieve Node details</strong>
-        </td>
-        <td :colspan="headers.length" v-else>
-          <NodeDetails :node="item" />
-        </td>
-      </template>
-    </v-data-table>
+    <v-responsive class="responsive-table">
+      <v-data-table
+        :headers="headers"
+        :items="$store.getters['portal/getDedicatedNodes']"
+        :server-items-length="$store.getters['portal/getDedicatedNodesCount']"
+        :single-expand="true"
+        :expanded.sync="expanded"
+        show-expand
+        :disable-sort="true"
+        item-key="nodeId"
+        class="elevation-1"
+        :loading="$store.getters['portal/getTableLoad']"
+        :page.sync="page"
+        loading-text="loading dedicated nodes ..."
+        :items-per-page="pageSize"
+        :footer-props="{
+          'items-per-page-options': [5, 10, 15, 50],
+        }"
+        @update:options="onUpdateOptions($event.page, $event.itemsPerPage)"
+        @item-expanded="getDNodeDetails"
+      >
+        <template v-slot:[`item.mru`]="{ item }">
+          {{ convert(item.mru) }}
+        </template>
+        <template v-slot:[`item.sru`]="{ item }">
+          {{ convert(item.sru) }}
+        </template>
+        <template v-slot:[`item.hru`]="{ item }">
+          {{ convert(item.hru) }}
+        </template>
+        <template v-slot:[`item.actions`]="{ item }">
+          <NodeActionBtn :nodeId="item.nodeId" :status="item.rentStatus" @node-status-changed="onStatusUpdate()" />
+        </template>
+        <template v-slot:[`item.discount`]="{ item }">
+          <v-tooltip bottom color="primary" close-delay="1000">
+            <template v-slot:activator="{ on, attrs }">
+              <span v-bind="attrs" v-on="on">{{ item.discount + (item.extraFee ? item.extraFee / 1000 : 0) }} *</span>
+            </template>
+            <span
+              >Discounts: <br />
+              <ul>
+                <li>
+                  You receive {{ item.applyedDiscount.first }}% discount if you reserve an entire
+                  <a
+                    target="_blank"
+                    href="https://manual.grid.tf/dashboard/portal/dashboard_portal_dedicated_nodes.html#billing--pricing"
+                    style="color: blue"
+                    >node</a
+                  >
+                </li>
+                <li>
+                  You're receiving {{ item.applyedDiscount.second }}% discount as per the
+                  <a target="_blank" href="https://manual.grid.tf/cloud/cloudunits_pricing.html#discount-levels">
+                    <p style="color: blue; display: inline">discount levels</p>
+                  </a>
+                </li>
+              </ul>
+            </span>
+          </v-tooltip>
+        </template>
+        <template v-slot:expanded-item="{ headers, item }">
+          <td :colspan="headers.length" v-if="dNodeLoading" style="text-align: center">
+            <div class="pa-1">
+              <v-progress-circular indeterminate model-value="20" :width="3"></v-progress-circular>
+            </div>
+          </td>
+          <td :colspan="headers.length" v-else-if="dNodeError" style="text-align: center">
+            <strong style="color: #f44336">Failed to retrieve Node details</strong>
+          </td>
+          <td :colspan="headers.length" v-else>
+            <NodeDetails :node="item" />
+          </td>
+        </template>
+      </v-data-table>
+    </v-responsive>
   </v-container>
 </template>
 
@@ -201,5 +203,9 @@ export default class NodesTable extends Vue {
 <style scoped>
 .v-tooltip__content {
   pointer-events: initial;
+}
+.responsive-table {
+  width: 100%;
+  height: 100%;
 }
 </style>

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -1,6 +1,5 @@
 <template>
   <v-container>
-    key => {{ filterKeys }}
     <v-data-table
       :headers="headers"
       :items="$store.getters['portal/getDedicatedNodes']"
@@ -22,7 +21,6 @@
       @item-expanded="getDNodeDetails"
     >
       <template v-slot:[`item.mru`]="{ item }">
-        item22 => {{ item }}
         {{ convert(item.mru) }}
       </template>
       <template v-slot:[`item.sru`]="{ item }">
@@ -129,6 +127,7 @@ export default class NodesTable extends Vue {
 
   @Watch("trigger", { immediate: true }) onTab() {
     this.requestNodes();
+    this.expanded = this.expanded.length ? [] : this.expanded;
   }
 
   @Watch("filterKeys") async filterRequest(value: string) {
@@ -151,8 +150,6 @@ export default class NodesTable extends Vue {
 
   async getDNodeDetails(event: any) {
     // value is whether or not the row is expanded now.
-    console.log("event: ", event);
-
     if (!event.value) return;
     try {
       this.dNodeError = false;
@@ -179,7 +176,7 @@ export default class NodesTable extends Vue {
   // reload the nodes table
   async requestNodes() {
     if (this.$api) {
-      // this.$store.commit('portal/' + MutationTypes.SET_API, this.$api);
+      this.$store.commit("portal/" + MutationTypes.SET_API, this.$api);
       this.$store.commit("portal/" + MutationTypes.SET_TWIN_ID, this.twinId);
       this.$store.commit("portal/" + MutationTypes.SET_TAB_QUERY, this.tab.query);
       await this.$store.dispatch(ActionTypes.REQUEST_DEDICATED_NODES);

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -98,13 +98,10 @@ export default class NodesTable extends Vue {
 
   $api: any;
   expanded: any = [];
-  loading = true;
   dNodeLoading = true;
   dNodeError = false;
   address = "";
 
-  nodes: any[] = [];
-  count = 0;
   pageNumber = 1;
   pageSize = 10;
 
@@ -165,7 +162,6 @@ export default class NodesTable extends Vue {
   }
 
   async onStatusUpdate() {
-    this.loading = true;
     this.$toasted.show(`Table may take some time to update the changes.`);
     setTimeout(async () => {
       this.requestNodes();

--- a/packages/dashboard/src/portal/store/actions.ts
+++ b/packages/dashboard/src/portal/store/actions.ts
@@ -33,7 +33,7 @@ export default {
 
     for (const key in state.dedicatedNodesFilter) {
       let value = state.dedicatedNodesFilter[key];
-      if (key == "free_hru" || key == "free_mru" || key == "free_sru" || key == "free_cru") {
+      if (key == "total_hru" || key == "total_mru" || key == "total_sru" || key == "total_cru") {
         value *= 1024 * 1024 * 1024; // convert from gb to b
       }
       // don't break the call for the null values

--- a/packages/dashboard/src/portal/store/actions.ts
+++ b/packages/dashboard/src/portal/store/actions.ts
@@ -1,9 +1,13 @@
 import { web3AccountsSubscribe, web3Enable } from "@polkadot/extension-dapp";
 import type { ActionContext } from "vuex";
 
-import { getProposal, getProposals } from "../lib/dao";
+import { getProposals } from "../lib/dao";
 import { getFarm } from "../lib/farms";
 import { PortalState } from "./state";
+
+export enum ActionTypes {
+  REQUEST_DEDICATED_NODES = "requestDedicatedNodes",
+}
 
 export default {
   async subscribeAccounts({ commit }: ActionContext<PortalState, PortalState>) {
@@ -12,6 +16,25 @@ export default {
       commit("setAccounts", { accounts: injectedAccounts });
     });
   },
+
+  async requestDedicatedNodes({ state, commit }: ActionContext<PortalState, PortalState>) {
+    let url = `${window.configs.APP_GRIDPROXY_URL}/nodes?ret_count=true&rentable=true`;
+
+    for (const key in state.dedicatedNodesFilter) {
+      let value = state.dedicatedNodesFilter[key];
+
+      if (key == "free_hru" || key == "free_mru" || key == "free_sru" || key == "free_cru") {
+        value *= 1024 * 1024 * 1024; // convert from gb to b
+      }
+
+      // don't break the call for the null values
+      if (value == null || value == undefined) value = "";
+
+      url += `&${key}=${value}`;
+    }
+    // console.log('url => ', url);
+  },
+
   async unsubscribeAccounts({ commit }: ActionContext<PortalState, PortalState>) {
     const unsubscribe = await web3AccountsSubscribe(() => {
       console.log(`unsubscribing`);

--- a/packages/dashboard/src/portal/store/actions.ts
+++ b/packages/dashboard/src/portal/store/actions.ts
@@ -19,6 +19,8 @@ export default {
 
   async requestDedicatedNodes({ state, commit }: ActionContext<PortalState, PortalState>) {
     let url = `${window.configs.APP_GRIDPROXY_URL}/nodes?ret_count=true&rentable=true`;
+    url += `&size=${state.dedicatedNodesTablePageSize}`;
+    url += `&page=${state.dedicatedNodesTablePageNumber}`;
 
     for (const key in state.dedicatedNodesFilter) {
       let value = state.dedicatedNodesFilter[key];

--- a/packages/dashboard/src/portal/store/actions.ts
+++ b/packages/dashboard/src/portal/store/actions.ts
@@ -3,6 +3,8 @@ import type { ActionContext } from "vuex";
 
 import { getProposals } from "../lib/dao";
 import { getFarm } from "../lib/farms";
+import { updateDedicatedNodes } from "../lib/nodes";
+import { MutationTypes } from "./mutations";
 import { PortalState } from "./state";
 
 export enum ActionTypes {
@@ -18,23 +20,33 @@ export default {
   },
 
   async requestDedicatedNodes({ state, commit }: ActionContext<PortalState, PortalState>) {
-    let url = `${window.configs.APP_GRIDPROXY_URL}/nodes?ret_count=true&rentable=true`;
+    commit(MutationTypes.SET_TABLE_LOAD, true);
+
+    let url = `${window.configs.APP_GRIDPROXY_URL}/nodes?status=up&ret_count=true&rentable=true`;
     url += `&size=${state.dedicatedNodesTablePageSize}`;
     url += `&page=${state.dedicatedNodesTablePageNumber}`;
 
     for (const key in state.dedicatedNodesFilter) {
       let value = state.dedicatedNodesFilter[key];
-
       if (key == "free_hru" || key == "free_mru" || key == "free_sru" || key == "free_cru") {
         value *= 1024 * 1024 * 1024; // convert from gb to b
       }
-
       // don't break the call for the null values
-      if (value == null || value == undefined) value = "";
-
+      if (value == null || value == undefined || value == 0) value = "";
       url += `&${key}=${value}`;
     }
-    // console.log('url => ', url);
+
+    const res = await fetch(url);
+
+    const nodesCount: any = res.headers.get("count");
+    commit(MutationTypes.SET_DEDICATED_NODES_COUNT, +nodesCount);
+
+    let nodes = await res.json();
+    // Update the nodes with price and discount.
+    nodes = await updateDedicatedNodes(state.api, state.address, nodes);
+
+    commit(MutationTypes.SET_DEDICATED_NODES, { nodes });
+    commit(MutationTypes.SET_TABLE_LOAD, false);
   },
 
   async unsubscribeAccounts({ commit }: ActionContext<PortalState, PortalState>) {
@@ -45,40 +57,44 @@ export default {
     commit("removeAccounts");
   },
   async getProposal({ commit, state }: ActionContext<PortalState, PortalState>, twin: number) {
-    const active = (await getProposals(state.api)).active;
-    if (!active.length) return;
-    const farms = await getFarm(state.api, parseFloat(`${twin}`));
+    if (state.api) {
+      console.log(state.api, "ahooooooooooooooooooooooooooooooooooo");
 
-    // only users who own a farm should get the notification
-    if (!farms.length) {
-      commit("setProposals", { proposals: 0 });
-      return;
+      const active = (await getProposals(state.api)).active;
+      if (!active.length) return;
+      const farms = await getFarm(state.api, parseFloat(`${twin}`));
+
+      // only users who own a farm should get the notification
+      if (!farms.length) {
+        commit("setProposals", { proposals: 0 });
+        return;
+      }
+      const farmIds = farms.map(function (value) {
+        return value.id;
+      });
+
+      const voted: number[] = [];
+      active.forEach((proposal, index) => {
+        let inYes = false;
+        proposal.ayes.forEach(({ farmId }) => {
+          if (farmIds.includes(farmId)) {
+            inYes = true;
+            voted.push(index);
+            return;
+          }
+        });
+        if (inYes) return;
+        proposal.nayes.forEach(({ farmId }) => {
+          if (farmIds.includes(farmId)) {
+            voted.push(index);
+            return;
+          }
+        });
+      });
+      voted.forEach(index => {
+        active.splice(index, 1);
+      });
+      commit("setProposals", { proposals: active.length });
     }
-    const farmIds = farms.map(function (value) {
-      return value.id;
-    });
-
-    const voted: number[] = [];
-    active.forEach((proposal, index) => {
-      let inYes = false;
-      proposal.ayes.forEach(({ farmId }) => {
-        if (farmIds.includes(farmId)) {
-          inYes = true;
-          voted.push(index);
-          return;
-        }
-      });
-      if (inYes) return;
-      proposal.nayes.forEach(({ farmId }) => {
-        if (farmIds.includes(farmId)) {
-          voted.push(index);
-          return;
-        }
-      });
-    });
-    voted.forEach(index => {
-      active.splice(index, 1);
-    });
-    commit("setProposals", { proposals: active.length });
   },
 };

--- a/packages/dashboard/src/portal/store/getters.ts
+++ b/packages/dashboard/src/portal/store/getters.ts
@@ -2,8 +2,16 @@ import { GetterTree } from "vuex";
 
 import { PortalState } from "./state";
 export default {
+  getDedicatedNodes: state => {
+    return state.dedicatedNodes;
+  },
+  getDedicatedNodesCount: state => {
+    return state.dedicatedNodesCount;
+  },
   accounts: (state: PortalState) => state.accounts,
   proposals: (state: PortalState) => state.proposals,
   getDedicatedNodesTablePageNumber: state => state.dedicatedNodesTablePageNumber,
   getDedicatedNodesTablePageSize: state => state.dedicatedNodesTablePageSize,
+  getTableLoad: state => state.tableLoad,
+  getAPI: state => state.api,
 } as GetterTree<PortalState, PortalState>;

--- a/packages/dashboard/src/portal/store/getters.ts
+++ b/packages/dashboard/src/portal/store/getters.ts
@@ -14,4 +14,5 @@ export default {
   getDedicatedNodesTablePageSize: state => state.dedicatedNodesTablePageSize,
   getTableLoad: state => state.tableLoad,
   getAPI: state => state.api,
+  getTwinID: state => state.twinID,
 } as GetterTree<PortalState, PortalState>;

--- a/packages/dashboard/src/portal/store/getters.ts
+++ b/packages/dashboard/src/portal/store/getters.ts
@@ -4,4 +4,6 @@ import { PortalState } from "./state";
 export default {
   accounts: (state: PortalState) => state.accounts,
   proposals: (state: PortalState) => state.proposals,
+  getDedicatedNodesTablePageNumber: state => state.dedicatedNodesTablePageNumber,
+  getDedicatedNodesTablePageSize: state => state.dedicatedNodesTablePageSize,
 } as GetterTree<PortalState, PortalState>;

--- a/packages/dashboard/src/portal/store/index.ts
+++ b/packages/dashboard/src/portal/store/index.ts
@@ -11,4 +11,4 @@ export const portalStore = {
   mutations,
   actions,
   getters,
-} as ModuleTree<PortalState>;
+} as unknown as ModuleTree<PortalState>;

--- a/packages/dashboard/src/portal/store/mutations.ts
+++ b/packages/dashboard/src/portal/store/mutations.ts
@@ -38,7 +38,6 @@ export default {
 
   setNodesFilter(state: PortalState, payload: { key: string; value: any }) {
     state.dedicatedNodesFilter[payload.key] = payload.value;
-    console.log(payload.key, state.dedicatedNodesFilter[payload.key]);
   },
 
   setDedicatedNodesTablePageNumber(state: PortalState, payload: number) {
@@ -60,16 +59,10 @@ export default {
     state.address = address;
   },
 
-  setNodes(state: PortalState, payload: any): void {
+  setNodes(state: PortalState, nodes: any[]): void {
     // clear the state each time you reload. to avoid duplicated nodes
     state.dedicatedNodes = [];
-
-    console.log("payload.nodes: , ", payload.nodes);
-
-    state.dedicatedNodes = payload.nodes;
-    // for (let i = 0; i < payload.nodes.length; i++) {
-    //   state.dedicatedNodes.push(fillNodesFields(state as unknown as IState, payload.nodes[i], [payload.farms]));
-    // }
+    state.dedicatedNodes = nodes;
   },
 
   setDedicatedNodesCount(state: PortalState, payload: number) {

--- a/packages/dashboard/src/portal/store/mutations.ts
+++ b/packages/dashboard/src/portal/store/mutations.ts
@@ -15,6 +15,9 @@ export enum MutationTypes {
   SET_DEDICATED_NODES = "setDedicatedNodes",
   SET_DEDICATED_NODES_COUNT = "setDedicatedNodesCount",
   SET_ADDRESS = "setAddress",
+
+  CLEAR_DEDICATED_NODES_FILTER = "clearDedicatedNodesFilter",
+  CLEAR_DEDICATED_NODES_FILTER_KEY = "clearDedicatedNodesFilterKey",
 }
 
 export default {
@@ -68,5 +71,13 @@ export default {
 
   setDedicatedNodesCount(state: PortalState, payload: number) {
     state.dedicatedNodesCount = payload;
+  },
+
+  clearDedicatedNodesFilter(state: PortalState) {
+    state.dedicatedNodesFilter = {};
+  },
+
+  clearDedicatedNodesFilterKey(state: PortalState, key: string) {
+    state.dedicatedNodesFilter[key] = "";
   },
 };

--- a/packages/dashboard/src/portal/store/mutations.ts
+++ b/packages/dashboard/src/portal/store/mutations.ts
@@ -1,5 +1,9 @@
 import { ApiPromise } from "@polkadot/api";
 
+import { fillNodesFields } from "@/explorer/store/mutations";
+import { IState } from "@/explorer/store/state";
+
+import { apiInterface } from "../lib/util";
 import { accountInterface, PortalState } from "./state";
 
 export enum MutationTypes {
@@ -7,6 +11,12 @@ export enum MutationTypes {
   SET_DEDICATED_NODES_FILTER = "setNodesFilter",
   SET_DEDICATED_NODES_TABLE_PAGE_NUMBER = "setDedicatedNodesTablePageNumber",
   SET_DEDICATED_NODES_TABLE_PAGE_SIZE = "setDedicatedNodesTablePageSize",
+  SET_TWIN_ID = "setTwinID",
+  SET_TAB_QUERY = "setTabQuery",
+  SET_TABLE_LOAD = "setTableLoad",
+  SET_DEDICATED_NODES_COUNT = "setDedicatedNodesCount",
+  SET_API = "setApi",
+  SET_ADDRESS = "setAddress",
 }
 
 export enum PortalMutationTypes {
@@ -22,8 +32,8 @@ export default {
   setProposals(state: PortalState, payload: { proposals: number }) {
     state.proposals = payload.proposals;
   },
-  setApi(state: PortalState, payload: { api: ApiPromise }) {
-    state.api = payload.api;
+  setApi(state: PortalState, api: apiInterface) {
+    state.api = api;
   },
 
   setNodesFilter(state: PortalState, payload: { key: string; value: any }) {
@@ -36,5 +46,33 @@ export default {
   },
   setDedicatedNodesTablePageSize(state: PortalState, payload: number) {
     state.dedicatedNodesTablePageSize = payload;
+  },
+  setTwinID(state: PortalState, payload: number) {
+    state.twinID = payload;
+  },
+  setTabQuery(state: PortalState, payload: string) {
+    state.tabQuery = payload;
+  },
+  setTableLoad(state: PortalState, payload: boolean) {
+    state.tableLoad = payload;
+  },
+  setAddress(state: PortalState, address: string) {
+    state.address = address;
+  },
+
+  setNodes(state: PortalState, payload: any): void {
+    // clear the state each time you reload. to avoid duplicated nodes
+    state.dedicatedNodes = [];
+
+    console.log("payload.nodes: , ", payload.nodes);
+
+    state.dedicatedNodes = payload.nodes;
+    // for (let i = 0; i < payload.nodes.length; i++) {
+    //   state.dedicatedNodes.push(fillNodesFields(state as unknown as IState, payload.nodes[i], [payload.farms]));
+    // }
+  },
+
+  setDedicatedNodesCount(state: PortalState, payload: number) {
+    state.dedicatedNodesCount = payload;
   },
 };

--- a/packages/dashboard/src/portal/store/mutations.ts
+++ b/packages/dashboard/src/portal/store/mutations.ts
@@ -1,12 +1,17 @@
 import { ApiPromise } from "@polkadot/api";
 
-import { PortalState } from "./state";
+import { accountInterface, PortalState } from "./state";
+
+export enum MutationTypes {
+  SET_DEDICATED_NODES = "setNodes",
+  SET_DEDICATED_NODES_FILTER = "setNodesFilter",
+}
 
 export enum PortalMutationTypes {
   SET_ACCOUNTS = "setAccounts",
 }
 export default {
-  setAccounts(state: PortalState, payload: { accounts: [] }) {
+  setAccounts(state: PortalState, payload: { accounts: accountInterface[] }) {
     state.accounts = payload.accounts;
   },
   removeAccounts(state: PortalState) {
@@ -17,5 +22,10 @@ export default {
   },
   setApi(state: PortalState, payload: { api: ApiPromise }) {
     state.api = payload.api;
+  },
+
+  setNodesFilter(state: PortalState, payload: { key: string; value: any }) {
+    state.dedicatedNodesFilter[payload.key] = payload.value;
+    console.log(payload.key, state.dedicatedNodesFilter[payload.key]);
   },
 };

--- a/packages/dashboard/src/portal/store/mutations.ts
+++ b/packages/dashboard/src/portal/store/mutations.ts
@@ -5,6 +5,8 @@ import { accountInterface, PortalState } from "./state";
 export enum MutationTypes {
   SET_DEDICATED_NODES = "setNodes",
   SET_DEDICATED_NODES_FILTER = "setNodesFilter",
+  SET_DEDICATED_NODES_TABLE_PAGE_NUMBER = "setDedicatedNodesTablePageNumber",
+  SET_DEDICATED_NODES_TABLE_PAGE_SIZE = "setDedicatedNodesTablePageSize",
 }
 
 export enum PortalMutationTypes {
@@ -27,5 +29,12 @@ export default {
   setNodesFilter(state: PortalState, payload: { key: string; value: any }) {
     state.dedicatedNodesFilter[payload.key] = payload.value;
     console.log(payload.key, state.dedicatedNodesFilter[payload.key]);
+  },
+
+  setDedicatedNodesTablePageNumber(state: PortalState, payload: number) {
+    state.dedicatedNodesTablePageNumber = payload;
+  },
+  setDedicatedNodesTablePageSize(state: PortalState, payload: number) {
+    state.dedicatedNodesTablePageSize = payload;
   },
 };

--- a/packages/dashboard/src/portal/store/mutations.ts
+++ b/packages/dashboard/src/portal/store/mutations.ts
@@ -1,67 +1,68 @@
-import { ApiPromise } from "@polkadot/api";
-
-import { fillNodesFields } from "@/explorer/store/mutations";
-import { IState } from "@/explorer/store/state";
-
 import { apiInterface } from "../lib/util";
 import { accountInterface, PortalState } from "./state";
 
 export enum MutationTypes {
-  SET_DEDICATED_NODES = "setNodes",
-  SET_DEDICATED_NODES_FILTER = "setNodesFilter",
+  SET_ACCOUNTS = "setAccounts",
+  REMOVE_ACCOUNTS = "removeAccounts",
+  SET_PROPOSALS = "setProposals",
+  SET_API = "setApi",
+  SET_DEDICATED_NODES_FILTER = "setDedicatedNodesFilter",
   SET_DEDICATED_NODES_TABLE_PAGE_NUMBER = "setDedicatedNodesTablePageNumber",
   SET_DEDICATED_NODES_TABLE_PAGE_SIZE = "setDedicatedNodesTablePageSize",
   SET_TWIN_ID = "setTwinID",
   SET_TAB_QUERY = "setTabQuery",
   SET_TABLE_LOAD = "setTableLoad",
+  SET_DEDICATED_NODES = "setDedicatedNodes",
   SET_DEDICATED_NODES_COUNT = "setDedicatedNodesCount",
-  SET_API = "setApi",
   SET_ADDRESS = "setAddress",
 }
 
-export enum PortalMutationTypes {
-  SET_ACCOUNTS = "setAccounts",
-}
 export default {
   setAccounts(state: PortalState, payload: { accounts: accountInterface[] }) {
     state.accounts = payload.accounts;
   },
+
   removeAccounts(state: PortalState) {
     state.accounts = [];
   },
+
   setProposals(state: PortalState, payload: { proposals: number }) {
     state.proposals = payload.proposals;
   },
+
   setApi(state: PortalState, api: apiInterface) {
     state.api = api;
   },
 
-  setNodesFilter(state: PortalState, payload: { key: string; value: any }) {
+  setDedicatedNodesFilter(state: PortalState, payload: { key: string; value: any }) {
     state.dedicatedNodesFilter[payload.key] = payload.value;
   },
 
   setDedicatedNodesTablePageNumber(state: PortalState, payload: number) {
     state.dedicatedNodesTablePageNumber = payload;
   },
+
   setDedicatedNodesTablePageSize(state: PortalState, payload: number) {
     state.dedicatedNodesTablePageSize = payload;
   },
+
   setTwinID(state: PortalState, payload: number) {
     state.twinID = payload;
   },
+
   setTabQuery(state: PortalState, payload: string) {
     state.tabQuery = payload;
   },
+
   setTableLoad(state: PortalState, payload: boolean) {
     state.tableLoad = payload;
   },
+
   setAddress(state: PortalState, address: string) {
     state.address = address;
   },
 
-  setNodes(state: PortalState, nodes: any[]): void {
-    // clear the state each time you reload. to avoid duplicated nodes
-    state.dedicatedNodes = [];
+  setDedicatedNodes(state: PortalState, nodes: any[]): void {
     state.dedicatedNodes = nodes;
   },
 

--- a/packages/dashboard/src/portal/store/state.ts
+++ b/packages/dashboard/src/portal/store/state.ts
@@ -1,4 +1,7 @@
-import { ApiPromise } from "@polkadot/api";
+import { INode } from "@/explorer/graphql/api";
+
+import { apiInterface } from "../lib/util";
+
 export interface accountInterface {
   address: string;
   meta: { genesisHash: string; name: string; source: string };
@@ -8,17 +11,29 @@ export interface accountInterface {
 
 export interface PortalState {
   accounts: accountInterface[];
+  dedicatedNodes: INode[];
   proposals: number;
-  api: ApiPromise;
+  api: apiInterface;
+  address: string;
+  tabQuery: string;
+  tableLoad: boolean;
+  twinID: number;
   dedicatedNodesFilter: any;
   dedicatedNodesTablePageSize: number;
   dedicatedNodesTablePageNumber: number;
+  dedicatedNodesCount: number;
 }
 export default {
   accounts: [],
+  dedicatedNodes: [],
   proposals: 0,
   api: undefined,
+  address: "",
+  tabQuery: "",
+  tableLoad: false,
+  twinID: 0,
   dedicatedNodesFilter: {},
-  nodesTablePageSize: 10,
-  nodesTablePageNumber: 1,
+  dedicatedNodesTablePageSize: 10,
+  dedicatedNodesTablePageNumber: 1,
+  dedicatedNodesCount: 0,
 };

--- a/packages/dashboard/src/portal/store/state.ts
+++ b/packages/dashboard/src/portal/store/state.ts
@@ -10,9 +10,11 @@ export interface PortalState {
   accounts: accountInterface[];
   proposals: number;
   api: ApiPromise;
+  dedicatedNodesFilter: any;
 }
 export default {
   accounts: [],
   proposals: 0,
   api: undefined,
+  dedicatedNodesFilter: {},
 };

--- a/packages/dashboard/src/portal/store/state.ts
+++ b/packages/dashboard/src/portal/store/state.ts
@@ -11,10 +11,14 @@ export interface PortalState {
   proposals: number;
   api: ApiPromise;
   dedicatedNodesFilter: any;
+  dedicatedNodesTablePageSize: number;
+  dedicatedNodesTablePageNumber: number;
 }
 export default {
   accounts: [],
   proposals: 0,
   api: undefined,
   dedicatedNodesFilter: {},
+  nodesTablePageSize: 10,
+  nodesTablePageNumber: 1,
 };

--- a/packages/dashboard/src/portal/views/Nodes.vue
+++ b/packages/dashboard/src/portal/views/Nodes.vue
@@ -97,19 +97,9 @@ export default class NodesView extends Vue {
       placeholder: "Filter by GPU's vendor name.",
     },
     {
-      label: "GPU's vendor id",
-      key: "gpu_vendor_id",
-      placeholder: "Filter by GPU's vendor id.",
-    },
-    {
       label: "GPU's device name",
       key: "gpu_device_name",
       placeholder: "Filter by GPU's device name.",
-    },
-    {
-      label: "GPU's device id",
-      key: "gpu_device_id",
-      placeholder: "Filter by GPU's device id.",
     },
   ];
 

--- a/packages/dashboard/src/portal/views/Nodes.vue
+++ b/packages/dashboard/src/portal/views/Nodes.vue
@@ -63,7 +63,7 @@ export default class NodesView extends Vue {
     },
   ];
 
-  activeFiltersList: string[] = ["Free SRU (GB)"];
+  activeFiltersList: string[] = ["Total SRU (GB)"];
 
   get activeFilters() {
     const keySet = new Set(this.activeFiltersList);
@@ -72,24 +72,24 @@ export default class NodesView extends Vue {
 
   filters = [
     {
-      label: "Free SRU (GB)",
-      key: "free_sru",
-      placeholder: "Filter by Free SSD greater than or equal to.",
+      label: "Total SRU (GB)",
+      key: "total_sru",
+      placeholder: "Filter by total SSD greater than or equal to.",
     },
     {
-      label: "Free HRU (GB)",
-      key: "free_hru",
-      placeholder: "Filter by Free HDD greater than or equal to.",
+      label: "Total HRU (GB)",
+      key: "total_hru",
+      placeholder: "Filter by total HDD greater than or equal to.",
     },
     {
-      label: "Free MRU (GB)",
-      key: "free_mru",
-      placeholder: "Filter by Free Memory greater than or equal to.",
+      label: "Total MRU (GB)",
+      key: "total_mru",
+      placeholder: "Filter by total Memory greater than or equal to.",
     },
     {
-      label: "Free CRU (Cores)",
-      key: "free_cru",
-      placeholder: "Filter by Free Cores greater than or equal to.",
+      label: "Total CRU (Cores)",
+      key: "total_cru",
+      placeholder: "Filter by total Cores greater than or equal to.",
     },
     {
       label: "GPU's vendor name",

--- a/packages/dashboard/src/portal/views/Nodes.vue
+++ b/packages/dashboard/src/portal/views/Nodes.vue
@@ -1,29 +1,45 @@
 <template>
-  <v-container>
-    <v-card>
-      <v-tabs v-model="activeTab" background-color="deep-blue accent-4" centered dark @change="onTabChange()">
-        <v-tab v-for="tab in tabs" :key="tab.index" :value="tab.query" :href="'#' + tab.query">
-          {{ tab.label }}
-        </v-tab>
-      </v-tabs>
-      <NodesTable
-        :tab="tabs.find(tab => tab.query === activeTab)"
-        :twinId="$store.state.credentials.twin.id"
-        :trigger="trigger"
-      />
-    </v-card>
-  </v-container>
+  <Layout>
+    <template v-slot:filters>
+      <LayoutFilters :items="filters.map(f => f.label)" v-model="activeFiltersList" />
+    </template>
+
+    <template v-slot:active-filters>
+      <div v-for="filter in activeFilters" :key="filter.key">
+        <NodeFilter :filterKey="filter.key" :label="filter.label" :items="[]" :placeholder="filter.placeholder" />
+      </div>
+    </template>
+
+    <template v-slot:node-table>
+      <v-card>
+        <v-tabs v-model="activeTab" background-color="deep-blue accent-4" centered dark @change="onTabChange()">
+          <v-tab v-for="tab in tabs" :key="tab.index" :value="tab.query" :href="'#' + tab.query">
+            {{ tab.label }}
+          </v-tab>
+        </v-tabs>
+        <NodesTable
+          :tab="tabs.find(tab => tab.query === activeTab)"
+          :twinId="$store.state.credentials.twin.id"
+          :trigger="trigger"
+          :filterKeys="activeFilters"
+        />
+      </v-card>
+    </template>
+  </Layout>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 
+import Layout from "../components/Layout.vue";
+import LayoutFilters from "../components/LayoutFilters.vue";
+import NodeFilter from "../components/NodeFilter.vue";
 import NodesTable from "../components/NodesTable.vue";
 import { ITab } from "../lib/nodes";
 
 @Component({
   name: "NodesView",
-  components: { NodesTable },
+  components: { NodesTable, LayoutFilters, Layout, NodeFilter },
 })
 export default class NodesView extends Vue {
   tabs: ITab[] = [
@@ -46,6 +62,47 @@ export default class NodesView extends Vue {
       index: 3,
     },
   ];
+
+  activeFiltersList: string[] = ["Free SRU (GB)"];
+
+  get activeFilters() {
+    const keySet = new Set(this.activeFiltersList);
+    return this.filters.filter(filter => keySet.has(filter.label));
+  }
+
+  filters = [
+    {
+      label: "Free SRU (GB)",
+      key: "free_sru",
+      placeholder: "Filter by Free SSD greater than or equal to.",
+    },
+    {
+      label: "Free HRU (GB)",
+      key: "free_hru",
+      placeholder: "Filter by Free HDD greater than or equal to.",
+    },
+    {
+      label: "Free MRU (GB)",
+      key: "free_mru",
+      placeholder: "Filter by Free Memory greater than or equal to.",
+    },
+    {
+      label: "Free CRU (Cores)",
+      key: "free_cru",
+      placeholder: "Filter by Free Cores greater than or equal to.",
+    },
+    {
+      label: "GPU's vendor",
+      key: "gpu_vendor",
+      placeholder: "Filter by GPU's vendor.",
+    },
+    {
+      label: "GPU's device",
+      key: "gpu_device",
+      placeholder: "Filter by GPU's device.",
+    },
+  ];
+
   $api = "";
   activeTab = this.tabs[0].query;
   trigger = "";

--- a/packages/dashboard/src/portal/views/Nodes.vue
+++ b/packages/dashboard/src/portal/views/Nodes.vue
@@ -92,14 +92,24 @@ export default class NodesView extends Vue {
       placeholder: "Filter by Free Cores greater than or equal to.",
     },
     {
-      label: "GPU's vendor",
-      key: "gpu_vendor",
-      placeholder: "Filter by GPU's vendor.",
+      label: "GPU's vendor name",
+      key: "gpu_vendor_name",
+      placeholder: "Filter by GPU's vendor name.",
     },
     {
-      label: "GPU's device",
-      key: "gpu_device",
-      placeholder: "Filter by GPU's device.",
+      label: "GPU's vendor id",
+      key: "gpu_vendor_id",
+      placeholder: "Filter by GPU's vendor id.",
+    },
+    {
+      label: "GPU's device name",
+      key: "gpu_device_name",
+      placeholder: "Filter by GPU's device name.",
+    },
+    {
+      label: "GPU's device id",
+      key: "gpu_device_id",
+      placeholder: "Filter by GPU's device id.",
     },
   ];
 


### PR DESCRIPTION
### Description

Created a new layout component for the new dedicated nodes view, added action/mutation type, and added a watcher on the search input value change to request the grid proxy with the new value.

### Changes

- Created mutation and used It instead of hard-coded
- add `dedicatedNodes`, `dedicatedNodesFilter`, `dedicatedNodesTablePageSize`, `dedicatedNodesTablePageNumber` and `dedicatedNodesCount` fields inside the PortalState point to the dedicated nodes view.
- Created a layout for the dedicated nodes page
- Support filter nodes inside the dedicated nodes view

### Supported keys
- CPU <GB>
- memory <GB>
- SSD disk <GB>
- HDD disk <GB>
- GPU's vendor name
- GPU's vendor id
- GPU's device name
- GPU's device id

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/721

### Screens
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/b3858bff-e4a4-4540-963d-78e65421274b)

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/1e2ea729-8bce-4eee-97d9-70c738e8d62d)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
