### PR TITLE
The twin loading color in the light mode doesn't show the text because of the white color.

### DIFF
--- a/packages/dashboard/src/portal/views/Account.vue
+++ b/packages/dashboard/src/portal/views/Account.vue
@@ -29,8 +29,8 @@
   </v-container>
   <v-container v-else-if="$store.state.credentials.loading">
     <div class="d-flex justify-center" style="display: block; padding: 10%">
-      <v-progress-circular indeterminate color="blue" :size="335" :width="7">
-        <span style="font-size: large; color: white">Loading Twin Details</span>
+      <v-progress-circular indeterminate :size="335" :width="7">
+        <span style="font-size: large">Loading Twin Details</span>
       </v-progress-circular>
     </div>
   </v-container>


### PR DESCRIPTION
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/748

### Screenshots 

- [Screencast from 03-07-23 17:12:24.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/30e94bd1-ed52-4996-8e06-cf60f9d6f226)


