### PR TITLE
fix tft conversion

### DIFF
--- a/packages/playground/src/components/swap_price.vue
+++ b/packages/playground/src/components/swap_price.vue
@@ -55,7 +55,7 @@ async function getTFTPrice(): Promise<number> {
   try {
     const client = new QueryClient(window.env.SUBSTRATE_URL);
     const res = await client.tftPrice.get();
-    return res;
+    return res / 1000;
   } catch (e) {
     console.log(e);
     return 0;


### PR DESCRIPTION
### Description

Fixed the TFT conversion in the new playground.

- Before

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/4299cbdb-e38c-4ea3-8556-cac5336641ae)


- After

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/6b59bd36-cf10-4bd9-a45d-e332d77b880e)


### Changes

- Divided the returned tft price by 1000 since the price returned from the chain is in milliTFT.

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/27215140-4116-409c-b322-554aef9c28c8)

### Related Issues

#1227 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
