### PR TITLE
Make accessing rootfs value consistent in all weblets  

### DIFF
--- a/packages/playground/src/components/caprover_worker.vue
+++ b/packages/playground/src/components/caprover_worker.vue
@@ -40,9 +40,7 @@
           cpu: $props.modelValue.solution?.cpu,
           memory: $props.modelValue.solution?.memory,
           publicIp: true,
-          ssd:
-            ($props.modelValue.solution?.disk ?? 0) +
-            rootFs($props.modelValue.solution?.cpu ?? 0, $props.modelValue.solution?.memory ?? 0),
+          ssd: ($props.modelValue.solution?.disk ?? 0) + rootFilesystemSize,
           rentedBy: $props.modelValue.dedicated ? profileManager.profile?.twinId : undefined,
           certified: $props.modelValue.certified,
         }"
@@ -68,11 +66,16 @@
 import { useProfileManager } from "../stores";
 import rootFs from "../utils/root_fs";
 
-defineProps<{ modelValue: CaproverWorker }>();
+const props = defineProps<{ modelValue: CaproverWorker }>();
+const rootFilesystemSize = computed(() =>
+  rootFs(props.modelValue.solution?.cpu ?? 0, props.modelValue.solution?.memory ?? 0),
+);
 const profileManager = useProfileManager();
 </script>
 
 <script lang="ts">
+import { computed } from "vue";
+
 import SelectFarmManager from "../components/select_farm_manager.vue";
 import SelectNode from "../components/select_node.vue";
 import type { CaproverWorker } from "../types";

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -79,7 +79,7 @@
               cpu: solution?.cpu,
               memory: solution?.memory,
               publicIp: ipv4,
-              ssd: disks.reduce((total, disk) => total + disk.size, solution?.disk + 2),
+              ssd: disks.reduce((total, disk) => total + disk.size, solution?.disk + rootFilesystemSize),
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
               hasGPU: hasGPU,
@@ -205,7 +205,7 @@ const disks = ref<Disk[]>([]);
 const network = ref();
 const hasGPU = ref();
 const selectedNode = ref() as Ref<INode>;
