### PR TITLE
Fix Undefined nodeId

### DIFF
--- a/packages/playground/src/weblets/freeflow.vue
+++ b/packages/playground/src/weblets/freeflow.vue
@@ -94,7 +94,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="!valid"
+        :disabled="!valid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -150,7 +150,13 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid || network?.error">Deploy </v-btn>
+      <v-btn
+        color="primary"
+        variant="tonal"
+        @click="deploy"
+        :disabled="tabs?.invalid || network?.error || selectedNode === undefined"
+        >Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -177,7 +177,13 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" :disabled="tabs?.invalid || network?.error" @click="deploy">Deploy</v-btn>
+      <v-btn
+        color="primary"
+        variant="tonal"
+        :disabled="tabs?.invalid || network?.error || selectedNode === undefined"
+        @click="deploy"
+        >Deploy</v-btn
+      >
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -183,7 +183,9 @@
       </SelectFarmManager>
     </form-validator>
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid || selectedNode === undefined">
+        Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_caprover.vue
+++ b/packages/playground/src/weblets/tf_caprover.vue
@@ -90,7 +90,18 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn
+        color="primary"
+        variant="tonal"
+        @click="deploy"
+        :disabled="
+          tabs?.invalid ||
+          leader.selectedNode === undefined ||
+          workers.some(worker => worker.selectedNode === undefined)
+        "
+      >
+        Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -86,7 +86,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="!valid"
+        :disabled="!valid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -128,7 +128,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="tabs?.invalid"
+        :disabled="tabs?.invalid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -138,7 +138,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="!valid"
+        :disabled="!valid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -72,7 +72,18 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn variant="tonal" color="primary" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+      <v-btn
+        variant="tonal"
+        color="primary"
+        @click="deploy"
+        :disabled="
+          tabs?.invalid ||
+          master.selectedNode === undefined ||
+          workers.some(worker => worker.selectedNode === undefined)
+        "
+      >
+        Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -111,7 +111,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="tabs?.invalid"
+        :disabled="tabs?.invalid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_nextcloud.vue
+++ b/packages/playground/src/weblets/tf_nextcloud.vue
@@ -110,7 +110,9 @@
       </SelectFarmManager>
     </form-validator>
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" :disabled="!valid" @click="deploy">Deploy</v-btn>
+      <v-btn color="primary" variant="tonal" :disabled="!valid || selectedNode === undefined" @click="deploy"
+        >Deploy</v-btn
+      >
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -106,7 +106,9 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid || selectedNode === undefined">
+        Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -148,7 +148,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="tabs?.invalid"
+        :disabled="tabs?.invalid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -110,7 +110,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="!valid"
+        :disabled="!valid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -115,7 +115,12 @@
     </d-tabs>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" :disabled="tabs?.invalid || network?.error" @click="deploy">
+      <v-btn
+        color="primary"
+        variant="tonal"
+        :disabled="tabs?.invalid || network?.error || selectedNode === undefined"
+        @click="deploy"
+      >
         Deploy
       </v-btn>
     </template>

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -97,7 +97,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="!valid"
+        :disabled="!valid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -160,7 +160,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="tabs?.invalid"
+        :disabled="tabs?.invalid || selectedNode === undefined"
       >
         Deploy
       </v-btn>

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -123,7 +123,9 @@
     </form-validator>
 
     <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+      <v-btn color="primary" variant="tonal" @click="deploy" :disabled="!valid || selectedNode === undefined">
+        Deploy
+      </v-btn>
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -139,7 +139,7 @@
         color="primary"
         variant="tonal"
         @click="deploy(domainNameCmp?.domain, domainNameCmp?.customDomain)"
-        :disabled="!valid"
+        :disabled="!valid || selectedNode === undefined"
       >
         Deploy
       </v-btn>


### PR DESCRIPTION
### Description

- Sometimes the `Deploy` button gets enabled while the node loading.
- Also If i tapped anywhere in the page, the button gets enabled for unknown reason. 
### Changes

- I added condition to button to make sure it won't get enabled if nodeId is undefined.
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1244

- Before 

https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/21edded8-a1fd-4a6b-919e-8c090a729734

- After 

https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/33b54170-17dc-4b79-a4e8-1662d1e17415





