### PR TITLE
[hotfix] list failed deployments with details in vm, k8s 

### DIFF
--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -15,6 +15,7 @@
         <v-card-title style="color: #ffcc00; font-weight: bold">Failed Deployments</v-card-title>
         <v-divider color="#FFCC00" />
         <v-card-text>
+          <div v-if="namesOfFailedDeployments === ''">Failed to load, Please contact support.</div>
           <div v-html="namesOfFailedDeployments"></div>
         </v-card-text>
         <v-card-actions class="justify-end">
@@ -130,7 +131,7 @@ function formatFailedDeployments(failedDeployments: []) {
         ", ",
       )}<br>`;
     } else {
-      formattedText += `- <strong>${deployment.name}<br>`;
+      formattedText += `- ${deployment.name}<br>`;
       showEncryption.value = true;
     }
   }

--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -112,9 +112,9 @@ async function loadDeployments() {
 
   const clusters = mergeLoadedDeployments(chunk1, chunk2, chunk3);
   const failedDeployments = [
-    ...(chunk1.count !== 0 ? (chunk3 as any).failedDeployments : []),
-    ...(chunk2.count !== 0 ? (chunk3 as any).failedDeployments : []),
-    ...(chunk3.count !== 0 ? (chunk3 as any).failedDeployments : []),
+    ...(Array.isArray((chunk1 as any).failedDeployments) ? (chunk1 as any).failedDeployments : []),
+    ...(Array.isArray((chunk2 as any).failedDeployments) ? (chunk2 as any).failedDeployments : []),
+    ...(Array.isArray((chunk3 as any).failedDeployments) ? (chunk3 as any).failedDeployments : []),
   ];
   namesOfFailedDeployments.value = formatFailedDeployments(failedDeployments as any);
   count.value = clusters.count;

--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -122,21 +122,23 @@ async function loadDeployments() {
   items.value = clusters.items;
   loading.value = false;
 }
-
 function formatFailedDeployments(failedDeployments: []) {
-  let formattedText = "";
+  let formattedText = "<ul>";
   for (const deployment of failedDeployments as { name: string; nodes: string[] }[]) {
     if (deployment.nodes.length > 0) {
-      formattedText += `- ${deployment.name} on node${deployment.nodes.length > 1 ? "s" : ""}: ${deployment.nodes.join(
-        ", ",
-      )}<br>`;
+      formattedText += ` <li>${deployment.name} on node${
+        deployment.nodes.length > 1 ? "s" : ""
+      }: ${deployment.nodes.join(", ")}</li>`;
     } else {
-      formattedText += `- ${deployment.name}<br>`;
+      formattedText += ` <li>${deployment.name}</li>`;
       showEncryption.value = true;
     }
   }
+  formattedText += "</ul>";
+
   return formattedText;
 }
+
 defineExpose({ loadDeployments });
 </script>
 

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -117,9 +117,9 @@ async function loadDeployments() {
       : await loadVms(updateGrid(grid!, { projectName: "" }), { filter });
   const vms = mergeLoadedDeployments(chunk1, chunk2, chunk3 as any);
   const failedDeployments = [
-    ...(chunk1 as any).failedDeployments,
-    ...(chunk2 as any).failedDeployments,
-    ...(chunk3.count !== 0 ? (chunk3 as any).failedDeployments : []),
+    ...(Array.isArray((chunk1 as any).failedDeployments) ? (chunk1 as any).failedDeployments : []),
+    ...(Array.isArray((chunk2 as any).failedDeployments) ? (chunk2 as any).failedDeployments : []),
+    ...(Array.isArray((chunk3 as any).failedDeployments) ? (chunk3 as any).failedDeployments : []),
   ];
   console.log("Failed Deployments: ", failedDeployments);
   namesOfFailedDeployments.value = formatFailedDeployments(failedDeployments as any);

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -121,9 +121,7 @@ async function loadDeployments() {
     ...(Array.isArray((chunk2 as any).failedDeployments) ? (chunk2 as any).failedDeployments : []),
     ...(Array.isArray((chunk3 as any).failedDeployments) ? (chunk3 as any).failedDeployments : []),
   ];
-  console.log("Failed Deployments: ", failedDeployments);
   namesOfFailedDeployments.value = formatFailedDeployments(failedDeployments as any);
-
   count.value = vms.count;
   items.value = vms.items;
 
@@ -138,7 +136,7 @@ function formatFailedDeployments(failedDeployments: []) {
         ", ",
       )}<br>`;
     } else {
-      formattedText += `- <strong>${deployment.name}<br>`;
+      formattedText += `- ${deployment.name}<br>`;
       showEncryption.value = true;
     }
   }

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -129,20 +129,21 @@ async function loadDeployments() {
 }
 
 function formatFailedDeployments(failedDeployments: []) {
-  let formattedText = "";
+  let formattedText = "<ul>";
   for (const deployment of failedDeployments as { name: string; nodes: string[] }[]) {
     if (deployment.nodes.length > 0) {
-      formattedText += `- ${deployment.name} on node${deployment.nodes.length > 1 ? "s" : ""}: ${deployment.nodes.join(
-        ", ",
-      )}<br>`;
+      formattedText += ` <li>${deployment.name} on node${
+        deployment.nodes.length > 1 ? "s" : ""
+      }: ${deployment.nodes.join(", ")}</li>`;
     } else {
-      formattedText += `- ${deployment.name}<br>`;
+      formattedText += ` <li>${deployment.name}</li>`;
       showEncryption.value = true;
     }
   }
+  formattedText += "</ul>";
+
   return formattedText;
 }
