### PR TITLE
adding grid services link

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -260,6 +260,11 @@ const routes: AppRoute[] = [
         icon: "mdi-open-in-new",
         url: "https://hub.grid.tf/",
       },
+      {
+        title: "Grid Services",
+        icon: "mdi-open-in-new",
+        url: "https://status.grid.tf/status/threefold",
+      },
     ],
   },
   {

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -319,8 +319,6 @@ $router.beforeEach((to, from, next) => {
 </script>
 
 <script lang="ts">
-import { title } from "process";
-
 import AppInfo from "./components/app_info.vue";
 import AppTheme from "./components/app_theme.vue";
 import ConnectWalletLanding from "./components/connect_wallet_landing.vue";

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -262,7 +262,7 @@ const routes: AppRoute[] = [
       },
       {
         title: "Grid Services",
-        icon: "mdi-open-in-new",
+        icon: "mdi-grid-large",
         url: "https://status.grid.tf/status/threefold",
       },
     ],

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -271,6 +271,11 @@ const routes: AppRoute[] = [
         icon: "mdi-open-in-new",
         url: "https://hub.grid.tf/",
       },
+    ],
+  },
+  {
+    title: "Grid Services",
+    items: [
       {
         title: "Grid Services",
         icon: "mdi-grid-large",
@@ -314,6 +319,8 @@ $router.beforeEach((to, from, next) => {
 </script>
 
 <script lang="ts">
+import { title } from "process";
+
 import AppInfo from "./components/app_info.vue";
 import AppTheme from "./components/app_theme.vue";
 import ConnectWalletLanding from "./components/connect_wallet_landing.vue";


### PR DESCRIPTION
### Description

Adding a link for [Grid Services](https://status.grid.tf/status/threefold) in the Other Services section.

### Changes

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/f7035278-103a-4b6c-a042-7be61bf3c9b5)

### Related Issues

#1199  

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
