### PR TITLE
Include rootfs in node filters

### DIFF
--- a/packages/playground/src/components/caprover_worker.vue
+++ b/packages/playground/src/components/caprover_worker.vue
@@ -55,7 +55,7 @@
           farmId: $props.modelValue.farm?.farmID,
           cpu: $props.modelValue.solution?.cpu ?? 0,
           memory: $props.modelValue.solution?.memory ?? 0,
-          disks: [$props.modelValue.solution?.disk ?? 0],
+          diskSizes: [$props.modelValue.solution?.disk ?? 0],
           rentedBy: $props.modelValue.dedicated ? profileManager.profile?.twinId : undefined,
           certified: $props.modelValue.certified,
         }"

--- a/packages/playground/src/components/caprover_worker.vue
+++ b/packages/playground/src/components/caprover_worker.vue
@@ -55,7 +55,7 @@
           farmId: $props.modelValue.farm?.farmID,
           cpu: $props.modelValue.solution?.cpu ?? 0,
           memory: $props.modelValue.solution?.memory ?? 0,
-          disks: [{ name: 'data0', size: $props.modelValue.solution?.disk ?? 0, mountPoint: '/var/lib/docker' }],
+          disks: [$props.modelValue.solution?.disk ?? 0],
           rentedBy: $props.modelValue.dedicated ? profileManager.profile?.twinId : undefined,
           certified: $props.modelValue.certified,
         }"

--- a/packages/playground/src/components/k8s_worker.vue
+++ b/packages/playground/src/components/k8s_worker.vue
@@ -111,7 +111,7 @@
           cpu: $props.modelValue.cpu,
           memory: $props.modelValue.memory,
           publicIp: $props.modelValue.ipv4,
-          ssd: $props.modelValue.diskSize + $props.modelValue.rootFsSize,
+          ssd: ($props.modelValue.diskSize ?? 0) + $props.modelValue.rootFsSize,
           rentedBy: $props.modelValue.dedicated ? profileManager.profile?.twinId : undefined,
           certified: $props.modelValue.certified,
         }"

--- a/packages/playground/src/components/k8s_worker.vue
+++ b/packages/playground/src/components/k8s_worker.vue
@@ -125,7 +125,7 @@
           farmId: $props.modelValue.farm?.farmID,
           cpu: $props.modelValue.cpu,
           memory: $props.modelValue.memory,
-          disks: [{ name: 'data0', size: $props.modelValue?.diskSize ?? 0, mountPoint: '/var/lib/docker' }],
+          disks: [$props.modelValue?.diskSize ?? 0],
           rentedBy: $props.modelValue.dedicated ? profileManager.profile?.twinId : undefined,
           certified: $props.modelValue.certified,
         }"

--- a/packages/playground/src/components/k8s_worker.vue
+++ b/packages/playground/src/components/k8s_worker.vue
@@ -125,7 +125,7 @@
           farmId: $props.modelValue.farm?.farmID,
           cpu: $props.modelValue.cpu,
           memory: $props.modelValue.memory,
-          disks: [$props.modelValue?.diskSize ?? 0],
+          diskSizes: [$props.modelValue?.diskSize ?? 0],
           rentedBy: $props.modelValue.dedicated ? profileManager.profile?.twinId : undefined,
           certified: $props.modelValue.certified,
         }"

