### PR TITLE
Add support to load gpu cards of a node in gridproxy

### DIFF
--- a/packages/gridproxy_client/src/modules/gateways.ts
+++ b/packages/gridproxy_client/src/modules/gateways.ts
@@ -13,6 +13,8 @@ export interface Resources {
 export interface Location {
   country: string;
   city: string;
+  longitude: number;
+  latitude: number;
 }
 export interface PublicConfig {
   domain: string;
@@ -36,6 +38,13 @@ export interface NodeStats {
     deployments: number;
     workloads: number;
   };
+}
+
+export interface GPUCard {
+  id: string;
+  vendor: string;
+  device: string;
+  contract: number;
 }
 
 export interface GridNode {
@@ -63,6 +72,7 @@ export interface GridNode {
   publicIps: PublicIps;
   twin: Twin;
   stats: NodeStats;
+  cards: GPUCard[];
 }
 
 export class GatewaysClient extends AbstractClient<GatewayBuilder, GatewaysQuery> {


### PR DESCRIPTION
## Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1169

### Usage

```ts
import GridProxyClient, { Network } from "./modules/public_api";

const gridProxyClient = new GridProxyClient(Network.Dev);

// Load single node gpu cards info
const node14Cards = await gridProxyClient.nodes.gpuById(14)

// Load gpu cards while loading node itself
const node14 = await gridProxyClient.nodes.byId(14, { loadGpu: true })

// Load page of nodes with gpu cards info
const nodes = await gridProxyClient.nodes.list({}, { loadGpu: true })

```