### PR TITLE
Fix grid nightly failing issue

### DIFF
--- a/packages/grid_client/scripts/kubernetes_with_qsfs.ts
+++ b/packages/grid_client/scripts/kubernetes_with_qsfs.ts
@@ -25,6 +25,7 @@ async function main() {
 
   const qsfsQueryOptions: FilterOptions = {
     hru: 6,
+    availableFor: grid3.twinId,
     farmId: 1,
   };
 


### PR DESCRIPTION
### Description

[Issue](https://github.com/threefoldtech/tfgrid-sdk-ts/actions/runs/6008601478/job/16296517664) with workflow was that filter was missing the available for the twin filter.  

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/109473873/591bed45-dd9e-4a98-bfa4-c7fc870c8f99)

