### PR TITLE
Add build files for ARM

### DIFF
--- a/.github/workflows/publish_arm.yml
+++ b/.github/workflows/publish_arm.yml
@@ -1,0 +1,67 @@
+name: Publish ARM
+
+on:
+  workflow_run:
+    workflows: ["Full Clients Publish"]
+    types:
+      - completed
+
+jobs:
+  docker-image-grid-http-server:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: 'Get tag'
+        id: tag
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            let run = await github.rest.actions.getWorkflowRun({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            return run.data.head_branch;
+
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.tag.outputs.result }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          context: git
+          images: ghcr.io/${{ github.repository_owner }}/grid_http_server
+          flavor: |
+            suffix=-arm,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: packages/grid_http_server/arm
+          push: true
+          platforms: linux/arm64,linux/armhf
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GRID_VERSION=${{ steps.tag.outputs.result }}

--- a/.github/workflows/publish_arm.yml
+++ b/.github/workflows/publish_arm.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   docker-image-grid-http-server:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/packages/grid_http_server/arm/Dockerfile
+++ b/packages/grid_http_server/arm/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine AS build
+
+ARG GRID_VERSION
+RUN apk add nodejs npm curl python3 build-base && npm install --global yarn && yarn add @threefold/grid_http_server@${GRID_VERSION}
+
+FROM alpine
+RUN apk add nodejs npm curl && npm install --global yarn
+COPY --from=build /node_modules /node_modules
+COPY --from=build /package.json /yarn.lock /
+
+ENTRYPOINT [ "yarn" ]


### PR DESCRIPTION
### Description

Adds a Dockerfile and Github workflow to build and release a `grid_http_server container` for the ARM architecture. See https://github.com/threefoldtech/farmerbot/issues/11 for motivation and discussion.

### Notes

* All changes are adjacent to the existing workflows, to prevent any issues or complications with the mainline builds
* The container images are tagged with a suffix `-arm`, for example `latest-arm` . While different architecture can coexist under a single tag, it's only possible if all are built under a single workflow run (avoided to preserve the point above)
* This workflow is triggered by the completion of the main release workflow to ensure the desired release can be obtained with `yarn`.  This complicated tagging the image, thus the included `github-script` step
* Any suggestions regarding how to organize the new files, in terms of directory structure or naming conventions, are welcome