### PR TITLE
add a breathing space between the header and the subheader in the profile connector

### DIFF
--- a/packages/dashboard/src/components/TfChainConnector.vue
+++ b/packages/dashboard/src/components/TfChainConnector.vue
@@ -32,7 +32,7 @@
       </template>
 
       <v-card>
-        <v-card-title>Connect your TFChain Wallet</v-card-title>
+        <v-card-title class="mb-2">Connect your TFChain Wallet</v-card-title>
         <v-card-subtitle>
           Please visit
           <a href="https://manual.grid.tf/dashboard/dashboard.html#tfchain-wallet" target="_blank">the manual</a> get


### PR DESCRIPTION
### Description

add a breathing space between the header and the subheader in the profile connector

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/952

### Screenshots
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/6bcb5aa8-459c-4882-8c81-60b7b8ccafe5)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
