### PR TITLE
add minting website to dashboard

### DIFF
--- a/packages/dashboard/src/Dashboard.vue
+++ b/packages/dashboard/src/Dashboard.vue
@@ -223,6 +223,7 @@ interface SidenavItem {
   icon: string;
   prefix: string;
   active?: boolean;
+  hidden?: boolean;
   hyperlink?: boolean;
   children: Array<{
     label?: string;
@@ -269,6 +270,9 @@ export default class Dashboard extends Vue {
     });
   }
   async mounted() {
+    this.routes = this.routes.filter(route => {
+      if (!route.hidden) return route;
+    });
     await this.subscribe();
     this.accounts = this.$store.state.portal.accounts;
     if (this.$route.path === "/" && !this.$api) {
@@ -460,6 +464,13 @@ export default class Dashboard extends Vue {
       icon: "earth",
       prefix: "/other/bootstrap",
       children: [],
+    },
+    {
+      label: "Minting",
+      icon: "cash-multiple",
+      prefix: "/other/minting",
+      children: [],
+      hidden: !(window.configs.APP_NETWORK === "main"),
     },
     {
       label: "Monitoring",

--- a/packages/dashboard/src/Dashboard.vue
+++ b/packages/dashboard/src/Dashboard.vue
@@ -470,7 +470,7 @@ export default class Dashboard extends Vue {
       icon: "cash-multiple",
       prefix: "/other/minting",
       children: [],
-      hidden: (window.configs.APP_NETWORK !== "main"),
+      hidden: window.configs.APP_NETWORK !== "main",
     },
     {
       label: "Monitoring",

--- a/packages/dashboard/src/Dashboard.vue
+++ b/packages/dashboard/src/Dashboard.vue
@@ -470,7 +470,7 @@ export default class Dashboard extends Vue {
       icon: "cash-multiple",
       prefix: "/other/minting",
       children: [],
-      hidden: !(window.configs.APP_NETWORK === "main"),
+      hidden: (window.configs.APP_NETWORK !== "main"),
     },
     {
       label: "Monitoring",

--- a/packages/dashboard/src/other/router/index.ts
+++ b/packages/dashboard/src/other/router/index.ts
@@ -2,12 +2,16 @@ import Vue from "vue";
 import VueRouter, { RouteConfig } from "vue-router";
 
 import BootstrapView from "../views/BootstrapView.vue";
-
+import MintingView from "../views/MintingView.vue";
 Vue.use(VueRouter);
 
 export const otherRoutes: Array<RouteConfig> = [
   {
     path: "/other/bootstrap",
     component: BootstrapView,
+  },
+  {
+    path: "/other/minting",
+    component: MintingView,
   },
 ];

--- a/packages/dashboard/src/other/views/MintingView.vue
+++ b/packages/dashboard/src/other/views/MintingView.vue
@@ -1,0 +1,10 @@
+<template>
+  <div style="padding-top: 64px; height: 100vh">
+    <iframe
+      src="https://alpha.minting.tfchain.grid.tf/"
+      style="border: none; background-color: white"
+      width="100%"
+      height="100%"
+    />
+  </div>
+</template>


### PR DESCRIPTION
### Description

add the minting website to the dashboard, this will be visible only on the main net
on main net:
   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/775e0277-0f45-4f90-b6ac-597611862144)
other networks :
   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/06066be3-f717-4d1e-8bd0-faebf5996226)


### Related Issues
- #775 
### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
