### PR TITLE
Make it clear for creating account

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -137,7 +137,7 @@
                           :loading="creatingAccount"
                           @click="openAcceptTerms = termsLoading = true"
                         >
-                          generate account
+                          create account
                         </VBtn>
                       </div>
                     </InputValidator>


### PR DESCRIPTION
### Description
Change the button `Generate Account` to  `Create Account` to be consistent with help text.

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/735

![Screenshot from 2023-09-17 11-51-54](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/38118c8b-9812-4436-837f-b682bd9f933a)


