### PR TITLE
Set timeout before loading nodes

### DIFF
--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -127,6 +127,8 @@ const cards: NodeGPUCardType[] = [];
 const emptyResult = ref(false);
 const validator = ref();
 const pingingNode = ref(false);
+const timeoutId = ref();
+
 watch(selectedCards, async () => {
   for (const card of nodeCards.value) {
     for (const selectedCard of selectedCards.value) {
@@ -195,6 +197,7 @@ watch(
       return;
     shouldBeUpdated.value = true;
   },
+  { deep: false },
 );
 
 watch([loadingNodes, shouldBeUpdated], async ([l, s]) => {
@@ -206,7 +209,10 @@ watch([loadingNodes, shouldBeUpdated], async ([l, s]) => {
       availableNodes.value = [];
       return;
     }
-    loadNodes(farmId);
+    clearTimeout(timeoutId.value);
+    timeoutId.value = setTimeout(() => {
+      loadNodes(farmId);
+    }, 1000);
   });
 });
 

--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -127,7 +127,7 @@ const cards: NodeGPUCardType[] = [];
 const emptyResult = ref(false);
 const validator = ref();
 const pingingNode = ref(false);
-const timeoutId = ref();
+const delay = ref();
 
 watch(selectedCards, async () => {
   for (const card of nodeCards.value) {
@@ -209,8 +209,8 @@ watch([loadingNodes, shouldBeUpdated], async ([l, s]) => {
       availableNodes.value = [];
       return;
     }
-    clearTimeout(timeoutId.value);
-    timeoutId.value = setTimeout(() => {
+    clearTimeout(delay.value);
+    delay.value = setTimeout(() => {
       loadNodes(farmId);
     }, 1000);
   });


### PR DESCRIPTION
### Description

- Set a timeout and cancel any previously scheduled function calls before loading nodes
- Set deep option to false in props watcher

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/757

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
