### PR TITLE
Fix the billing rate for the first period

### DIFF
--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -120,9 +120,9 @@ class TFContracts extends Contracts {
           for (const contracts of [nodeContracts, nameContracts, rentContracts]) {
             if (contracts.length === 1) {
               createdAt = contracts[0]["createdAt"];
+              duration = (billReports[0]["timestamp"] - createdAt) / 3600;
+              break;
             }
-            duration = (billReports[0]["timestamp"] - createdAt) / 3600;
-            break;
           }
         }
         if (!duration) {


### PR DESCRIPTION
### Description

The billing rate is wrong for the first period in the case of name or rent contracts.

### Related Issues

- #791 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