-
+const rootFilesystemSize = 2;
 function addDisk() {
   const name = generateName(7);
   disks.value.push({
@@ -263,7 +263,7 @@ async function deploy() {
           publicIpv6: ipv6.value,
           planetary: planetary.value,
           envs: [{ key: "SSH_KEY", value: profileManager.profile!.ssh }],
-          rootFilesystemSize: 2,
+          rootFilesystemSize,
           hasGPU: hasGPU.value,
           nodeId: selectedNode.value.nodeId,
           gpus: hasGPU.value ? selectedNode.value.cards?.map(card => card.id) : undefined,

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -4,7 +4,7 @@
     @mount="layoutMount"
     :cpu="solution?.cpu"
     :memory="solution?.memory"
-    :disk="disks.reduce((total, disk) => total + disk.size, solution?.disk)"
+    :disk="disks.reduce((total, disk) => total + disk.size, rootFilesystemSize)"
     :ipv4="ipv4"
     :certified="certified"
     :dedicated="dedicated"
@@ -72,7 +72,7 @@
               cpu: solution?.cpu,
               memory: solution?.memory,
               publicIp: ipv4,
-              ssd: disks.reduce((total, disk) => total + disk.size, solution?.disk),
+              ssd: disks.reduce((total, disk) => total + disk.size, rootFilesystemSize),
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"
@@ -178,7 +178,7 @@
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import Network from "../components/networks.vue";
 import SelectSolutionFlavor from "../components/select_solution_flavor.vue";
@@ -229,7 +229,7 @@ const network = ref();
 const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
-
+const rootFilesystemSize = computed(() => solution.value?.disk);
 function layoutMount() {
   if (envs.value.length > 0) {
     envs.value.splice(0, 1);
@@ -280,7 +280,7 @@ async function deploy() {
           planetary: planetary.value,
           publicIpv4: ipv4.value,
           publicIpv6: ipv6.value,
-          rootFilesystemSize: solution.value.disk,
+          rootFilesystemSize: rootFilesystemSize.value,
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -223,7 +223,7 @@ const farm = ref() as Ref<Farm>;
 const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
-
+const rootFilesystemSize = computed(() => storage.value);
 watch(firstRound, () => lastRoundInput.value.validate(lastRound.value.toString()));
 
 async function deploy() {
@@ -258,7 +258,7 @@ async function deploy() {
                   },
                 ]
               : [],
-          rootFilesystemSize: storage.value,
+          rootFilesystemSize: rootFilesystemSize.value,
           publicIpv4: ipv4.value,
           planetary: true,
           nodeId: selectedNode.value.nodeId,

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -93,7 +93,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -121,6 +121,7 @@ const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
 const domainNameCmp = ref();
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu || 0, solution.value?.memory || 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a Casperlabs instance.");
@@ -172,6 +173,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,
+          rootFilesystemSize: rootFilesystemSize.value,
         },
       ],
     });
@@ -215,6 +217,7 @@ import SelectNode from "../components/select_node.vue";
 import SelectSolutionFlavor from "../components/select_solution_flavor.vue";
 import { deploymentListEnvironments } from "../constants";
 import type { INode } from "../utils/filter_nodes";
+import rootFs from "../utils/root_fs";
 
 export default {
   name: "TFCasperlabs",

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -121,7 +121,7 @@ const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
 const domainNameCmp = ref();
-const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu || 0, solution.value?.memory || 0));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a Casperlabs instance.");

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -150,7 +150,7 @@ const smtp = ref(createSMTPServer());
 const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
-const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 const flist: Flist = {
   value: "https://hub.grid.tf/tf-official-apps/forum-docker-v3.1.2.flist",
   entryPoint: "/sbin/zinit init",

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -3,7 +3,7 @@
     ref="layout"
     :cpu="solution?.cpu"
     :memory="solution?.memory"
-    :disk="(solution?.disk ?? 0) + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0)"
+    :disk="(solution?.disk ?? 0) + rootFilesystemSize"
     :certified="certified"
     :dedicated="dedicated"
     :ipv4="ipv4"
@@ -76,7 +76,7 @@
               :filters="{
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                ssd: (solution?.disk ?? 0) + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0),
+                ssd: (solution?.disk ?? 0) + rootFilesystemSize,
                 publicIp: ipv4,
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
@@ -123,7 +123,7 @@
 import type { GridClient } from "@threefold/grid_client";
 import { Buffer } from "buffer";
 import TweetNACL from "tweetnacl";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -150,7 +150,7 @@ const smtp = ref(createSMTPServer());
 const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
-
+const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
 const flist: Flist = {
   value: "https://hub.grid.tf/tf-official-apps/forum-docker-v3.1.2.flist",
   entryPoint: "/sbin/zinit init",
@@ -196,7 +196,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           disks: [{ size: solution.value?.disk, mountPoint: "/var/lib/docker" }],
           flist: flist.value,
           entryPoint: flist.entryPoint,
-          rootFilesystemSize: rootFs(solution.value.cpu, solution.value.memory),
+          rootFilesystemSize: rootFilesystemSize.value,
           farmId: farm.value.farmID,
           farmName: farm.value.name,
           publicIpv4: ipv4.value,

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -164,7 +164,7 @@ const email = ref("");
 const password = ref(generatePassword(12));
 const solution = ref() as Ref<SolutionFlavor>;
 const farm = ref() as Ref<Farm>;
-const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 const flist: Flist = {
   value: "https://hub.grid.tf/tf-official-apps/funkwhale-dec21.flist",
   entryPoint: "/init.sh",

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -142,7 +142,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -164,6 +164,7 @@ const email = ref("");
 const password = ref(generatePassword(12));
 const solution = ref() as Ref<SolutionFlavor>;
 const farm = ref() as Ref<Farm>;
+const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
 const flist: Flist = {
   value: "https://hub.grid.tf/tf-official-apps/funkwhale-dec21.flist",
   entryPoint: "/init.sh",
@@ -233,6 +234,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,
+          rootFilesystemSize: rootFilesystemSize.value,
         },
       ],
     });
@@ -276,6 +278,7 @@ import SelectNode from "../components/select_node.vue";
 import SelectSolutionFlavor from "../components/select_solution_flavor.vue";
 import { deploymentListEnvironments } from "../constants";
 import type { INode } from "../utils/filter_nodes";
+import rootFs from "../utils/root_fs";
 
 export default {
   name: "TfFunkwhale",

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -132,7 +132,7 @@ const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
 const domainNameCmp = ref();
 const smtp = ref(createSMTPServer());
-const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a mattermost instance.");

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -3,7 +3,7 @@
     ref="layout"
     :cpu="solution?.cpu"
     :memory="solution?.memory"
-    :disk="solution?.disk + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0)"
+    :disk="solution?.disk + rootFilesystemSize"
     :ipv4="ipv4"
     :certified="certified"
     :dedicated="dedicated"
@@ -59,7 +59,7 @@
               :filters="{
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                ssd: solution?.disk + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0),
+                ssd: solution?.disk + rootFilesystemSize,
                 publicIp: ipv4,
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
@@ -104,7 +104,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -132,7 +132,7 @@ const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
 const domainNameCmp = ref();
 const smtp = ref(createSMTPServer());
-
+const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a mattermost instance.");
@@ -179,7 +179,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           ],
           flist: flist.value,
           entryPoint: flist.entryPoint,
