### PR TITLE
Updating load more gateway nodes button

### DIFF
--- a/packages/playground/src/components/select_gateway_node.vue
+++ b/packages/playground/src/components/select_gateway_node.vue
@@ -27,6 +27,31 @@
         <template v-slot:append-item v-if="page !== -1">
           <div class="px-4 mt-4">
             <v-btn
+              v-if="gatewayOption == 'farm'"
+              block
+              color="secondary"
+              variant="tonal"
+              rounded="large"
+              size="large"
+              @click="loadNextPage"
+              :loading="loading"
+            >
+              Load More Gateway Nodes in {{ farmData?.name }}
+            </v-btn>
+            <v-btn
+              v-else-if="gatewayOption == 'country'"
+              block
+              color="secondary"
+              variant="tonal"
+              rounded="large"
+              size="large"
+              @click="loadNextPage"
+              :loading="loading"
+            >
+              Load More Gateway Nodes in {{ farmData?.country }}
+            </v-btn>
+            <v-btn
+              v-else
               block
               color="secondary"
               variant="tonal"
@@ -66,6 +91,7 @@ const items = ref<any[]>([]);
 const page = ref(1);
 const size = 50;
 const validator = ref();
+const gatewayOption = ref("");
 
 onMounted(loadNextPage);
 onUnmounted(() => emits("update:model-value", undefined));
@@ -84,6 +110,7 @@ async function loadNextPage() {
   validator.value?.setStatus(ValidatorStatus.Init);
   const grid = await getGrid(profileManager.profile!);
   let nodes = [];
+  gatewayOption.value = "farm";
   const options: gatewayFilters = {
     page: page.value++,
     size,
@@ -92,13 +119,15 @@ async function loadNextPage() {
   nodes = await loadGatewayNodes(grid!, options);
 
   if (!nodes.length && props.customDomain && props.farmData?.country) {
+    gatewayOption.value = "country";
     options.farmId = undefined;
     options.country = props.farmData.country;
     nodes = await loadGatewayNodes(grid!, options); // search in the same country
-  }
-  if (!nodes.length && props.customDomain) {
-    options.country = options.farmId = undefined;
-    nodes = await loadGatewayNodes(grid!, options); // search in the whole network
+    if (!nodes.length && props.customDomain) {
+      gatewayOption.value = "Network";
+      options.country = options.farmId = undefined;
+      nodes = await loadGatewayNodes(grid!, options); // search in the whole network
+    }
   }
 
   if (nodes.length === 0 || nodes.length < size) {


### PR DESCRIPTION
### Description

Updating the load more button content to  ```Load more  gateway nodes in <<farmName>>``` if more nodes are available in same farm, if not the country will be checked for gateway nodes if available content will be updated to ```Load more  gateway nodes in <<country>>```, finally the whole network will be checked for nodes and the button content will be ```Load more  gateway nodes```

![Screenshot from 2023-08-24 14-11-51](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/da7ffc42-4816-4fbc-855b-01678e5c6932)
![Screenshot from 2023-08-24 14-13-31](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/ac764e0f-e2eb-420a-a8d4-b72834d9270a)
![Screenshot from 2023-08-24 14-14-05](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/ba05dd67-4249-4dfa-9398-5cbf110ad449)

### Changes

List of changes this PR includes

### Related Issues

#829
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
