### PR TITLE
Dashboard: Keep the loading spinner until the public IP is deleted.

### DIFF
--- a/packages/dashboard/src/portal/components/PublicIPTable.vue
+++ b/packages/dashboard/src/portal/components/PublicIPTable.vue
@@ -77,9 +77,7 @@ export default class PublicIPTable extends Vue {
   }
   deletePublicIP(ip: any, i: number) {
     this.loading = i;
-    this.deleteIP(ip).finally(() => {
-      this.loading = null;
-    });
+    this.deleteIP(ip);
   }
 }
 </script>


### PR DESCRIPTION
### Description

`deletePublicIP` function only calls another function and makes the loading to `null`so the progress spinner will appear for a very short while, 
#### there is no need to set loading to null because :
  - the whole row will disappear as soon as the ip is deleted
  - in all cases `loadingDelete` will set to false so the progress spinner will disappear  
   

[Screencast from 08 أغس, 2023 EEST 04:25:46 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/0c426de7-6464-4ac9-a309-12df88efb69f)




### Changes

Remove `finally` that makes loading to `null` before the transaction is completed.

### Related Issues

#923 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
