### PR TITLE
Development playground fix select node

### DIFF
--- a/packages/playground/src/components/select_country.vue
+++ b/packages/playground/src/components/select_country.vue
@@ -1,7 +1,7 @@
 <template>
   <input-tooltip tooltip="Select a country to deploy your instance inside it.">
     <v-autocomplete
-      :disabled="loading"
+      :disabled="loading || loadingNodes"
       label="Country"
       :items="countries"
       clearable
@@ -16,14 +16,16 @@ import { NodeStatus } from "tf_gridproxy_client";
 import { onMounted, ref, watch } from "vue";
 
 import { gridProxyClient } from "../clients";
+import { useFarm } from "./select_farm_manager.vue";
 
 defineProps<{ modelValue?: string }>();
 const emits = defineEmits<{ (events: "update:modelValue", value?: string): void }>();
 
 const country = ref<string>();
 watch(country, c => emits("update:modelValue", c));
-
+const farmManager = useFarm();
 const loading = ref(false);
+const loadingNodes = ref(farmManager?.getLoading());
 const countries = ref<string[]>();
 async function getCountries() {
   try {

--- a/packages/playground/src/components/select_farm.vue
+++ b/packages/playground/src/components/select_farm.vue
@@ -6,7 +6,7 @@
     <input-validator :rules="[validators.required('Farm is required.')]" :value="farm?.farmID" ref="farmInput">
       <input-tooltip tooltip="The name of the farm that you want to deploy inside it.">
         <v-autocomplete
-          :disabled="loading"
+          :disabled="loading || loadingNodes"
           label="Farm Name"
           v-bind="props"
           :items="farms"
@@ -64,6 +64,7 @@ watch([farm, country], ([f, c]) => {
   emits("update:modelValue", f ? { farmID: f.farmID, name: f.name, country: c ?? undefined } : undefined);
 });
 const loading = ref(false);
+const loadingNodes = ref(farmManager?.getLoading());
 watch([farm, loading], ([farm, loading]) => {
   if (loading) FarmGatewayManager?.setLoading(true);
 

--- a/packages/playground/src/components/select_farm_manager.vue
+++ b/packages/playground/src/components/select_farm_manager.vue
@@ -6,6 +6,7 @@ import { provide, type Ref, ref, watch } from "vue";
 
 const subscribtion: any[] = [];
 const farm = ref() as Ref<number | undefined>;
+const LoadingNodes = ref(false);
 provide("farm:manager", {
   setFarmId(_farm) {
     farm.value = _farm;
@@ -15,6 +16,12 @@ provide("farm:manager", {
     return () => {
       subscribtion.splice(subscribtion.indexOf(fn), 1);
     };
+  },
+  setLoading(loading: boolean) {
+    LoadingNodes.value = loading;
+  },
+  getLoading() {
+    return LoadingNodes;
   },
 } as IFarm);
 
@@ -27,6 +34,8 @@ import { inject } from "vue";
 export interface IFarm {
   setFarmId(farmId?: number): void;
   subscribe(fn: (farm?: number) => void): () => void;
+  setLoading(loading: boolean): void;
+  getLoading(): Ref<boolean>;
 }
 
 export function useFarm(): IFarm | null {

--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -150,6 +150,7 @@ watch(
     if (node) {
       validator.value?.setStatus(ValidatorStatus.Pending);
       pingingNode.value = true;
+      farmManager?.setLoading(true);
       try {
         await grid!.zos.pingNode({ nodeId: node.nodeId });
         emits("update:modelValue", {
@@ -163,6 +164,7 @@ watch(
         validator.value?.setStatus(ValidatorStatus.Invalid);
       } finally {
         pingingNode.value = false;
+        farmManager?.setLoading(false);
       }
     }
 
@@ -221,7 +223,6 @@ onMounted(() => {
 
 async function loadNodes(farmId: number) {
   availableNodes.value = [];
-  nodesArr.value = [];
   selectedNode.value = undefined;
   loadingNodes.value = true;
   errorMessage.value = "";
@@ -251,6 +252,7 @@ async function loadNodes(farmId: number) {
       }
 
       if (res) {
+        nodesArr.value = [];
         for (const node of res) {
           if (!nodesArr.value.some(n => n.nodeId === node.nodeId)) {
             nodesArr.value.push({

--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -5,7 +5,7 @@
       class="mb-2"
       type="warning"
       variant="tonal"
-      v-if="!loadingNodes && selectedNode === undefined && emptyResult"
+      v-if="!loadingNodes && selectedNode === undefined && emptyResult && props.filters.rentedBy"
     >
       There are no nodes rented by you that match your selected resources, try to change your resources or rent a node
       and try again.
@@ -215,18 +215,19 @@ function getChipColor(item: any) {
 
 onMounted(() => {
   farmManager?.subscribe(farmId => {
-    loadNodes(farmId);
+    if (farmId) loadNodes(farmId);
   });
 });
 
-async function loadNodes(farmId: number | undefined) {
+async function loadNodes(farmId: number) {
   availableNodes.value = [];
   nodesArr.value = [];
   selectedNode.value = undefined;
   loadingNodes.value = true;
   errorMessage.value = "";
   const filters = props.filters;
-
+  farmManager?.setLoading(true);
+  emptyResult.value = false;
   const grid = await getGrid(profileManager.profile!);
   if (grid) {
     try {
@@ -268,6 +269,7 @@ async function loadNodes(farmId: number | undefined) {
       errorMessage.value = normalizeError(e, "Something went wrong while deploying.");
     } finally {
       loadingNodes.value = false;
+      farmManager?.setLoading(false);
     }
   }
 }

--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -150,7 +150,6 @@ watch(
     if (node) {
       validator.value?.setStatus(ValidatorStatus.Pending);
       pingingNode.value = true;
-      farmManager?.setLoading(true);
       try {
         await grid!.zos.pingNode({ nodeId: node.nodeId });
         emits("update:modelValue", {
@@ -271,7 +270,6 @@ async function loadNodes(farmId: number) {
       errorMessage.value = normalizeError(e, "Something went wrong while fetching nodes.");
     } finally {
       loadingNodes.value = false;
-      farmManager?.setLoading(false);
     }
   }
 }


### PR DESCRIPTION
### Description

apply some changes by @zaelgohary 
 
fix : 
 -  https://github.com/threefoldtech/tfgrid-sdk-ts/issues/757#issuecomment-1651451285
 - `Selecting a farm and then switching to another one before the nodes load will display the nodes of the first farm and sometimes it displays the nodes of both farms.`
 
### Changes
- show the message only if dedicated is enabled 
- disable farm filed when the nodes are loagding
- fix error message

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
