### PR TITLE
updated the return type of the pricing calculator 

### DIFF
--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -182,7 +182,7 @@
 </template>
 
 <script lang="ts" setup>
-import { watch } from "vue";
+import { capitalize, watch } from "vue";
 import { onMounted } from "vue";
 import { ref } from "vue";
 
@@ -261,8 +261,8 @@ async function setPriceList(pkgs: any): Promise<PriceType[]> {
       label: "Dedicated Node",
       price: `${pkgs.dedicatedPrice}`,
       color: "black",
-      packageName: pkgs.dedicatedPackage,
-      backgroundColor: color(pkgs.dedicatedPackage),
+      packageName: capitalize(pkgs.dedicatedPackage.package),
+      backgroundColor: color(pkgs.dedicatedPackage.package),
       TFTs: (+pkgs.dedicatedPrice / TFTPrice.value).toFixed(2),
       info: "A user can reserve an entire node then use it exclusively to deploy solutions",
     },
@@ -270,8 +270,8 @@ async function setPriceList(pkgs: any): Promise<PriceType[]> {
       label: "Shared Node",
       price: `${pkgs.sharedPrice}`,
       color: "black",
-      packageName: pkgs.sharedPackage,
-      backgroundColor: color(pkgs.sharedPackage),
+      packageName: capitalize(pkgs.sharedPackage.package),
+      backgroundColor: color(pkgs.sharedPackage.package),
       TFTs: (+pkgs.sharedPrice / TFTPrice.value).toFixed(2),
       info: "Shared Nodes allow several users to host various workloads on a single node",
     },


### PR DESCRIPTION
### Description

- Fixed the return types of the pricing calculator instead of returning [object Object].

- Capitalized the package Names. ex. `Gold` instead of `gold`

### Changes

- Before

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/c3ed3559-a36e-459c-b0a2-a8d1dc214f5f)


- After

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/11c13ba6-962f-443e-94dc-689a4d35ea76)


- Before

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/f3e471a1-72d6-4019-8307-7b321b86c6e1)

- After

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/c94d6462-0608-4bf7-958e-60309c9d1ff2)

### Related Issues

#1271 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
