### PR TITLE
Update the sdk version for grid nightly workflow to use 2.0.0 in case the network is qa, test, or main

### DIFF
--- a/.github/workflows/grid_client_nightly.yml
+++ b/.github/workflows/grid_client_nightly.yml
@@ -27,15 +27,15 @@ jobs:
       - uses: actions/checkout@v2
         if: ${{ env.NETWORK == 'qa' }}
         with:
-          ref: refs/tags/v0.0.1
+          ref: refs/tags/v2.0.0
       - uses: actions/checkout@v2
         if: ${{ env.NETWORK == 'test' }}
         with:
-          ref: refs/tags/v0.0.1
+          ref: refs/tags/v2.0.0
       - uses: actions/checkout@v2
         if: ${{ env.NETWORK == 'main' }}
         with:
-          ref: refs/tags/v0.0.1
+          ref: refs/tags/v2.0.0
       - name: Set up node 18
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
### Description

Update the sdk version for grid nightly workflow to use 2.0.0 in case the network is qa, test, or main

### Related Issues

- #669
### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
