### PR TITLE
Checking for free public IPs before deploying the instances

### DIFF
--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -5,7 +5,7 @@ import { TFClient } from "../clients/tf-grid/client";
 import { GridClientConfig } from "../config";
 import { events } from "../helpers/events";
 import { validateObject } from "../helpers/validator";
-import { DeploymentFactory, NodeInfo, Nodes } from "../primitives/index";
+import { DeploymentFactory, Nodes } from "../primitives/index";
 import { Workload, WorkloadTypes } from "../zos/workload";
 import { Operations, TwinDeployment } from "./models";
 class TwinDeploymentHandler {
@@ -269,15 +269,22 @@ class TwinDeploymentHandler {
     const farmIPs: Map<number, number> = new Map();
 
     for (const twinDeployment of twinDeployments) {
-      if (twinDeployment.operation === Operations.deploy) {
-        const node = await this.nodes.getNode(twinDeployment.nodeId);
-        if (node) {
-          if (!farmIPs.has(node.farmId)) {
-            farmIPs.set(node.farmId, twinDeployment.publicIps);
-          } else {
-            farmIPs.set(node.farmId, farmIPs.get(node.farmId)! + twinDeployment.publicIps);
-          }
-        }
+      if (twinDeployment.operation !== Operations.deploy) {
+        continue;
+      }
+
+      if (twinDeployment.publicIps === 0) {
+        continue;
+      }
+
+      const node = await this.nodes.getNode(twinDeployment.nodeId);
+      if (!node) {
+        continue;
+      }
+      if (!farmIPs.has(node.farmId)) {
+        farmIPs.set(node.farmId, twinDeployment.publicIps);
+      } else {
+        farmIPs.set(node.farmId, farmIPs.get(node.farmId)! + twinDeployment.publicIps);
       }
     }
 

--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -267,27 +267,29 @@ class TwinDeploymentHandler {
 
   async checkFarmIps(twinDeployments: TwinDeployment[]) {
     const farmIPs: Map<number, number> = new Map();
+
     for (const twinDeployment of twinDeployments) {
       if (twinDeployment.operation === Operations.deploy) {
         const node = await this.nodes.getNode(twinDeployment.nodeId);
         if (node) {
-          if (!(node.farmId in farmIPs)) {
+          if (!farmIPs.has(node.farmId)) {
             farmIPs.set(node.farmId, twinDeployment.publicIps);
           } else {
-            farmIPs.set(node.farmId, farmIPs[node.farmId] + twinDeployment.publicIps);
+            farmIPs.set(node.farmId, farmIPs.get(node.farmId)! + twinDeployment.publicIps);
           }
         }
       }
     }
 
-    for (const farm of Object.keys(farmIPs)) {
-      const _farm = await this.nodes.filterFarms({
-        farmId: +farm,
-      });
-      const freeIps = _farm[0].publicIps.filter(res => res.contract_id === 0).length;
-      if (freeIps < farmIPs[farm]) {
+    for (const farmId of farmIPs.keys()) {
+      const _farm = await this.tfclient.farms.get({ id: farmId });
+      const freeIps = _farm.publicIps.filter(res => res.contractId === 0).length;
+
+      if (freeIps < farmIPs.get(farmId)!) {
         throw Error(
-          `Farm ${farm} doesn't have enough public IPs: requested IPs=${farmIPs[farm]}, avaiable IPs=${freeIps}`,
+          `Farm ${farmId} doesn't have enough public IPs: requested IPs=${farmIPs.get(
+            farmId,
+          )}, available IPs=${freeIps}`,
         );
       }
     }

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -596,6 +596,7 @@ class FarmFilterOptions {
   @Expose() @IsOptional() @IsInt() @Min(1) nodeRentedBy?: number;
   @Expose() @IsOptional() @IsInt() page?: number;
   @Expose() @IsOptional() @IsInt() size?: number;
+  @Expose() @IsOptional() @IsInt() farmId?: number;
 }
 
 class CalculatorModel {

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -24,6 +24,7 @@ interface PublicIps {
   id: string;
   ip: string;
   contractId: number;
+  contract_id: number; // Added to match the one in the farm interface || TODO: Should we replace the whole http requests to be done with the gridProxy.
   gateway: string;
 }
 
@@ -382,6 +383,7 @@ class Nodes {
       node_has_gpu: options.nodeHasGPU,
       node_rented_by: options.nodeRentedBy,
       node_certified: options.nodeCertified,
+      farm_id: options.farmId,
     };
     return Object.entries(params)
       .map(param => param.join("="))

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -23,7 +23,6 @@ interface FarmInfo {
 interface PublicIps {
   id: string;
   ip: string;
-  contractId: number;
   contract_id: number; // Added to match the one in the farm interface || TODO: Should we replace the whole http requests to be done with the gridProxy.
   gateway: string;
 }
@@ -177,7 +176,7 @@ class Nodes {
       farms = await this.getAllFarms(url);
     }
     return farms
-      .filter(farm => farm.publicIps.filter(ip => ip.contractId === 0).length > 0)
+      .filter(farm => farm.publicIps.filter(ip => ip.contract_id === 0).length > 0)
       .map(farm => farm.farmId)
       .includes(farmId);
   }


### PR DESCRIPTION
### Description

Declared a new field that matches the farmId in the response of the grid proxy, created a new method 'checkFarmIps' inside the 'TwinDeploymentHandler' to check if the deployment farm has the requested ips

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1136

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/dd5bf492-fda3-4d63-b3a4-21094ae0d8b1)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
