### PR TITLE
Update the renting script to use the `getRentContractId` method instead of `getRented`.

### DIFF
--- a/packages/grid_client/scripts/renting.ts
+++ b/packages/grid_client/scripts/renting.ts
@@ -13,7 +13,7 @@ async function main() {
   // const res = await client.nodes.reserve({ nodeId: 22 });
   // log(res);
 
-  // const res = await client.nodes.getRent({ nodeId: 12 });
+  // const res = await client.nodes.getRentContractId({ nodeId: 12 });
   // log(res);
 
   // const res = await client.nodes.unreserve({ nodeId: 12 });

--- a/packages/grid_client/scripts/renting.ts
+++ b/packages/grid_client/scripts/renting.ts
@@ -4,6 +4,11 @@ import { log } from "./utils";
 async function main() {
   const client = await getClient();
 
+  async function unreserve() {
+    const unreserved = await client.nodes.unreserve({ nodeId: 12 });
+    log(unreserved);
+  }
+
   const nodesDedicated = await client.capacity.filterNodes({ dedicated: true });
   log(nodesDedicated);
 
@@ -16,9 +21,8 @@ async function main() {
   const rentContractId = await client.nodes.getRentContractId({ nodeId: 12 });
   log(rentContractId);
 
-  const unreserved = await client.nodes.unreserve({ nodeId: 12 });
-  log(unreserved);
-
+  // Uncomment the line below if you intend to perform unreserve.
+  // unreserve();
   await client.disconnect();
 }
 

--- a/packages/grid_client/scripts/renting.ts
+++ b/packages/grid_client/scripts/renting.ts
@@ -4,20 +4,20 @@ import { log } from "./utils";
 async function main() {
   const client = await getClient();
 
-  // const res = await client.capacity.filterNodes({ dedicated: true });
-  // log(res);
+  const nodesDedicated = await client.capacity.filterNodes({ dedicated: true });
+  log(nodesDedicated);
 
-  const res = await client.capacity.filterNodes({ availableFor: client.twinId });
-  log(res);
+  const nodesAvailableFor = await client.capacity.filterNodes({ availableFor: client.twinId });
+  log(nodesAvailableFor);
 
-  // const res = await client.nodes.reserve({ nodeId: 22 });
-  // log(res);
+  const reserved = await client.nodes.reserve({ nodeId: 22 });
+  log(reserved);
 
-  // const res = await client.nodes.getRentContractId({ nodeId: 12 });
-  // log(res);
+  const rentContractId = await client.nodes.getRentContractId({ nodeId: 12 });
+  log(rentContractId);
 
-  // const res = await client.nodes.unreserve({ nodeId: 12 });
-  // log(res);
+  const unreserved = await client.nodes.unreserve({ nodeId: 12 });
+  log(unreserved);
 
   await client.disconnect();
 }


### PR DESCRIPTION
### Description

There was a missing update in the renting script, the `getRented` was removed and the script needs to be updated

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/906

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