-          rootFilesystemSize: rootFs(solution.value.cpu, solution.value.memory),
+          rootFilesystemSize: rootFilesystemSize.value,
           farmId: farm.value.farmID,
           farmName: farm.value.name,
           publicIpv4: ipv4.value,

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -131,7 +131,7 @@ const flist: Flist = {
 const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
-
+const rootFilesystemSize = 2;
 async function deploy() {
   layout.value.setStatus("deploy");
 
@@ -159,7 +159,7 @@ async function deploy() {
           publicIpv6: true,
           planetary: false,
           envs: [{ key: "SSH_KEY", value: profileManager.profile!.ssh }],
-          rootFilesystemSize: 2,
+          rootFilesystemSize,
           disks: [
             {
               size: 15,

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -3,7 +3,7 @@
     ref="layout"
     :cpu="solution?.cpu"
     :memory="solution?.memory"
-    :disk="solution?.disk + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0)"
+    :disk="solution?.disk + rootFilesystemSize"
     :ipv4="ipv4"
     :certified="certified"
     :dedicated="dedicated"
@@ -93,7 +93,7 @@
               :filters="{
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                ssd: solution?.disk + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0),
+                ssd: solution?.disk + rootFilesystemSize,
                 publicIp: ipv4,
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
@@ -143,7 +143,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -174,7 +174,7 @@ const ipv4 = ref(false);
 const domainNameCmp = ref();
 
 const smtp = ref(createSMTPServer());
-
+const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a owncloud instance.");
@@ -221,7 +221,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           ],
           flist: flist.value,
           entryPoint: flist.entryPoint,
-          rootFilesystemSize: rootFs(solution.value.cpu, solution.value.memory),
+          rootFilesystemSize: rootFilesystemSize.value,
           farmId: farm.value.farmID,
           farmName: farm.value.name,
           publicIpv4: ipv4.value,

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -174,7 +174,7 @@ const ipv4 = ref(false);
 const domainNameCmp = ref();
 
 const smtp = ref(createSMTPServer());
-const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a owncloud instance.");

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -143,7 +143,7 @@ const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
 const domainNameCmp = ref();
-const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a peertube instance.");

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -115,7 +115,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -143,7 +143,7 @@ const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
 const domainNameCmp = ref();
-
+const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a peertube instance.");
@@ -203,6 +203,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,
+          rootFilesystemSize: rootFilesystemSize.value,
         },
       ],
     });
@@ -248,6 +249,7 @@ import { deploymentListEnvironments } from "../constants";
 import type { INode } from "../utils/filter_nodes";
 import { getGrid } from "../utils/grid";
 import { normalizeError } from "../utils/helpers";
+import rootFs from "../utils/root_fs";
 
 export default {
   name: "TfPeertube",

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -200,7 +200,7 @@ async function deploy() {
               value: publicRestoreKey.value,
             },
           ],
