### PR TITLE
Release packages on npm with an edge tag 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+    env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -24,15 +25,20 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
-
+    
       - name: Install
         run: yarn --pure-lockfile
       - name: Build
         run: lerna run build --no-private
-      - name: Publish
+
+      - name: Publish Pre-release
+        if: contains(github.ref, 'rc')
+        run: lerna publish from-package --no-private --yes --dist-tag edge
+
+      - name: Publish Release
+        if: "!contains(github.ref, 'rc')"
         run: lerna publish from-package --no-private --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        
 
   docker-image-grid-client:
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
+
       - name: Install
         run: yarn --pure-lockfile
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
-    
       - name: Install
         run: yarn --pure-lockfile
       - name: Build


### PR DESCRIPTION
### Description

If the version that will be published is pre-release npm should still have the latest version as default version so we need to add  a tag to override the default tag `latest`.
in the workflow if the version contains `rc` the publish pre-release will execute and adding the ` --dist-tag edge`
else will not provide a tag so we will have the latest tag

### Changes

Add conditional commands that specify the the version tag `latest` or `edge` 

### Related Issues

- #993 
- 
### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
