### PR TITLE
invalidate vms and gw keys before deploy

### DIFF
--- a/packages/playground/src/utils/deploy_vm.ts
+++ b/packages/playground/src/utils/deploy_vm.ts
@@ -21,6 +21,7 @@ export async function deployVM(grid: GridClient, options: DeployVMOptions) {
   const nodePicker = new NodePicker();
   const vms = new MachinesModel();
   vms.name = options.name;
+  await grid.machines.getObj(vms.name); //invalidating the cashed keys
   vms.network = createNetwork(options.network);
   vms.machines = await Promise.all(options.machines.map(machine => createMachine(grid, machine, nodePicker)));
   vms.metadata = options.metadata;

--- a/packages/playground/src/utils/gateway.ts
+++ b/packages/playground/src/utils/gateway.ts
@@ -39,6 +39,7 @@ export interface DeployGatewayNameOptions {
 export async function deployGatewayName(grid: GridClient, options: DeployGatewayNameOptions) {
   const gateway = new GatewayNameModel();
   gateway.name = options.name;
+  await grid.gateway.getObj(gateway.name); //invalidating the cashed keys
   gateway.node_id = options.nodeId;
   gateway.tls_passthrough = options.tlsPassthrough || false;
   gateway.backends = options.backends.map(({ ip, port }) => `http://${ip}:${port}`);


### PR DESCRIPTION
### Description

"When the contract is deleted, there will be a key left and the playground should invalidate that key by trying to get a deployment with its name (this will delete any keys left). But the playground seems doesn't invalidate the solution before starting the new deployment."
[comment](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/695#issuecomment-1600907246)

Not sure if we should do so with k8s and clusters, will open a new issue for it whenever I got a confirmation on the [comment](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/695#issuecomment-1619992726)
### Changes

use getObj For invalidating the cashed keys in the KV store, getObj checks if the key has no deployments. it is deleted.

### Related Issues

- #695 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
