### PR TITLE
Send the CRU in VCores instead of bytes, update the validation error message

### DIFF
--- a/packages/dashboard/src/explorer/utils/validations.ts
+++ b/packages/dashboard/src/explorer/utils/validations.ts
@@ -25,12 +25,17 @@ export function inputValidation(value: string, key: string): string {
   const textNumbersFields: string[] = ["farm_name"];
 
   const countryFields: string[] = ["countryFullName", "country"];
-  const specialChars = /[ `!@#$%^&*()+\-=[\]{};':"\\|,.<>/?~]/;
+  const specialChars = /[ `!@#$%^&*()+\-=[\]{};':"\\|,<>/?~]/;
   const countryRegex = /^[A-Za-z][A-Za-z\s]*$/;
   let errorMsg = "";
 
   if (numericFields.includes(key)) {
-    if (isNaN(+value) || specialChars.test(value) || +value <= 0 || value.includes("e")) {
+    if (isNaN(+value) || specialChars.test(value)) {
+      errorMsg = "This Field accepts only a valid number.";
+      return errorMsg;
+    }
+
+    if (+value <= 0) {
       errorMsg = "This field must be a number larger than 0.";
       return errorMsg;
     }

--- a/packages/dashboard/src/explorer/utils/validations.ts
+++ b/packages/dashboard/src/explorer/utils/validations.ts
@@ -1,62 +1,132 @@
+type ErrorValidation = {
+  errorMessage: string;
+  isValid: boolean;
+};
+
+const numericFields: string[] = [
+  "nodeId",
+  "farmId",
+  "twinId",
+  "freePublicIPs",
+  "farmID",
+  "node_id",
+  "free_ips",
+  "twin_id",
+  "farm_ids",
+  "pricingPolicyId",
+  "total_cru",
+];
+const textualFields: string[] = ["farmingPolicyName", "certificationType"];
+const textNumbersFields: string[] = ["farm_name", "gpu_device_name", "gpu_vendor_name"];
+const resourcesFieldsInBytes = ["free_mru", "free_sru", "free_hru", "total_sru", "total_hru", "total_mru"];
+
+const countryFields: string[] = ["countryFullName", "country"];
+const specialChars = /[`!@#$%^&*()+\-=[\]{};':"\\|,.<>/?~]/;
+const countryRegex = /^[A-Za-z][A-Za-z\s]*$/;
+
 export function inputValidation(value: string, key: string): string {
   // value: Current value of the input.
   // key: Current key of the input, e.g. [nodeId,farmId]..etc
 
-  const numericFields: string[] = [
-    "nodeId",
-    "farmId",
-    "twinId",
-    "freePublicIPs",
-    "farmID",
-    "node_id",
-    "free_ips",
-    "twin_id",
-    "farm_ids",
-    "free_mru",
-    "free_sru",
-    "free_hru",
-    "total_sru",
-    "total_hru",
-    "total_mru",
-    "total_cru",
-    "pricingPolicyId",
-  ];
-  const textualFields: string[] = ["farmingPolicyName", "certificationType"];
-  const textNumbersFields: string[] = ["farm_name"];
+  const validateIntgerFiled = validateNumberField(value, key);
+  const validateCountryField = validateCountryFields(value, key);
+  const validateTextNumbersField = validateTextNumbersFields(value, key);
+  const validateTextualField = validateTextualFields(value, key);
 
-  const countryFields: string[] = ["countryFullName", "country"];
-  const specialChars = /[ `!@#$%^&*()+\-=[\]{};':"\\|,<>/?~]/;
-  const countryRegex = /^[A-Za-z][A-Za-z\s]*$/;
-  let errorMsg = "";
+  if (!validateIntgerFiled.isValid) {
+    return validateIntgerFiled.errorMessage;
+  }
+  if (!validateCountryField.isValid) {
+    return validateCountryField.errorMessage;
+  }
+  if (!validateTextNumbersField.isValid) {
+    return validateTextNumbersField.errorMessage;
+  }
+  if (!validateTextualField.isValid) {
+    return validateTextualField.errorMessage;
+  }
+  return "";
+}
 
+function validateTextualFields(value: string, key: string) {
+  // Validate validateTextualFields field and return true if valid false if not, also return string as error message.
+  const validated = {
+    errorMessage: "",
+    isValid: true,
+  };
+
+  if (textualFields.includes(key)) {
+    if (specialChars.test(value)) {
+      validated.errorMessage = "This field does not accept special characters.";
+      validated.isValid = false;
+    } else if (value.match(".*\\d.*")) {
+      validated.errorMessage = "This field does not accept numbers.";
+      validated.isValid = false;
+    }
+  }
+  return validated;
+}
+
+function validateTextNumbersFields(value: string, key: string) {
+  // Validate textNumber field and return true if valid false if not, also return string as error message.
+  const validated = {
+    errorMessage: "",
+    isValid: true,
+  };
+
+  if (textNumbersFields.includes(key)) {
+    if (specialChars.test(value)) {
+      validated.errorMessage = "This field does not accept special characters.";
+      validated.isValid = false;
+    }
+  }
+  return validated;
+}
+
+function validateCountryFields(value: string, key: string) {
+  // Validate country field and return true if valid false if not, also return string as error message.
+  const validated = {
+    errorMessage: "",
+    isValid: true,
+  };
+  if (countryFields.includes(key)) {
+    if (!countryRegex.test(value)) {
+      validated.errorMessage = "Country name should not contain special characters or numbers.";
+      validated.isValid = false;
+    }
+  }
+  return validated;
+}
+
+function validateNumberField(value: string, key: string): ErrorValidation {
+  // Validate number field and return true if valid false if not, also return string as error message.
+  const validated = {
+    errorMessage: "",
+    isValid: true,
+  };
   if (numericFields.includes(key)) {
     if (isNaN(+value) || specialChars.test(value)) {
-      errorMsg = "This Field accepts only a valid number.";
-      return errorMsg;
+      validated.errorMessage = "This Field accepts only a valid number.";
+      validated.isValid = false;
     }
 
     if (+value <= 0) {
-      errorMsg = "This field must be a number larger than 0.";
-      return errorMsg;
-    }
-  } else if (countryFields.includes(key)) {
-    if (!countryRegex.test(value)) {
-      return (errorMsg = "Country name should not contain special characters or numbers.");
-    }
-  } else if (textNumbersFields.includes(key)) {
-    if (specialChars.test(value)) {
-      errorMsg = "This field does not accept special characters.";
-      return errorMsg;
-    }
-  } else if (textualFields.includes(key)) {
-    if (specialChars.test(value)) {
-      errorMsg = "This field does not accept special characters.";
-      return errorMsg;
-    } else if (value.match(".*\\d.*")) {
-      errorMsg = "This field does not accept numbers.";
-      return errorMsg;
+      validated.errorMessage = "This field must be a number larger than 0.";
+      validated.isValid = false;
     }
   }
-  errorMsg = "";
-  return errorMsg;
+
+  if (resourcesFieldsInBytes.includes(key)) {
+    if (isNaN(+value)) {
+      validated.errorMessage = "This Field accepts only a valid number.";
+      validated.isValid = false;
+    }
+
+    if (+value <= 0) {
+      validated.errorMessage = "This field must be a number larger than 0.";
+      validated.isValid = false;
+    }
+  }
+
+  return validated;
 }

--- a/packages/dashboard/src/portal/store/actions.ts
+++ b/packages/dashboard/src/portal/store/actions.ts
@@ -33,8 +33,9 @@ export default {
 
     for (const key in state.dedicatedNodesFilter) {
       let value = state.dedicatedNodesFilter[key];
-      if (key == "total_hru" || key == "total_mru" || key == "total_sru" || key == "total_cru") {
+      if (key == "total_hru" || key == "total_mru" || key == "total_sru") {
         value *= 1024 * 1024 * 1024; // convert from gb to b
+        value = parseInt(value);
       }
       // don't break the call for the null values
       if (value == null || value == undefined || value == 0) value = "";


### PR DESCRIPTION
### Related issues
- see [this commenct](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/721)

- Update the validation error message in case a not-valid number entered 
- - ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/45291560-edc4-494a-92c1-bea54df49de2)
- Update the Sur, Hru, and Mru fields to accept decimal numbers
- - ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/f7202bf3-3837-482d-9938-a78ca33f78b2)
- Filter the Cru based on VCores instead of bytes 
- - ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/07506ac3-af9c-42ac-9717-0e1775459551)
- Search with `IContaines` supported from the grid proxy
- - ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/654a3c2c-f220-4c57-a94c-241f45254cc3)

 