-
 const filteredHeaders = computed(() => {
   let headers = [
     { title: "PLACEHOLDER", key: "data-table-select" },

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -16,7 +16,17 @@
           <v-card-title style="color: #ffcc00; font-weight: bold">Failed Deployments</v-card-title>
           <v-divider color="#FFCC00" />
           <v-card-text>
-            <div v-html="namesOfFailedDeployments"></div>
+            <ul>
+              <li v-for="deployment in failedDeployments" :key="deployment.name">
+                {{
+                  deployment.nodes.length > 0
+                    ? `${deployment.name} on node${deployment.nodes.length > 1 ? "s" : ""}: ${deployment.nodes.join(
+                        ", ",
+                      )}`
+                    : deployment.name
+                }}
+              </li>
+            </ul>
           </v-card-text>
           <v-card-actions class="justify-end">
             <v-btn @click="showDialog = false" class="grey lighten-2 black--text" color="#FFCC00">Close</v-btn>
@@ -95,9 +105,9 @@ defineEmits<{ (event: "update:model-value", value: any[]): void }>();
 const loading = ref(false);
 const count = ref<number>();
 const items = ref<any[]>([]);
-const namesOfFailedDeployments = ref("");
 const showDialog = ref(false);
 const showEncryption = ref(false);
+const failedDeployments = ref<any[]>([]);
 
 onMounted(loadDeployments);
 async function loadDeployments() {
@@ -116,34 +126,17 @@ async function loadDeployments() {
       ? { count: 0, items: [] }
       : await loadVms(updateGrid(grid!, { projectName: "" }), { filter });
   const vms = mergeLoadedDeployments(chunk1, chunk2, chunk3 as any);
-  const failedDeployments = [
+  failedDeployments.value = [
     ...(Array.isArray((chunk1 as any).failedDeployments) ? (chunk1 as any).failedDeployments : []),
     ...(Array.isArray((chunk2 as any).failedDeployments) ? (chunk2 as any).failedDeployments : []),
     ...(Array.isArray((chunk3 as any).failedDeployments) ? (chunk3 as any).failedDeployments : []),
   ];
-  namesOfFailedDeployments.value = formatFailedDeployments(failedDeployments as any);
   count.value = vms.count;
   items.value = vms.items;
 
   loading.value = false;
 }
 
-function formatFailedDeployments(failedDeployments: []) {
-  let formattedText = "<ul>";
-  for (const deployment of failedDeployments as { name: string; nodes: string[] }[]) {
-    if (deployment.nodes.length > 0) {
-      formattedText += ` <li>${deployment.name} on node${
-        deployment.nodes.length > 1 ? "s" : ""
-      }: ${deployment.nodes.join(", ")}</li>`;
-    } else {
-      formattedText += ` <li>${deployment.name}</li>`;
-      showEncryption.value = true;
-    }
-  }
-  formattedText += "</ul>";
-
-  return formattedText;
-}
 const filteredHeaders = computed(() => {
   let headers = [
     { title: "PLACEHOLDER", key: "data-table-select" },

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -1,13 +1,28 @@
 <template>
   <div>
     <v-alert v-if="!loading && count && items.length < count" type="warning" variant="tonal">
-      Failed to load <strong>{{ count - items.length }}</strong> deployment{{ count - items.length > 1 ? "s" : "" }};
+      Failed to load <strong>{{ count - items.length }}</strong> deployment{{ count - items.length > 1 ? "s" : "" }}.
+
       <span>
-        This might happen because the node is down or it's not reachable or the deployment{{
-          count - items.length > 1 ? "s are" : " is"
-        }}
-        encrypted by another key.
+        This might happen because the node is down or it's not reachable
+        <span v-if="showEncryption"
+          >or the deployment{{ count - items.length > 1 ? "s are" : " is" }} encrypted by another key</span
+        >.
       </span>
+      <v-icon class="custom-icon" @click="showDialog = true">mdi-file-document-outline </v-icon>
+
+      <v-dialog transition="dialog-bottom-transition" v-model="showDialog" persistent max-width="500px">
+        <v-card>
+          <v-card-title style="color: #ffcc00; font-weight: bold">Failed Deployments</v-card-title>
+          <v-divider color="#FFCC00" />
+          <v-card-text>
+            <div v-html="namesOfFailedDeployments"></div>
+          </v-card-text>
+          <v-card-actions class="justify-end">
+            <v-btn @click="showDialog = false" class="grey lighten-2 black--text" color="#FFCC00">Close</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
     </v-alert>
 
     <ListTable
@@ -80,6 +95,9 @@ defineEmits<{ (event: "update:model-value", value: any[]): void }>();
 const loading = ref(false);
 const count = ref<number>();
 const items = ref<any[]>([]);
+const namesOfFailedDeployments = ref("");
+const showDialog = ref(false);
+const showEncryption = ref(false);
 
 onMounted(loadDeployments);
 async function loadDeployments() {
@@ -98,11 +116,33 @@ async function loadDeployments() {
       ? { count: 0, items: [] }
       : await loadVms(updateGrid(grid!, { projectName: "" }), { filter });
   const vms = mergeLoadedDeployments(chunk1, chunk2, chunk3 as any);
+  const failedDeployments = [
+    ...(chunk1 as any).failedDeployments,
+    ...(chunk2 as any).failedDeployments,
+    ...(chunk3.count !== 0 ? (chunk3 as any).failedDeployments : []),
+  ];
+  console.log("Failed Deployments: ", failedDeployments);
+  namesOfFailedDeployments.value = formatFailedDeployments(failedDeployments as any);
 
   count.value = vms.count;
   items.value = vms.items;
 
   loading.value = false;
+}
+
+function formatFailedDeployments(failedDeployments: []) {
+  let formattedText = "";
+  for (const deployment of failedDeployments as { name: string; nodes: string[] }[]) {
+    if (deployment.nodes.length > 0) {
+      formattedText += `- ${deployment.name} on node${deployment.nodes.length > 1 ? "s" : ""}: ${deployment.nodes.join(
+        ", ",
+      )}<br>`;
+    } else {
+      formattedText += `- <strong>${deployment.name}<br>`;
+      showEncryption.value = true;
+    }
+  }
+  return formattedText;
 }
 
 const filteredHeaders = computed(() => {
@@ -160,3 +200,9 @@ export default {
   },
 };
 </script>
+
+<style>
+.custom-icon {
+  float: right;
+}
+</style>

--- a/packages/playground/src/utils/load_deployment.ts
+++ b/packages/playground/src/utils/load_deployment.ts
@@ -22,7 +22,7 @@ export async function loadVms(grid: GridClient, options: LoadVMsOptions = {}) {
   let count = machines.length;
   const failedDeployments: FailedDeployment[] = [];
 
-  const promises = machines.map(async (name, index) => {
+  const promises = machines.map(async name => {
     const nodeIds = await grid.machines._getDeploymentNodeIds(name);
     const machinePromise = grid.machines.getObj(name);
     const timeoutPromise = new Promise((resolve, reject) => {

--- a/packages/playground/src/utils/load_deployment.ts
+++ b/packages/playground/src/utils/load_deployment.ts
@@ -1,7 +1,7 @@
 import type { GridClient } from "@threefold/grid_client";
 
 import { formatConsumption } from "./contracts";
-import { getGrid, updateGrid } from "./grid";
+import { updateGrid } from "./grid";
 import { normalizeError } from "./helpers";
 
 export interface LoadedDeployments<T> {
@@ -33,10 +33,12 @@ export async function loadVms(grid: GridClient, options: LoadVMsOptions = {}) {
 
     try {
       const result = await Promise.race([machinePromise, timeoutPromise]);
-
       if (result instanceof Error && result.message === "Timeout") {
         console.log(`%c[Error] Timeout loading deployment with name ${name}`, "color: rgb(207, 102, 121)");
         return null;
+      } else if ((result as any).length === 0) {
+        console.log(`%c[Error] failed to load deployment with name ${name}}`, "color: rgb(207, 102, 121)");
+        failedDeployments.push({ name, nodes: nodeIds });
       } else {
         return result;
       }
@@ -119,6 +121,9 @@ export async function loadK8s(grid: GridClient) {
       if (result instanceof Error && result.message === "Timeout") {
         console.log(`%c[Error] Timeout loading deployment with name ${name}`, "color: rgb(207, 102, 121)");
         return null;
+      } else if ((result as any).masters.length === 0 && (result as any).workers.length === 0) {
+        console.log(`%c[Error] failed to load deployment with name ${name}}`, "color: rgb(207, 102, 121)");
+        failedDeployments.push({ name, nodes: nodeIds });
       } else {
         return result;
       }

--- a/packages/playground/src/utils/load_deployment.ts
+++ b/packages/playground/src/utils/load_deployment.ts
@@ -37,7 +37,7 @@ export async function loadVms(grid: GridClient, options: LoadVMsOptions = {}) {
         console.log(`%c[Error] Timeout loading deployment with name ${name}`, "color: rgb(207, 102, 121)");
         return null;
       } else if ((result as any).length === 0) {
-        console.log(`%c[Error] failed to load deployment with name ${name}}`, "color: rgb(207, 102, 121)");
+        console.log(`%c[Error] failed to load deployment with name ${name}`, "color: rgb(207, 102, 121)");
         failedDeployments.push({ name, nodes: nodeIds });
       } else {
         return result;
@@ -122,7 +122,7 @@ export async function loadK8s(grid: GridClient) {
         console.log(`%c[Error] Timeout loading deployment with name ${name}`, "color: rgb(207, 102, 121)");
         return null;
       } else if ((result as any).masters.length === 0 && (result as any).workers.length === 0) {
-        console.log(`%c[Error] failed to load deployment with name ${name}}`, "color: rgb(207, 102, 121)");
+        console.log(`%c[Error] failed to load deployment with name ${name}`, "color: rgb(207, 102, 121)");
         failedDeployments.push({ name, nodes: nodeIds });
       } else {
         return result;


### PR DESCRIPTION
- make listing vms && k8s faster (it takes max 10 seconds before timeout)
- show number, name and node id of failed deployments

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/f55b8e4b-d95c-4824-8cc8-797eb1eaec40)

- If failed

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/aeb375b9-963a-424b-a00d-f89ec6058267)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/5e4a954a-26b4-4e56-8031-2dcc3ea87abb)

- In case the node is not reachable

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/1c7f28da-ab07-4c6d-ac94-07376c942262)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/57a25fc7-7403-4463-9efa-2b756e560507)

- same for k8s 

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/66959d82-4591-40a0-82a7-ef5e14d12d3d)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/225c9563-49c7-4619-b252-cb91789fdf7a)