--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -96,7 +96,7 @@ export interface NodeFilters {
   hasGPU?: boolean;
   cpu: number;
   memory: number;
-  disks: number[];
+  diskSizes: number[];
   certified?: boolean;
   rentedBy?: number;
   type?: string;
@@ -165,7 +165,7 @@ watch(
       await validateNodeStoragePool(
         grid,
         node.nodeId,
-        props.filters.disks.map(disk => disk * 1024 ** 3),
+        props.filters.diskSizes.map(disk => disk * 1024 ** 3),
         props.rootFileSystemSize * 1024 ** 3,
       );
     }
@@ -189,7 +189,7 @@ watch(
   (value, oldValue) => {
     if (
       value.farmId === oldValue.farmId &&
-      value.disks === oldValue.disks &&
+      value.diskSizes === oldValue.diskSizes &&
       value.cpu === oldValue.cpu &&
       value.memory === oldValue.memory &&
       value.certified === oldValue.certified &&
@@ -243,7 +243,7 @@ async function loadNodes(farmId: number) {
         farmId: farmId,
         cpu: filters.cpu,
         memory: filters.memory,
-        disks: [...filters.disks, props.rootFileSystemSize],
+        diskSizes: [...filters.diskSizes, props.rootFileSystemSize],
         ipv4: filters.ipv4,
         hasGPU: filters.hasGPU ? filters.hasGPU : undefined,
         certified: filters.certified,

--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -96,11 +96,7 @@ export interface NodeFilters {
   hasGPU?: boolean;
   cpu: number;
   memory: number;
-  disks: {
-    name?: string;
-    size: number;
-    mountPoint: string;
-  }[];
+  disks: number[];
   certified?: boolean;
   rentedBy?: number;
   type?: string;
@@ -169,7 +165,7 @@ watch(
       await validateNodeStoragePool(
         grid,
         node.nodeId,
-        props.filters.disks.map(disk => disk.size * 1024 ** 3),
+        props.filters.disks.map(disk => disk * 1024 ** 3),
         props.rootFileSystemSize * 1024 ** 3,
       );
     }
@@ -247,7 +243,7 @@ async function loadNodes(farmId: number) {
         farmId: farmId,
         cpu: filters.cpu,
         memory: filters.memory,
-        disks: [...filters.disks],
+        disks: [...filters.disks, props.rootFileSystemSize],
         ipv4: filters.ipv4,
         hasGPU: filters.hasGPU ? filters.hasGPU : undefined,
         certified: filters.certified,

--- a/packages/playground/src/utils/filter_nodes.ts
+++ b/packages/playground/src/utils/filter_nodes.ts
@@ -23,7 +23,7 @@ export async function getFilteredNodes(grid: GridClient, options: NodeFilters): 
     farmId: options.farmId ? options.farmId : undefined,
     cru: options.cpu,
     mru: Math.round(options.memory / 1024),
-    sru: options.disks.reduce((total, disk) => total + disk),
+    sru: options.diskSizes.reduce((total, disk) => total + disk),
     publicIPs: options.ipv4,
     hasGPU: options.hasGPU,
     rentedBy: options.rentedBy ? grid.twinId : undefined,

--- a/packages/playground/src/utils/filter_nodes.ts
+++ b/packages/playground/src/utils/filter_nodes.ts
@@ -23,7 +23,7 @@ export async function getFilteredNodes(grid: GridClient, options: NodeFilters): 
     farmId: options.farmId ? options.farmId : undefined,
     cru: options.cpu,
     mru: Math.round(options.memory / 1024),
-    sru: options.disks.reduce((total, disk) => total + disk.size, 2),
+    sru: options.disks.reduce((total, disk) => total + disk, 2),
     publicIPs: options.ipv4,
     hasGPU: options.hasGPU,
     rentedBy: options.rentedBy ? grid.twinId : undefined,

--- a/packages/playground/src/utils/filter_nodes.ts
+++ b/packages/playground/src/utils/filter_nodes.ts
@@ -23,7 +23,7 @@ export async function getFilteredNodes(grid: GridClient, options: NodeFilters): 
     farmId: options.farmId ? options.farmId : undefined,
     cru: options.cpu,
     mru: Math.round(options.memory / 1024),
-    sru: options.disks.reduce((total, disk) => total + disk, 2),
+    sru: options.disks.reduce((total, disk) => total + disk),
     publicIPs: options.ipv4,
     hasGPU: options.hasGPU,
     rentedBy: options.rentedBy ? grid.twinId : undefined,

--- a/packages/playground/src/weblets/freeflow.vue
+++ b/packages/playground/src/weblets/freeflow.vue
@@ -78,7 +78,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: disks.map(disk => disk.size),
+              diskSizes: disks.map(disk => disk.size),
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/freeflow.vue
+++ b/packages/playground/src/weblets/freeflow.vue
@@ -63,7 +63,7 @@
             :filters="{
               cpu: solution?.cpu,
               memory: solution?.memory,
-              ssd: solution?.disk,
+              ssd: (solution?.disk ?? 0) + rootFileSystemSize,
               publicIp: ipv4,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,

--- a/packages/playground/src/weblets/freeflow.vue
+++ b/packages/playground/src/weblets/freeflow.vue
@@ -78,7 +78,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: disks,
+              disks: disks.map(disk => disk.size),
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -97,7 +97,7 @@
               memory: solution?.memory,
               ipv4: ipv4,
               ipv6: ipv4,
-              disks: [{ size: solution?.disk, mountPoint: '/' }, ...disks],
+              disks: [solution?.disk, ...disks.map(disk => disk.size)],
               hasGPU: hasGPU,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -97,7 +97,7 @@
               memory: solution?.memory,
               ipv4: ipv4,
               ipv6: ipv4,
-              disks: [solution?.disk, ...disks.map(disk => disk.size)],
+              diskSizes: [solution?.disk, ...disks.map(disk => disk.size)],
               hasGPU: hasGPU,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -81,7 +81,7 @@
               cpu: solution?.cpu,
               memory: solution?.memory,
               publicIp: ipv4,
-              ssd: disks.reduce((total, disk) => total + disk.size, solution?.disk + rootFilesystemSize),
+              ssd: disks.reduce((total, disk) => total + disk.size, (solution?.disk ?? 0) + rootFilesystemSize),
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
               hasGPU: hasGPU,

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -89,7 +89,7 @@
               memory: solution?.memory,
               ipv4: ipv4,
               ipv6: ipv4,
-              disks: disks.map(disk => disk.size),
+              diskSizes: disks.map(disk => disk.size),
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -89,7 +89,7 @@
               memory: solution?.memory,
               ipv4: ipv4,
               ipv6: ipv4,
-              disks: disks,
+              disks: disks.map(disk => disk.size),
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -174,15 +174,7 @@
             ipv4: ipv4,
             ipv6: ipv4,
             type: type,
-            disks:
-              type === 'indexer'
-                ? [
-                    {
-                      size: 50,
-                      mountPoint: '/var/lib/docker',
-                    },
-                  ]
-                : [],
+            disks: type === 'indexer' ? [50] : [],
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,
           }"

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -174,7 +174,7 @@
             ipv4: ipv4,
             ipv6: ipv4,
             type: type,
-            disks: type === 'indexer' ? [50] : [],
+            diskSizes: type === 'indexer' ? [50] : [],
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,
           }"

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -70,7 +70,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [{ size: solution?.disk, mountPoint: '/data' }],
+              disks: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -56,7 +56,7 @@
             :filters="{
               cpu: solution?.cpu,
               memory: solution?.memory,
-              ssd: solution?.disk,
+              ssd: (solution?.disk ?? 0) + rootFilesystemSize,
               publicIp: ipv4,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -70,7 +70,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [solution?.disk],
+              diskSizes: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -106,7 +106,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [solution?.disk],
+                diskSizes: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -106,7 +106,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [{ size: solution?.disk, mountPoint: '/var/lib/docker' }],
+                disks: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -119,7 +119,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [solution?.disk],
+              diskSizes: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -104,7 +104,7 @@
             :filters="{
               cpu: solution?.cpu,
               memory: solution?.memory,
-              ssd: solution?.disk,
+              ssd: (solution?.disk ?? 0) + rootFilesystemSize,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
               publicIp: ipv4,

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -119,7 +119,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [{ size: solution?.disk, mountPoint: '/data' }],
+              disks: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -89,7 +89,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [{ size: solution?.disk, mountPoint: '/data' }],
+                disks: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -74,7 +74,7 @@
               :filters="{
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                ssd: solution?.disk + rootFilesystemSize,
+                ssd: (solution?.disk ?? 0) + rootFilesystemSize,
                 publicIp: ipv4,
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -89,7 +89,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [solution?.disk],
+                diskSizes: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -80,7 +80,7 @@
           :filters="{
             cpu,
             memory,
-            ssd: 32,
+            ssd: 30 + rootFilesystemSize,
             publicIp: true,
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -96,7 +96,7 @@
             cpu,
             memory,
             ipv4: true,
-            disks: [15, 15],
+            diskSizes: [15, 15],
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,
           }"

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -96,10 +96,7 @@
             cpu,
             memory,
             ipv4: true,
-            disks: [
-              { size: 15, mountPoint: '/mnt/' + generateName(10) },
-              { size: 15, mountPoint: '/mnt/' + generateName(10) },
-            ],
+            disks: [15, 15],
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,
           }"

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -122,12 +122,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [
-                  {
-                    size: solution?.disk,
-                    mountPoint: '/var/lib/docker',
-                  },
-                ],
+                disks: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -108,7 +108,7 @@
               :filters="{
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                ssd: solution?.disk + rootFilesystemSize,
+                ssd: (solution?.disk ?? 0) + rootFilesystemSize,
                 publicIp: ipv4,
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -122,7 +122,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [solution?.disk],
+                diskSizes: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -91,7 +91,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [solution?.disk],
+              diskSizes: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -76,7 +76,7 @@
             :filters="{
               cpu: solution?.cpu,
               memory: solution?.memory,
-              ssd: solution?.disk,
+              ssd: (solution?.disk ?? 0) + rootFilesystemSize,
               publicIp: ipv4,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -91,7 +91,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [{ size: solution?.disk, mountPoint: '/data' }],
+              disks: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -90,7 +90,7 @@
               cpu,
               memory,
               ipv4: ipv4,
-              disks: [{ size: rootFilesystemSize, mountPoint: '/' }],
+              disks: [],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -90,7 +90,7 @@
               cpu,
               memory,
               ipv4: ipv4,
-              disks: [],
+              diskSizes: [],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -81,7 +81,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [{ size: solution?.disk, mountPoint: '/var/lib/docker' }],
+              disks: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -81,7 +81,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [solution?.disk],
+              diskSizes: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -66,7 +66,7 @@
             :filters="{
               cpu: solution?.cpu,
               memory: solution?.memory,
-              ssd: solution?.disk,
+              ssd: (solution?.disk ?? 0) + rootFilesystemSize,
               publicIp: ipv4,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -134,7 +134,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [{ size: solution?.disk, mountPoint: '/var/lib/docker' }],
+                disks: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -134,7 +134,7 @@
                 farmId: farm?.farmID,
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                disks: [solution?.disk],
+                diskSizes: [solution?.disk],
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,
               }"

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -119,7 +119,7 @@
               :filters="{
                 cpu: solution?.cpu,
                 memory: solution?.memory,
-                ssd: solution?.disk + rootFilesystemSize,
+                ssd: (solution?.disk ?? 0) + rootFilesystemSize,
                 publicIp: ipv4,
                 rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
                 certified: certified,

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -103,7 +103,7 @@
             farmId: farm?.farmID,
             cpu: solution?.cpu,
             memory: solution?.memory,
-            disks: [10, solution?.disk],
+            diskSizes: [10, solution?.disk],
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,
           }"

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -103,10 +103,7 @@
             farmId: farm?.farmID,
             cpu: solution?.cpu,
             memory: solution?.memory,
-            disks: [
-              { size: 10, mountPoint: '/var/lib/docker' },
-              { size: solution?.disk, mountPoint: '/umbrelDisk' },
-            ],
+            disks: [10, solution?.disk],
             rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
             certified: certified,
           }"

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -120,7 +120,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [solution?.disk],
+              diskSizes: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -105,7 +105,7 @@
             :filters="{
               cpu: solution?.cpu,
               memory: solution?.memory,
-              ssd: solution?.disk,
+              ssd: (solution?.disk ?? 0) + rootFilesystemSize,
               publicIp: ipv4,
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -120,7 +120,7 @@
               farmId: farm?.farmID,
               cpu: solution?.cpu,
               memory: solution?.memory,
-              disks: [{ size: solution?.disk, mountPoint: '/var/www/html' }],
+              disks: [solution?.disk],
               rentedBy: dedicated ? profileManager.profile?.twinId : undefined,
               certified: certified,
             }"


### PR DESCRIPTION
### Description

- some weblets were missing rootfs size in node filter, on the other hand node filters assumes the rootfs 2 GB in all cases regardless the actual rootfs value were passed or not.
- select node component takes disks inside props.filters the disks is an array of object that have name, size and mount point; actually we are not using the name or the mount point in any were inside select node component and its utils.

### Changes
- make disks in `NodeFilters` interface as array of numbers -> disk sizes
- pass only the disk size to select node component in all weblets
- include `rootFileSystemSize` in node filter and remove the initial 2GB hard coded value
- include `rootFileSystemSize` in select farm component in some weblets and handel undefined  case with nullish coalescing 

### Related Issues
- #925 
- #933 
### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