-          rootFilesystemSize: rootFilesystemSize.value,
+          rootFilesystemSize: rootFilesystemSize,
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -121,7 +121,7 @@
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import Network from "../components/networks.vue";
 import { useLayout } from "../components/weblet_layout.vue";
@@ -143,7 +143,8 @@ const ipv4 = ref(false);
 const planetary = ref(true);
 const cpu = 1;
 const memory = 512;
-const rootFsSize = rootFs(cpu, memory);
+const rootFsSize = computed(() => rootFs(cpu, memory));
+rootFs(cpu, memory);
 const farm = ref() as Ref<Farm>;
 const privateRestoreKey = ref("");
 const publicRestoreKey = ref("");

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -143,7 +143,7 @@ const ipv4 = ref(false);
 const planetary = ref(true);
 const cpu = 1;
 const memory = 512;
-const rootFilesystemSize = computed(() => rootFs(cpu, memory));
+const rootFilesystemSize = rootFs(cpu, memory);
 
 const farm = ref() as Ref<Farm>;
 const privateRestoreKey = ref("");

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -3,7 +3,7 @@
     ref="layout"
     :cpu="cpu"
     :memory="memory"
-    :disk="rootFsSize"
+    :disk="rootFilesystemSize"
     :ipv4="ipv4"
     :certified="certified"
     :dedicated="dedicated"
@@ -73,7 +73,7 @@
             :filters="{
               cpu,
               memory,
-              ssd: rootFsSize,
+              ssd: rootFilesystemSize,
               publicIp: ipv4,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
@@ -89,7 +89,7 @@
               cpu,
               memory,
               ipv4: ipv4,
-              disks: [{ size: rootFsSize, mountPoint: '/' }],
+              disks: [{ size: rootFilesystemSize, mountPoint: '/' }],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"
@@ -143,8 +143,8 @@ const ipv4 = ref(false);
 const planetary = ref(true);
 const cpu = 1;
 const memory = 512;
-const rootFsSize = computed(() => rootFs(cpu, memory));
-rootFs(cpu, memory);
+const rootFilesystemSize = computed(() => rootFs(cpu, memory));
+
 const farm = ref() as Ref<Farm>;
 const privateRestoreKey = ref("");
 const publicRestoreKey = ref("");
@@ -200,7 +200,7 @@ async function deploy() {
               value: publicRestoreKey.value,
             },
           ],
-          rootFilesystemSize: rootFsSize,
+          rootFilesystemSize: rootFilesystemSize.value,
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -104,7 +104,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -133,6 +133,7 @@ const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const domainNameCmp = ref();
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu || 0, solution.value?.memory || 0));
 
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
@@ -191,6 +192,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,
+          rootFilesystemSize: rootFilesystemSize.value,
         },
       ],
     });
@@ -234,6 +236,7 @@ import SelectNode from "../components/select_node.vue";
 import SelectSolutionFlavor from "../components/select_solution_flavor.vue";
 import { deploymentListEnvironments } from "../constants";
 import type { INode } from "../utils/filter_nodes";
+import rootFs from "../utils/root_fs";
 
 export default {
   name: "TfSubsquid",

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -133,7 +133,7 @@ const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const domainNameCmp = ref();
-const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu || 0, solution.value?.memory || 0));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -182,7 +182,7 @@ const ipv4 = ref(false);
 const domainNameCmp = ref();
 
 const smtp = ref(createSMTPServer());
-const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a taiga instance.");

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -3,7 +3,7 @@
     ref="layout"
     :cpu="solution?.cpu"
     :memory="solution?.memory"
-    :disk="solution?.disk + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0)"
+    :disk="solution?.disk + rootFilesystemSize"
     :ipv4="ipv4"
     :certified="certified"
     :dedicated="dedicated"
@@ -104,7 +104,7 @@
               :filters="{
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                ssd: solution?.disk + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0),
+                ssd: solution?.disk + rootFilesystemSize,
                 publicIp: ipv4,
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
@@ -150,7 +150,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -182,7 +182,7 @@ const ipv4 = ref(false);
 const domainNameCmp = ref();
 
 const smtp = ref(createSMTPServer());
