### PR TITLE
fix rootfs storage pool error

### DIFF
--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -467,7 +467,7 @@ class Nodes {
     try {
       this.fitDisksInDisksPool(ssdDisks, ssdPools, DiskTypes.SSD);
       this.fitDisksInDisksPool(hddDisks, hddPools, DiskTypes.HDD);
-      this.fitDisksInDisksPool(rootFileSystemDisks, ssdDisks, DiskTypes.SSD);
+      this.fitDisksInDisksPool(rootFileSystemDisks, ssdPools, DiskTypes.SSD);
       return true;
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
### Description

Fix a typo in `verifyNodeStoragePoolCapacity` that makes every deployment without  


### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/864
- #886

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
