### PR TITLE
change loading contract details error ux

### DIFF
--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -181,6 +181,7 @@ const headers: VDataTableHeader = [
 
 async function onMount() {
   loading.value = true;
+  failedContractId.value = undefined;
   contracts.value = [];
   grid.value = await getGrid(profileManager.profile!);
   contracts.value = await getUserContracts(grid.value!);


### PR DESCRIPTION
### Description

change the UX When contract details failed to load, it shows a toast and action button style change to retry

### Changes

Now, if any errors happen while loading contract details, an error message will appear on the current Ui and the user can view the contracts.

[Screencast from 01 نوف, 2023 EET 12:21:53 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/90afe559-34be-45a8-b918-5cb4100d3a3c)

> Note: in the record the expiration time is very short to for the recording purpose 
### Related Issues
- #1295 
### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
