### PR TITLE
Add disable-validation to stop validating in some cases

### DIFF
--- a/packages/playground/src/components/input_validator.vue
+++ b/packages/playground/src/components/input_validator.vue
@@ -41,6 +41,7 @@ export default {
     },
     validMessage: String,
     hint: String,
+    disableValidation: Boolean,
   },
   emits: {
     "update:modelValue": (valid: boolean) => valid,
@@ -104,6 +105,22 @@ export default {
         debouncedValidate(value);
       },
       { immediate: true },
+    );
+
+    watch(
+      () => props.disableValidation,
+      (disabled, wasDisabled) => {
+        const isEnabled = !disabled;
+        const wasEnabled = !wasDisabled;
+
+        if (disabled && wasEnabled) {
+          form?.unregister(uid);
+          error.value = null;
+          setStatus(ValidatorStatus.Valid);
+        }
+
+        if (wasDisabled && isEnabled) validate();
+      },
     );
 
     const blured = ref(false);


### PR DESCRIPTION
## Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/812

### Usage
Toggle `disable-validation` attribute value (as boolean) to toggle validation of an input as shown below
```html
<input-validator :rules="[...]"  #="{ props }"  disable-validation>
  <v-text-field label="Name" placeholder="Your name" v-bind="props" />
</input-validator>
```


### Example
https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/bc029e5c-c5b9-4df5-8f1a-9a28397869b0

