### PR TITLE
dashboard: gateway validation

### DIFF
--- a/packages/dashboard/src/portal/components/FarmNodesTable.vue
+++ b/packages/dashboard/src/portal/components/FarmNodesTable.vue
@@ -435,6 +435,7 @@ import { addNodePublicConfig, deleteNode, nodeInterface } from "@/portal/lib/far
 import { byteToGB, generateNodeSummary, generateReceipt, getNodeUptimePercentage } from "@/portal/lib/nodes";
 import { hex2a } from "@/portal/lib/util";
 
+import { IP4, IP6 } from "../lib/ips";
 import { setDedicatedNodeExtraFee } from "../lib/nodes";
 import NodeMintingDetails from "./NodeMintingDetails.vue";
 
@@ -801,6 +802,11 @@ export default class FarmNodesTable extends Vue {
     const IPv4AddressFormat = `(${IPv4SegmentFormat}[.]){3}${IPv4SegmentFormat}`;
     const gatewayRegex = new RegExp(`^${IPv4AddressFormat}$`);
     if (gatewayRegex.test(this.gw4)) {
+      const ip4 = new IP4(this.ip4);
+      if (!ip4.contains(this.gw4)) {
+        this.gw6ErrorMessage = "Gateway is not a part of the given IPV4.";
+        return false;
+      }
       this.gw4ErrorMessage = "";
       return true;
     } else {
@@ -842,6 +848,11 @@ export default class FarmNodesTable extends Vue {
         ")([0-9a-fA-F]{1})?$",
     );
     if (gatewayRegex.test(this.gw6)) {
+      const ip6 = new IP6(this.ip6);
+      if (!ip6.contains(this.gw6)) {
+        this.gw6ErrorMessage = "Gateway is not a part of the given IPV6.";
+        return false;
+      }
       this.gw6ErrorMessage = "";
       return true;
     } else {

--- a/packages/dashboard/src/portal/lib/ips.ts
+++ b/packages/dashboard/src/portal/lib/ips.ts
@@ -1,0 +1,53 @@
+/**
+ * Represents an IPv4 address with CIDR notation capabilities.
+ */
+export class IP4 {
+  private maskBits: number;
+  private mask: number;
+  private maskedIP: string;
+
+  /**
+   * Constructs an IP4 instance with the given IPv4 address in CIDR notation.
+   * @param ip - The IPv4 address in CIDR notation (e.g., "192.168.0.1/24").
+   * @throws Error if the CIDR mask is invalid.
+   */
+  constructor(private ip: string) {
+    const [ipPart, maskPart] = ip.split("/");
+    this.ip = ipPart;
+    this.mask = parseInt(maskPart);
+    this.maskBits = (0xffffffff << (32 - this.mask)) >>> 0;
+    const selfIpBits = this.ipBits(this.ip);
+    this.maskedIP = this.masked(selfIpBits).join(".");
+  }
+
+  /**
+   * Converts an IPv4 address string to an array of individual IP segments and ensure each bit is within 8 bits.
+   * @param ip - The IPv4 address.
+   * @returns An array containing the IP segments.
+   */
+  private ipBits(ip: string): number[] {
+    const ipSegments = ip.split(".").map(segment => parseInt(segment));
+    return ipSegments.map(bit => bit & 0xff);
+  }
+
+  /**
+   * Masks the given IPv4 segments using the stored mask bits.
+   * @param ipBits - The IPv4 segments to be masked.
+   * @returns The masked IPv4 segments.
+   */
+  private masked(ipBits: number[]): number[] {
+    return ipBits.map((bit, index) => bit & (this.maskBits >>> (24 - index * 8)));
+  }
+
+  /**
+   * Checks if the provided IPv4 address falls within the CIDR range of this instance.
+   * @param ipToCheck - The IPv6 address to check.
+   * @returns True if the address is within the CIDR range, otherwise false.
+   */
+  contains(ipToCheck: string): boolean {
+    const ipToCheckBits = this.ipBits(ipToCheck);
+    const maskedIpToCheck = this.masked(ipToCheckBits);
+
+    return maskedIpToCheck.join(".") === this.maskedIP;
+  }
+}

--- a/packages/dashboard/src/portal/lib/ips.ts
+++ b/packages/dashboard/src/portal/lib/ips.ts
@@ -31,14 +31,22 @@ export class IP4 {
   }
 
   /**
-   * Masks the given IPv4 segments using the stored mask bits.
+   * Applies the stored mask bits to the provided IPv4 segments.
+   *
+   * This method performs a bitwise AND operation between each segment of the IPv4 address
+   * and the corresponding mask bits. The mask bits are shifted to the right by a certain
+   * amount to align with the current segment, ensuring that only the relevant bits are retained.
+   *
+   * The bitwise AND operation with shifted mask bits effectively masks out the unwanted bits
+   * in each segment, following the CIDR notation. This process is essential for isolating
+   * the network portion of the address and applying the subnet mask effectively.
+   *
    * @param ipBits - The IPv4 segments to be masked.
-   * @returns The masked IPv4 segments.
+   * @returns The masked IPv4 segments after applying the bitwise AND operation.
    */
   private masked(ipBits: number[]): number[] {
     return ipBits.map((bit, index) => bit & (this.maskBits >>> (24 - index * 8)));
   }
-
   /**
    * Checks if the provided IPv4 address falls within the CIDR range of this instance.
    * @param ipToCheck - The IPv6 address to check.
@@ -77,7 +85,14 @@ export class IP6 {
   }
 
   /**
-   * Calculates the bitmask based on the stored mask.
+   * Calculates the bitmask based on the stored mask value.
+   *
+   * The bitmask is a binary value that represents the network portion of an IPv6 address
+   * according to the CIDR mask value. If the CIDR mask is 0, the entire address space is
+   * treated as the network. Otherwise, the bitmask is calculated by creating a value where
+   * the first `(128 - mask)` bits are 1 and the remaining `mask` bits are 0, effectively
+   * isolating the network portion.
+   *
    * @returns The bitmask as a BigInt.
    */
   private asBitmask(): bigint {
@@ -95,6 +110,7 @@ export class IP6 {
    */
   expandIPv6(ip: string): string {
     const parts = ip.split(":");
+    // to handle edge case starting with `::`
     let last_seen_empty = false;
     let empty_index: number | null = null;
     const expandedParts = [];

--- a/packages/dashboard/src/portal/lib/ips.ts
+++ b/packages/dashboard/src/portal/lib/ips.ts
@@ -51,3 +51,87 @@ export class IP4 {
     return maskedIpToCheck.join(".") === this.maskedIP;
   }
 }
+
+/**
+ * Represents an IPv6 address with CIDR notation capabilities.
+ */
+export class IP6 {
+  private ip: string;
+  private mask: number;
+  private maskedIp: string;
+
+  /**
+   * Constructs an IP6 instance with the given IPv6 address in CIDR notation.
+   * @param ip - The IPv6 address in CIDR notation (e.g., "2001:db8::1/64").
+   * @throws Error if the CIDR mask is invalid.
+   */
+  constructor(ip: string) {
+    const [ipPart, maskPart] = ip.split("/");
+    if (+maskPart > 128) {
+      throw new Error("CIDR mask can't be higher than 128");
+    }
+    this.ip = this.expandIPv6(ipPart);
+    this.mask = parseInt(maskPart);
+    const cidrIpValue = BigInt(`0x${this.ip.replace(/:/g, "")}`);
+    this.maskedIp = (cidrIpValue & this.asBitmask()).toString(16);
+  }
+
+  /**
+   * Calculates the bitmask based on the stored mask.
+   * @returns The bitmask as a BigInt.
+   */
+  private asBitmask(): bigint {
+    if (this.mask === 0) {
+      return BigInt("0xffffffffffffffffffffffffffffffff");
+    } else {
+      return ~(BigInt(2) ** BigInt(128 - this.mask) - BigInt(1));
+    }
+  }
+
+  /**
+   * Expands an abbreviated IPv6 address to its full form.
+   * @param ip - The abbreviated IPv6 address.
+   * @returns The expanded IPv6 address.
+   */
+  expandIPv6(ip: string): string {
+    const parts = ip.split(":");
+    let last_seen_empty = false;
+    let empty_index: number | null = null;
+    const expandedParts = [];
+    for (const index in parts) {
+      const part = parts[index];
+      if (part === "") {
+        if (last_seen_empty) continue;
+        last_seen_empty = true;
+        if (empty_index === null) {
+          empty_index = +index;
+        } else {
+          expandedParts.splice(empty_index, 0, "0000");
+          empty_index = +index;
+        }
+      } else {
+        expandedParts.push(part.padStart(4, "0"));
+        last_seen_empty = false;
+      }
+    }
+    // the :: may include many omitted parts ex: "2001:db8::1" so here we need to add 3 section of '0000'
+    const omittedParts = new Array(8 - expandedParts.length).fill("0000");
+    if (empty_index !== null) expandedParts.splice(empty_index, 0, ...omittedParts);
+
+    return expandedParts.join(":");
+  }
+
+  /**
+   * Checks if the provided IPv6 address falls within the CIDR range of this instance.
+   * @param ipToCheck - The IPv6 address to check.
+   * @returns True if the address is within the CIDR range, otherwise false.
+   */
+  contains(ipToCheck: string): boolean {
+    const maskBits = this.asBitmask();
+
+    const ipValue = BigInt(`0x${this.expandIPv6(ipToCheck).replace(/:/g, "")}`);
+    const cidrIpValue = BigInt(`0x${this.maskedIp}`);
+
+    return (ipValue & maskBits) === cidrIpValue;
+  }
+}

--- a/packages/dashboard/tests/unit/nodePublicConfig.test.ts
+++ b/packages/dashboard/tests/unit/nodePublicConfig.test.ts
@@ -1,0 +1,16 @@
+import { IP6 } from "../../src/portal/lib/ips";
+
+test("IP6 contains", () => {
+  const ip6Range = new IP6("2001:db8::/64");
+  expect(ip6Range.contains("2001:db8::1")).toBe(true);
+  expect(ip6Range.contains("2001:db8:1234::1")).toBe(false);
+});
+test("IP expand", () => {
+  const ip6Range = new IP6("2001:db8::/64"); // Creating an IP range with a /64 mask
+  expect(ip6Range.expandIPv6("2001:db8::")).toBe("2001:0db8:0000:0000:0000:0000:0000:0000");
+  expect(ip6Range.expandIPv6("2001:db8::1")).toBe("2001:0db8:0000:0000:0000:0000:0000:0001");
+  expect(ip6Range.expandIPv6("2001:db8:abcd::")).toBe("2001:0db8:abcd:0000:0000:0000:0000:0000");
+  expect(ip6Range.expandIPv6("1::")).toBe("0001:0000:0000:0000:0000:0000:0000:0000");
+  expect(ip6Range.expandIPv6("::1")).toBe("0000:0000:0000:0000:0000:0000:0000:0001");
+  expect(ip6Range.expandIPv6("12::1::")).toBe("0012:0000:0001:0000:0000:0000:0000");
+});

--- a/packages/dashboard/tests/unit/nodePublicConfig.test.ts
+++ b/packages/dashboard/tests/unit/nodePublicConfig.test.ts
@@ -1,10 +1,17 @@
-import { IP6 } from "../../src/portal/lib/ips";
+import { IP4, IP6 } from "../../src/portal/lib/ips";
+
+test("IP4 contains", () => {
+  const ip4Range = new IP4("192.168.0.0/24");
+  expect(ip4Range.contains("192.168.0.1")).toBe(true);
+  expect(ip4Range.contains("192.168.1.1")).toBe(false);
+});
 
 test("IP6 contains", () => {
   const ip6Range = new IP6("2001:db8::/64");
   expect(ip6Range.contains("2001:db8::1")).toBe(true);
   expect(ip6Range.contains("2001:db8:1234::1")).toBe(false);
 });
+
 test("IP expand", () => {
   const ip6Range = new IP6("2001:db8::/64"); // Creating an IP range with a /64 mask
   expect(ip6Range.expandIPv6("2001:db8::")).toBe("2001:0db8:0000:0000:0000:0000:0000:0000");
@@ -12,5 +19,5 @@ test("IP expand", () => {
   expect(ip6Range.expandIPv6("2001:db8:abcd::")).toBe("2001:0db8:abcd:0000:0000:0000:0000:0000");
   expect(ip6Range.expandIPv6("1::")).toBe("0001:0000:0000:0000:0000:0000:0000:0000");
   expect(ip6Range.expandIPv6("::1")).toBe("0000:0000:0000:0000:0000:0000:0000:0001");
-  expect(ip6Range.expandIPv6("12::1::")).toBe("0012:0000:0001:0000:0000:0000:0000");
+  expect(ip6Range.expandIPv6("12::1::")).toBe("0012:0000:0001:0000:0000:0000:0000:0000");
 });


### PR DESCRIPTION
### Description
The current ip validation not check if the given gw belogs to the provided ip in both ipv4 and ipv6 
I this pr I tried to implement a similar logic to that used in the chain. for now the classes only used to check if the given ip gw belongs to the original ip
valid gw6 :
    ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/359afe57-2b86-42a6-a85c-99073a49b671)
    ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/ce45d4b4-e427-4581-a48e-1a87aea04eb1)
invalid ones:
    ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/b7d0a493-5127-466c-9bc1-64d98049c196)
    ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/017bb396-ec23-4c29-95bb-39f160f79bfc)


### Changes

- add ips file that contains:
  - ip6 class: which contains two function 
      - `expand` to format the given ipv6 and handle the various format cases
      - 'contains' to check if the passed ip is whitin the base ip range
  - ip4 class: only the contains function similar to the one in IP6 class 
  - use the contains classes in `FarmNodesTable` as extra validation to validate if the __valid__ gw is belongs to the provided ip
  - create some unit tests to make it easier to add more tests
### Related Issues

- #924 

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
