### PR TITLE
Support nodes gpu filter

### DIFF
--- a/packages/gridproxy_client/src/builders/nodes.ts
+++ b/packages/gridproxy_client/src/builders/nodes.ts
@@ -1,4 +1,4 @@
-import { assertBoolean, assertId, assertIn, assertNatural, assertPattern, assertString } from "../utils";
+import { assertBoolean, assertId, assertIn, assertInt, assertNatural, assertPattern, assertString } from "../utils";
 import { AbstractBuilder, BuilderMapper, BuilderMethods, BuilderValidator } from "./abstract_builder";
 import { ID_PATTERN, NodeStatus } from "./gateways";
 
@@ -9,14 +9,18 @@ export interface NodesQuery {
   freeMru: number;
   freeHru: number;
   freeSru: number;
+  totalMru: number;
+  totalCru: number;
+  totalSru: number;
+  totalHru: number;
   freeIps: number;
   status: NodeStatus;
   city: string;
   country: string;
   farmName: string;
-  domain: boolean;
   ipv4: boolean;
   ipv6: boolean;
+  domain: boolean;
   dedicated: boolean;
   rentable: boolean;
   rented: boolean;
@@ -24,6 +28,13 @@ export interface NodesQuery {
   availableFor: number;
   farmIds: string;
   nodeId: number;
+  certificationType: "NotCertified" | "Silver" | "Gold";
+  hasGpu: boolean;
+  gpuDeviceId: string;
+  gpuDeviceName: string;
+  gpuVendorId: string;
+  gpuVendorName: string;
+  gpuAvailable: boolean;
 }
 
 const NODES_MAPPER: BuilderMapper<NodesQuery> = {
@@ -48,6 +59,17 @@ const NODES_MAPPER: BuilderMapper<NodesQuery> = {
   availableFor: "available_for",
   farmIds: "farm_ids",
   nodeId: "node_id",
+  certificationType: "certification_type",
+  gpuAvailable: "gpu_available",
+  gpuDeviceId: "gpu_device_id",
+  gpuDeviceName: "gpu_device_name",
+  gpuVendorId: "gpu_vendor_id",
+  gpuVendorName: "gpu_vendor_name",
+  hasGpu: "has_gpu",
+  totalCru: "total_cru",
+  totalHru: "total_hru",
+  totalMru: "total_mru",
+  totalSru: "total_sru",
 };
 
 const NODES_VALIDATOR: BuilderValidator<NodesQuery> = {
@@ -79,6 +101,19 @@ const NODES_VALIDATOR: BuilderValidator<NodesQuery> = {
     });
   },
   nodeId: assertId,
+  certificationType(value) {
+    assertIn(value, ["NotCertified", "Silver", "Gold"]);
+  },
+  gpuAvailable: assertBoolean,
+  gpuDeviceId: assertString,
+  gpuDeviceName: assertString,
+  gpuVendorId: assertString,
+  gpuVendorName: assertString,
+  hasGpu: assertBoolean,
+  totalCru: assertInt,
+  totalHru: assertInt,
+  totalMru: assertInt,
+  totalSru: assertInt,
 };
 
 export class NodesBuilder extends AbstractBuilder<NodesQuery> {
@@ -91,4 +126,5 @@ export class NodesBuilder extends AbstractBuilder<NodesQuery> {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface NodesBuilder extends BuilderMethods<NodesQuery, NodesBuilder> {}

--- a/packages/gridproxy_client/src/modules/gateways.ts
+++ b/packages/gridproxy_client/src/modules/gateways.ts
@@ -1,6 +1,6 @@
-import { AbstractClient } from "./abstract_client";
 import { CertificationType, GatewayBuilder, GatewaysQuery, NodeStatus } from "../builders/public_api";
 import { assertId, resolvePaginator } from "../utils";
+import { AbstractClient } from "./abstract_client";
 import { Farm } from "./farms";
 
 export interface Resources {
@@ -19,6 +19,12 @@ export interface PublicConfig {
   gw6: string;
   ipv4: string;
   ipv6: string;
+}
+
+export interface PublicIps {
+  total: number;
+  used: number;
+  free: number;
 }
 
 export interface GridNode {
@@ -43,6 +49,7 @@ export interface GridNode {
   rentContractId: number;
   rentedByTwinId: number;
   farm: Farm;
+  publicIps: PublicIps;
 }
 
 export class GatewaysClient extends AbstractClient<GatewayBuilder, GatewaysQuery> {

--- a/packages/gridproxy_client/src/modules/nodes.ts
+++ b/packages/gridproxy_client/src/modules/nodes.ts
@@ -1,9 +1,9 @@
-import { resolvePaginator } from "../utils";
-import { NodesBuilder, type NodesQuery } from "../builders/nodes";
-import { AbstractClient } from "./abstract_client";
-import type { GridNode } from "./gateways";
-import type { Farm, FarmsClient } from "./farms";
 import type { Pagination } from "../builders/abstract_builder";
+import { NodesBuilder, type NodesQuery } from "../builders/nodes";
+import { resolvePaginator } from "../utils";
+import { AbstractClient } from "./abstract_client";
+import type { Farm, FarmsClient } from "./farms";
+import type { GridNode, PublicIps } from "./gateways";
 
 export interface NodesExtractOptions {
   loadFarm?: boolean;
@@ -70,7 +70,21 @@ export class NodesClient extends AbstractClient<NodesBuilder, NodesQuery> {
   }
 
   private setFarm(node: GridNode): GridNode {
-    node.farm = this.farms.get(node.farmId)!;
+    const farm = this.farms.get(node.farmId);
+    if (farm) {
+      node.farm = farm;
+      node.publicIps = this.getFarmPublicIps(farm);
+    }
     return node;
+  }
+
+  private getFarmPublicIps(farm: Farm): PublicIps {
+    const total = farm.publicIps.length;
+    const free = farm.publicIps.filter(({ contractId }) => contractId === 0).length;
+    return {
+      total,
+      used: total - free,
+      free,
+    };
   }
 }


### PR DESCRIPTION
## Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1068

#### Usage

```ts
import GridProxyClient, { Network } from "@threefold/gridproxy_client"

const client = new GridProxyClient(Network.Dev)
client.nodes.list({}, { loadFarm: true }).then(console.log)
// loadFarm is an extra option which will load farm related to that node (load farm will be once for all nodes with same farm)
// then assign that farm to it's node and calculate publicIps related info
```

