### PR TITLE
Development 313 Gql contracts interface

### DIFF
--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -1,6 +1,7 @@
 import {
   ContractLockOptions,
   Contracts,
+  ExtrinsicResult,
   GetDedicatedNodePriceOptions,
   SetDedicatedNodeExtraFeesOptions,
 } from "@threefold/tfchain_client";
@@ -13,6 +14,46 @@ export interface ListContractByTwinIdOptions {
   graphqlURL: string;
   twinId: number;
   stateList?: ContractStates[];
+}
+
+export interface ContractUsedResources {
+  contract: GqlNodeContract;
+  hru: number;
+  sru: number;
+  cru: number;
+  mru: number;
+}
+
+export interface GqlBaseContract {
+  id: string;
+  gridVersion: string;
+  contractID: string;
+  twinID: string;
+  state: string;
+  createdAt: string;
+  solutionProviderID: string;
+}
+
+export interface GqlNameContract extends GqlBaseContract {
+  name: string;
+}
+
+export interface GqlNodeContract extends GqlBaseContract {
+  nodeID: number;
+  deploymentData: string;
+  deploymentHash: string;
+  numberOfPublicIPs: number;
+  resourcesUsed: ContractUsedResources;
+}
+
+export interface GqlRentContract extends GqlBaseContract {
+  nodeID: number;
+}
+
+export interface GqlContracts {
+  nameContracts: GqlNameContract[];
+  nodeContracts: GqlNodeContract[];
+  rentContracts: GqlRentContract[];
 }
 
 export interface ListContractByAddressOptions {
@@ -36,7 +77,7 @@ export interface CancelMyContractOptions {
 }
 
 class TFContracts extends Contracts {
-  async listContractsByTwinId(options: ListContractByTwinIdOptions) {
+  async listContractsByTwinId(options: ListContractByTwinIdOptions): Promise<GqlContracts> {
     options.stateList = options.stateList || [ContractStates.Created, ContractStates.GracePeriod];
     const state = `[${options.stateList.join(", ")}]`;
     const gqlClient = new Graphql(options.graphqlURL);
@@ -77,7 +118,8 @@ class TFContracts extends Contracts {
         rentContractsCount: rentContractsCount,
       });
 
-      return response["data"];
+      const data = response["data"] as GqlContracts;
+      return data;
     } catch (err) {
       throw Error(`Error listing contracts by twin id ${options.twinId}: ${err}`);
     }
@@ -108,7 +150,8 @@ class TFContracts extends Contracts {
           }`;
     try {
       const response = await gqlClient.query(body, { contractId: options.id });
-      const billReports = response["data"]["contractBillReports"];
+      const gqlContracts: GqlContracts = response["data"] as GqlContracts;
+      const billReports = ["contractBillReports"];
       if (billReports.length === 0) {
         return 0;
       } else {
@@ -117,19 +160,20 @@ class TFContracts extends Contracts {
         if (billReports.length === 2) {
           duration = (billReports[0]["timestamp"] - billReports[1]["timestamp"]) / 3600; // one hour
         } else {
-          const nodeContracts = response["data"]["nodeContracts"];
-          const nameContracts = response["data"]["nameContracts"];
-          const rentContracts = response["data"]["rentContracts"];
           let createdAt: number;
-          for (const contracts of [nodeContracts, nameContracts, rentContracts]) {
+          for (const contracts of [
+            gqlContracts.nodeContracts,
+            gqlContracts.nameContracts,
+            gqlContracts.rentContracts,
+          ]) {
             if (contracts.length === 1) {
-              createdAt = contracts[0]["createdAt"];
+              createdAt = +contracts[0].createdAt;
               duration = (billReports[0]["timestamp"] - createdAt) / 3600;
               break;
             }
           }
         }
-        if (!duration) {
+        if (!duration!) {
           duration = 1;
         }
         return amountBilled
@@ -151,7 +195,7 @@ class TFContracts extends Contracts {
     });
   }
 
-  async listMyContracts(options: ListMyContractOptions) {
+  async listMyContracts(options: ListMyContractOptions): Promise<GqlContracts> {
     const twinId = await this.client.twins.getMyTwinId();
     return await this.listContractsByTwinId({
       graphqlURL: options.graphqlURL,
@@ -172,23 +216,22 @@ class TFContracts extends Contracts {
    * @param  {CancelMyContractOptions} options
    * @returns {Promise<Record<string, number>[]>}
    */
-  async cancelMyContracts(options: CancelMyContractOptions): Promise<Record<string, number>[]> {
+  async cancelMyContracts(
+    options: CancelMyContractOptions,
+  ): Promise<(GqlNameContract | GqlRentContract | GqlNodeContract)[]> {
     const allContracts = await this.listMyContracts(options);
-    const contracts = [
-      ...allContracts["nameContracts"],
-      ...allContracts["nodeContracts"],
-      ...allContracts["rentContracts"],
-    ];
+    const contracts = [...allContracts.nameContracts, ...allContracts.nodeContracts, ...allContracts.rentContracts];
+
     const ids: number[] = [];
     for (const contract of contracts) {
-      ids.push(contract["contractID"]);
+      ids.push(+contract.contractID);
     }
     await this.batchCancelContracts(ids);
     return contracts;
   }
 
   async batchCancelContracts(ids: number[]): Promise<number[]> {
-    const extrinsics = [];
+    const extrinsics: ExtrinsicResult<number>[] = [];
     for (const id of ids) {
       extrinsics.push(await this.cancel({ id }));
     }

--- a/packages/grid_client/src/modules/contracts.ts
+++ b/packages/grid_client/src/modules/contracts.ts
@@ -1,5 +1,6 @@
 import * as PATH from "path";
 
+import { GqlNameContract, GqlNodeContract, GqlRentContract } from "../clients/tf-grid";
 import { TFClient } from "../clients/tf-grid/client";
 import { GridClientConfig } from "../config";
 import { events } from "../helpers/events";
@@ -218,10 +219,10 @@ class Contracts {
   @expose
   @validateInput
   @checkBalance
-  async cancelMyContracts(): Promise<Record<string, number>[]> {
+  async cancelMyContracts(): Promise<(GqlNameContract | GqlRentContract | GqlNodeContract)[]> {
     const contracts = await this.client.contracts.cancelMyContracts({ graphqlURL: this.config.graphqlURL });
     for (const contract of contracts) {
-      await this.invalidateDeployment(contract.contractId);
+      await this.invalidateDeployment(+contract.contractID);
     }
     return contracts;
   }


### PR DESCRIPTION
- Created an interface for the `NodeContract`, `NameContract`, and `RentContract`.

example 
```ts
export interface GqlContracts {
  nameContracts: GqlNameContract[];
  nodeContracts: GqlNodeContract[];
  rentContracts: GqlRentContract[];
}
```

### Related Issues 

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1254