### PR TITLE
Drop the disconnected event when disconnect method is called

### DIFF
--- a/packages/grid_client/scripts/connection.ts
+++ b/packages/grid_client/scripts/connection.ts
@@ -30,7 +30,7 @@ async function newClient(mnemonic: string) {
     await gridClient.connect();
 
     setTimeout(async () => {
-      console.log(`Requist the grid to get the twin id.`);
+      console.log(`Request the grid to get the twin id.`);
       const twinID = await gridClient.twins.get_my_twin_id();
       console.log(`Twin id: ${twinID}`);
     }, 10 * 60 * 1000);


### PR DESCRIPTION
### Description

the api object got deleted while disconnecting

### Changes

unify the disconnect handler to have the same signature when it's added(connecting) and removed(disconnecting)

### Related Issues

- #1046

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
