### PR TITLE
added wireguard access to umbrel

### DIFF
--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -116,7 +116,7 @@ const filteredHeaders = computed(() => {
     { title: "Public IPv4", key: "ipv4" },
     { title: "Public IPv6", key: "ipv6" },
     { title: "Planetary Network IP", key: "planetary" },
-    { title: "Wireguard", key: "wireguard" },
+    { title: "WireGuard", key: "wireguard" },
     { title: "Flist", key: "flist" },
     { title: "Cost", key: "billing" },
     { title: "Actions", key: "actions" },
@@ -134,7 +134,7 @@ const filteredHeaders = computed(() => {
     ProjectName.Nextcloud,
   ] as string[];
 
-  const WireguardSolutions = [ProjectName.VM, ProjectName.Fullvm] as string[];
+  const WireguardSolutions = [ProjectName.VM, ProjectName.Fullvm, ProjectName.Umbrel] as string[];
 
   const flistSolutions = [ProjectName.VM, ProjectName.Fullvm] as string[];
 

--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -248,7 +248,9 @@
               'http://' +
               (item.value[0].publicIP?.ip
                 ? item.value[0].publicIP.ip.slice(0, -3)
-                : '[' + item.value[0].planetary + ']')
+                : item.value[0].planetary
+                ? '[' + item.value[0].planetary + ']'
+                : item.value[0].interfaces[0].ip)
             "
           />
         </template>

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -142,6 +142,7 @@ const name = ref(generateName({ prefix: "um" }));
 const username = ref("admin");
 const password = ref(generatePassword());
 const ipv4 = ref(false);
+const wireguard = ref(true);
 const solution = ref() as Ref<SolutionFlavor>;
 const farm = ref() as Ref<Farm>;
 const loadingFarm = ref(false);
@@ -166,6 +167,9 @@ async function deploy() {
 
     const vm = await deployVM(grid!, {
       name: name.value,
+      network: {
+        addAccess: wireguard.value,
+      },
       machines: [
         {
           name: name.value,

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -65,7 +65,14 @@
         </input-validator>
       </password-input-wrapper>
 
-      <Network v-model:ipv4="ipv4" :disabled="loadingFarm" />
+      <Network
+        required
+        ref="network"
+        v-model:ipv4="ipv4"
+        v-model:planetary="planetary"
+        v-model:wireguard="wireguard"
+        :disabled="loadingFarm"
+      />
 
       <SelectSolutionFlavor
         v-model="solution"
@@ -124,6 +131,7 @@
 <script lang="ts" setup>
 import { computed, type Ref, ref } from "vue";
 
+import Network from "../components/networks.vue";
 import { useLayout } from "../components/weblet_layout.vue";
 import { useProfileManager } from "../stores";
 import type { Farm, Flist, solutionFlavor as SolutionFlavor } from "../types";
@@ -142,7 +150,9 @@ const name = ref(generateName({ prefix: "um" }));
 const username = ref("admin");
 const password = ref(generatePassword());
 const ipv4 = ref(false);
-const wireguard = ref(true);
+const planetary = ref(true);
+const wireguard = ref(false);
+const network = ref();
 const solution = ref() as Ref<SolutionFlavor>;
 const farm = ref() as Ref<Farm>;
 const loadingFarm = ref(false);
@@ -190,7 +200,7 @@ async function deploy() {
           farmId: farm.value.farmID,
           farmName: farm.value.name,
           country: farm.value.country,
-          planetary: true,
+          planetary: planetary.value,
           publicIpv4: ipv4.value,
           envs: [
             { key: "SSH_KEY", value: profileManager.profile!.ssh },


### PR DESCRIPTION
From [this issue](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1209) this PR adds the wireguard access for Umbrel on the Playground.

Did some testings and it works fine. 

***

EDIT: New commits include those changes:

* Added WireGuard and IPv4 network options
  * Nested ternary for network options (IPv4, Planetary, WireGuard) 
* IPv4 wasn't set completely on the Umbrel weblet
  * Now users can decide to use the 3 network options and the Admin panel button adjust accordingly with the proper link
* Added Umbrel in the WireGuard table so users can see the address when they use WireGuard
* Planetary is set by default to true
* One network choice is required as a minimum