### PR TITLE
Uppercase subheaders' first letters

### DIFF
--- a/packages/dashboard/src/explorer/components/InFilterV2.vue
+++ b/packages/dashboard/src/explorer/components/InFilterV2.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card flat color="transparent">
-    <v-subheader>{{ options.label.toLocaleUpperCase() }}</v-subheader>
+    <v-subheader>{{ options.label }}</v-subheader>
     <v-combobox
       :items="searchItems"
       chips

--- a/packages/dashboard/src/explorer/components/NodeFilter.vue
+++ b/packages/dashboard/src/explorer/components/NodeFilter.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card flat color="transparent">
-    <v-subheader>{{ label.toLocaleUpperCase() }}</v-subheader>
+    <v-subheader>{{ label }}</v-subheader>
     <v-text-field
       v-model="item"
       chips


### PR DESCRIPTION
### Changes

- Remove toLocaleUpperCase method from explorer subheaders

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/927

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
