### PR TITLE
replace password tooltip with a hint

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -190,14 +190,21 @@
                   #="{ props: validationProps }"
                   ref="passwordInput"
                 >
-                  <VTextField
-                    label="Password"
-                    v-model="password"
-                    v-bind="{ ...passwordInputProps, ...validationProps }"
-                    :disabled="creatingAccount || activatingAccount || activating"
-                    hint="Used to encrypt your mnemonic on your local system, and is used to login from the same device."
-                    class="mb-4"
-                  />
+                  <v-tooltip
+                    location="top right"
+                    text="Used to encrypt your mnemonic on your local system, and is used to login from the same device."
+                  >
+                    <template #activator="{ props: tooltipProps }">
+                      <div v-bind="tooltipProps">
+                        <VTextField
+                          label="Password"
+                          v-model="password"
+                          v-bind="{ ...passwordInputProps, ...validationProps }"
+                          :disabled="creatingAccount || activatingAccount || activating"
+                        />
+                      </div>
+                    </template>
+                  </v-tooltip>
                 </InputValidator>
               </PasswordInputWrapper>
 

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -190,21 +190,14 @@
                   #="{ props: validationProps }"
                   ref="passwordInput"
                 >
-                  <v-tooltip
-                    location="bottom"
-                    text="Used to encrypt your mnemonic on your local system, and is used to login from the same device."
-                  >
-                    <template #activator="{ props: tooltipProps }">
-                      <div v-bind="tooltipProps">
-                        <VTextField
-                          label="Password"
-                          v-model="password"
-                          v-bind="{ ...passwordInputProps, ...validationProps }"
-                          :disabled="creatingAccount || activatingAccount || activating"
-                        />
-                      </div>
-                    </template>
-                  </v-tooltip>
+                  <VTextField
+                    label="Password"
+                    v-model="password"
+                    v-bind="{ ...passwordInputProps, ...validationProps }"
+                    :disabled="creatingAccount || activatingAccount || activating"
+                    hint="Used to encrypt your mnemonic on your local system, and is used to login from the same device."
+                    class="mb-4"
+                  />
                 </InputValidator>
               </PasswordInputWrapper>
 


### PR DESCRIPTION
### Description

Moved the Password tooltip in the profile manager from the bottom to the upper right corner to avoid colliding with the Login button.

### Changes

- Before

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/6af2bf78-a752-4896-9f31-8f93819ea4b7)

- After

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/6bd79c61-38f6-46a9-86da-80cb6cc4fde3)


### Related Issues

#1262 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
