### PR TITLE
Remove an extra line for encoding content to base24.

### DIFF
--- a/packages/UI/examples/server-example/src/server.ts
+++ b/packages/UI/examples/server-example/src/server.ts
@@ -27,8 +27,7 @@ type Payload = {
 
 const verify = async (payload: Payload) => {
   try {
-    const content = Uint8Array.from(Buffer.from(payload.content || "", "base64"));
-    const hash = MD5(content.toString()).toString();
+    const hash = MD5(payload.content!).toString();
 
     const messageBytes = Uint8Array.from(Buffer.from(hash.toString(), "hex"));
     const keyring = new Keyring({ type: payload.keypairType });
@@ -38,9 +37,8 @@ const verify = async (payload: Payload) => {
     const key = keyring.addFromAddress(payload.pubkey);
     const sig = Uint8Array.from(Buffer.from(payload.signature, "hex"));
 
-    // Verify the signature
-    const isValid = key.verify(messageBytes, sig, key.publicKey);
-    return { isValid };
+    // Verify and return the signature
+    return key.verify(messageBytes, sig, key.publicKey);
   } catch (error) {
     console.error(error);
     // Handle any errors that occur during the verification process


### PR DESCRIPTION
### Description

Remove an extra line for encoding content to base24 in the server.ts example.

### Related Issues

- See this comment https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1127#issuecomment-1732535918

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
