### PR TITLE
add wireguard to deployment details dialog

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -53,7 +53,12 @@
                 :data="Math.ceil(disk.size / (1024 * 1024 * 1024))"
               />
               <CopyReadonlyInput label="WireGuard IP" :data="contract.interfaces[0].ip" />
-              <CopyReadonlyInput label="WireGuard Config" textarea :data="data.wireguard" v-if="data.wireguard" />
+              <CopyReadonlyInput
+                label="WireGuard Config"
+                textarea
+                :data="data.wireguard || contract.wireguard"
+                v-if="data.wireguard || contract.wireguard"
+              />
               <CopyReadonlyInput label="Flist" :data="contract.flist" v-if="contract.flist" />
               <template v-if="environments !== false">
                 <template v-for="key of Object.keys(contract.env)" :key="key">


### PR DESCRIPTION
### Description

The wireguard configuration is inside the details object; in contrast, for k8s deployments, the wireguard configuration is outside the details object.
Now, we look for both and display the one that is already there.
[Screencast from 11 يول, 2023 EEST 05:17:01 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/348b9141-8fda-4fc4-bbaf-ba3654435353)


### Related Issues

- #784  

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