-
+const rootFilesystemSize = computed(() => rootFs(solution.value.cpu, solution.value.memory));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a taiga instance.");
@@ -229,7 +229,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           ],
           flist: flist.value,
           entryPoint: flist.entryPoint,
-          rootFilesystemSize: rootFs(solution.value.cpu, solution.value.memory),
+          rootFilesystemSize: rootFilesystemSize.value,
           farmId: farm.value.farmID,
           farmName: farm.value.name,
           publicIpv4: ipv4.value,

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -3,7 +3,7 @@
     ref="layout"
     :cpu="solution?.cpu"
     :memory="solution?.memory"
-    :disk="(solution?.disk ?? 0) + 10 + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0)"
+    :disk="(solution?.disk ?? 0) + 10 + rootFilesystemSize"
     :ipv4="ipv4"
     :certified="certified"
     :dedicated="dedicated"
@@ -87,7 +87,7 @@
           :filters="{
             cpu: solution?.cpu,
             memory: solution?.memory,
-            ssd: (solution?.disk ?? 0) + 10 + rootFs(solution?.cpu ?? 0, solution?.memory ?? 0),
+            ssd: (solution?.disk ?? 0) + 10 + rootFilesystemSize,
             publicIp: ipv4,
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,
@@ -119,7 +119,7 @@
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -148,7 +148,7 @@ const flist: Flist = {
 const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
-
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 async function deploy() {
   layout.value.setStatus("deploy");
 
@@ -190,7 +190,7 @@ async function deploy() {
             { key: "PASSWORD", value: password.value },
             { key: "UMBREL_DISK", value: "/umbrelDisk" },
           ],
-          rootFilesystemSize: rootFs(solution.value.cpu, solution.value.memory),
+          rootFilesystemSize: rootFilesystemSize.value,
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -143,7 +143,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
@@ -174,7 +174,7 @@ const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
-
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu || 0, solution.value?.memory || 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a Wordpress instance.");
@@ -231,6 +231,7 @@ async function deploy(gatewayName: GatewayNode, customDomain: boolean) {
           nodeId: selectedNode.value.nodeId,
           rentedBy: dedicated.value ? grid!.twinId : undefined,
           certified: certified.value,
+          rootFilesystemSize: rootFilesystemSize.value,
         },
       ],
     });
@@ -273,6 +274,7 @@ import SelectNode from "../components/select_node.vue";
 import SelectSolutionFlavor from "../components/select_solution_flavor.vue";
 import { deploymentListEnvironments } from "../constants";
 import type { INode } from "../utils/filter_nodes";
+import rootFs from "../utils/root_fs";
 
 export default {
   name: "TFWordpress",

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -174,7 +174,7 @@ const dedicated = ref(false);
 const certified = ref(false);
 const selectedNode = ref() as Ref<INode>;
 const ipv4 = ref(false);
-const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu || 0, solution.value?.memory || 0));
+const rootFilesystemSize = computed(() => rootFs(solution.value?.cpu ?? 0, solution.value?.memory ?? 0));
 function finalize(deployment: any) {
   layout.value.reloadDeploymentsList();
   layout.value.setStatus("success", "Successfully deployed a Wordpress instance.");


### PR DESCRIPTION
### Description

This will make the code more maintainable as we need to access rootfs value many times in same weblet

### Changes
How you can access rootfs value in weblets

-------
 - Algorand
    `rootFilesystemSize`: computed value equals to the `storage` value
- Full vm
- node pilot
  `rootFilesystemSize` is set to `2` 

-------
- preesearch
 - `rootFilesystemSize` is set to the result rootfs function based on hardcoded values of cpu and memory
- micro Vm
    `rootFilesystemSize`: computed value equals to the selected package disk

- k8s worker
  `props.modelValue.rootFsSize` 
-------------  

- casperlabs
- discourse 
- funkwhale
- matermost
-  owncloud
- peertube 
- subsquid
- taiga
- umbrel
- wordpress 
- caprover worker
  -  `rootFilesystemSize`: computed value of the result of rootfs function based on selected package cpu and memory



### Related Issues

- #890

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
