### PR TITLE
Fix Caprover flow

### DIFF
--- a/packages/grid_client/scripts/caprover_worker.ts
+++ b/packages/grid_client/scripts/caprover_worker.ts
@@ -40,7 +40,6 @@ async function main() {
     // These env. vars needed to be changed based on the leader node.
     PUBLIC_KEY: config.ssh_key,
     SWM_NODE_MODE: "worker",
-    SWMTKN: "SWMTKN-1-1eikxeyat4br9t4la1dnln11l1tvlnrngzwh5iq68m2vn7edi1-6lc6xtw3pzd99lrowyuayr5yv",
     LEADER_PUBLIC_IP: "185.206.122.157",
     CAPTAIN_IMAGE_VERSION: "latest",
   };


### PR DESCRIPTION
To make worker join the cluster, user should go to the admin UI and add public IP of deployed worker to join the cluster (not from the script anymore).
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/14
