### PR TITLE
Grid_client: fix rollback

### DIFF
--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -13,7 +13,6 @@ class TwinDeploymentHandler {
   rmb: RMB;
   deploymentFactory: DeploymentFactory;
   original_deployments = [];
-  addedNameContracts = [];
   nodes: Nodes;
 
   constructor(public config: GridClientConfig) {
@@ -32,9 +31,7 @@ class TwinDeploymentHandler {
       }
     }
     try {
-      const contract = await this.tfclient.contracts.createName({ name });
-      this.addedNameContracts.push(name);
-      return contract;
+      return await this.tfclient.contracts.createName({ name });
     } catch (e) {
       throw Error(`Failed to create name contract ${name} due to ${e}`);
     }

--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -325,11 +325,6 @@ class TwinDeploymentHandler {
     // cancel all created contracts and leave the updated ones.
     events.emit("logs", "Rolling back deployments");
     const extrinsics: ExtrinsicResult<number | Contract>[] = [];
-    // delete name contracts for the updated deployment
-    for (const name of this.addedNameContracts) {
-      const extrinsic = await this.deleteNameContract(name);
-      if (extrinsic) extrinsics.push(extrinsic);
-    }
 
     for (const c of contracts.created) {
       if (c.state !== "Deleted") {


### PR DESCRIPTION
### Description

there is no need to delete the name contract, it already will be deleted while deleting created contracts. 

### Changes

remove the loop that deletes contracts names 

### Related Issues

- #500 


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
