### PR TITLE
Adjust the order of the resources in the node details

### DIFF
--- a/packages/dashboard/src/explorer/components/NodeUsedResources.vue
+++ b/packages/dashboard/src/explorer/components/NodeUsedResources.vue
@@ -66,7 +66,7 @@ export default class NodeUsedResources extends Vue {
 
   getNodeUsedResources() {
     this.loader = true;
-    return ["cru", "sru", "hru", "mru"].map((i, idx) => {
+    return ["cru", "mru", "sru", "hru"].map((i, idx) => {
       const value =
         this.nodeStatistics.total[i] != 0
           ? ((this.nodeStatistics.used[i] + this.nodeStatistics.system[i]) / this.nodeStatistics.total[i]) * 100
@@ -90,7 +90,7 @@ export default class NodeUsedResources extends Vue {
         this.resources = resources;
       }
     } else {
-      this.resources = ["cru", "sru", "hru", "mru"].map((i, idx) => {
+      this.resources = ["cru", "mru", "sru", "hru"].map((i, idx) => {
         return { id: idx + 1, value: 0, name: this.renamedResources[idx] };
       });
     }


### PR DESCRIPTION
### Description

Adjust the order of the resources in the node details

### Changes

the old order was cpu, ssd, hdd, mem
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/41957921/8f686920-5376-44fb-967c-848af69d79e0)

the new order is cpu, mem, ssd, hdd
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/41957921/dfb1e266-7ae7-4ce0-9763-81370353470e)


### Related Issues

- #819 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
