### PR TITLE
added debian-12 flist in micro_vm.vue

### DIFF
--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -204,6 +204,11 @@ const images = [
     entryPoint: "/sbin/zinit init",
   },
   {
+    name: "Debian-12",
+    flist: "https://hub.grid.tf/ahmedthabet.3bot/threefolddev-debian-12.flist",
+    entryPoint: "/sbin/zinit init",
+  },
+  {
     name: "Alpine-3",
     flist: "https://hub.grid.tf/tf-official-apps/threefoldtech-alpine-3.flist",
     entryPoint: "/entrypoint.sh",

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -205,7 +205,7 @@ const images = [
   },
   {
     name: "Debian-12",
-    flist: "https://hub.grid.tf/ahmedthabet.3bot/threefolddev-debian-12.flist",
+    flist: "https://hub.grid.tf/tf-official-apps/threefoldtech-debian-12.flist",
     entryPoint: "/sbin/zinit init",
   },
   {


### PR DESCRIPTION
Added debian-12 flist in micro_vm.vue

As of now, this branch is using @xmonader's FList
  * `https://hub.grid.tf/ahmedthabet.3bot/threefolddev-debian-12.flist`

But if needed, we set it as draft and wait until we have the official threefoldtech's FList
  * `https://hub.grid.tf/tf-official-apps/threefoldtech-debian-12.flist`