### PR TITLE
fix the none package condition

### DIFF
--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -169,7 +169,7 @@
                 >
               </p>
               <span class="package">
-                <b>{{ price.packageName != "None" ? price.packageName + " Package: " : "" }}</b></span
+                <b>{{ price.packageName != "none" ? capitalize(price.packageName) + " Package: " : "" }}</b></span
               >
               <b>${{ price.price }}/month, {{ price.TFTs }} TFT/month. </b>
             </span>
@@ -261,7 +261,7 @@ async function setPriceList(pkgs: any): Promise<PriceType[]> {
       label: "Dedicated Node",
       price: `${pkgs.dedicatedPrice}`,
       color: "black",
-      packageName: capitalize(pkgs.dedicatedPackage.package),
+      packageName: pkgs.dedicatedPackage.package,
       backgroundColor: color(pkgs.dedicatedPackage.package),
       TFTs: (+pkgs.dedicatedPrice / TFTPrice.value).toFixed(2),
       info: "A user can reserve an entire node then use it exclusively to deploy solutions",
@@ -270,7 +270,7 @@ async function setPriceList(pkgs: any): Promise<PriceType[]> {
       label: "Shared Node",
       price: `${pkgs.sharedPrice}`,
       color: "black",
-      packageName: capitalize(pkgs.sharedPackage.package),
+      packageName: pkgs.sharedPackage.package,
       backgroundColor: color(pkgs.sharedPackage.package),
       TFTs: (+pkgs.sharedPrice / TFTPrice.value).toFixed(2),
       info: "Shared Nodes allow several users to host various workloads on a single node",

--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -169,7 +169,7 @@
                 >
               </p>
               <span class="package">
-                <b>{{ price.packageName != "none" ? price.packageName + " Package: " : "" }}</b></span
+                <b>{{ price.packageName != "None" ? price.packageName + " Package: " : "" }}</b></span
               >
               <b>${{ price.price }}/month, {{ price.TFTs }} TFT/month. </b>
             </span>


### PR DESCRIPTION
### Description

When the user wasn't eligible for a package in the resource calculator, `None` appeared instead of the package name. 

### Changes

- Changed the condition to check for `None` instead of `none` since the package names was capitalized in #1273 

- Before

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/9c28df80-880c-4f2e-9054-c1c4a5deaa24)

- After

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/baab7f67-8fe2-4d53-9267-e7f5a85731a6)

### Related Issues

#1296 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
