### PR TITLE
Fix disappearance of locked TFTs

### DIFF
--- a/packages/dashboard/src/components/TfChainConnector.vue
+++ b/packages/dashboard/src/components/TfChainConnector.vue
@@ -373,7 +373,6 @@ export default class TfChainConnector extends Vue {
   stopBalanceInterval() {
     if (this.interval) {
       clearInterval(this.interval);
-      this.interval = null;
     }
   }
 

--- a/packages/dashboard/src/components/TfChainConnector.vue
+++ b/packages/dashboard/src/components/TfChainConnector.vue
@@ -358,7 +358,8 @@ export default class TfChainConnector extends Vue {
   @Watch("$store.state.credentials.balance", { deep: true })
   async balanceWatcher$(profile: any) {
     if (profile) {
-      this.balance = this.$store.state.credentials.balance;
+      this.balance.free = this.$store.state.credentials.balance.free;
+      this.balance.frozen = this.$store.state.credentials.balance.reserved;
     }
   }
 

--- a/packages/dashboard/src/portal/lib/balance.ts
+++ b/packages/dashboard/src/portal/lib/balance.ts
@@ -7,9 +7,8 @@ export interface balanceInterface {
 
 export async function getBalance(api: any, address: string) {
   const res = await api.query.system.account(address);
-
   return {
-    free: Math.floor((res.data.free.toJSON() / 1e7) * 1000) / 1000,
+    free: Math.floor((res.data.free.toJSON() / 1e7) * 1e7) / 1e7,
     transferable: Math.floor(((res.data.free.toJSON() - res.data.frozen.toJSON()) / 1e7) * 1000) / 1000,
     reserved: res.data.frozen.toJSON() / 1e7,
   };


### PR DESCRIPTION
- Fix disappearance of locked TFTs after performing any transaction.
- Fix format of TFTs that changes after any transaction to stay the same without refreshing.
- The balance of reciever will be updated every 2 min without refreshing or logging out to see recieved TFTs.
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/979
