### PR TITLE
Get only the available access nodes for the user while filtering them

### DIFF
--- a/packages/grid_client/src/high_level/machine.ts
+++ b/packages/grid_client/src/high_level/machine.ts
@@ -174,7 +174,7 @@ class VMHL extends HighLevelBase {
     let hasAccessNode = false;
     let accessNodes: Record<string, unknown> = {};
     if (addAccess) {
-      accessNodes = await this.nodes.getAccessNodes();
+      accessNodes = await this.nodes.getAccessNodes(this.config.twinId);
       for (const accessNode of Object.keys(accessNodes)) {
         if (network.nodeExists(Number(accessNode))) {
           hasAccessNode = true;

--- a/packages/grid_client/src/primitives/network.ts
+++ b/packages/grid_client/src/primitives/network.ts
@@ -83,7 +83,7 @@ class Network {
       throw Error(`Node ${node_id} does not exist in the network. Please add it first`);
     }
     events.emit("logs", `Adding access to node ${node_id}`);
-    const accessNodes = await this.capacity.getAccessNodes();
+    const accessNodes = await this.capacity.getAccessNodes(this.config.twinId);
     if (Object.keys(accessNodes).includes(node_id.toString())) {
       if (ipv4 && !accessNodes[node_id]["ipv4"]) {
         throw Error(`Node ${node_id} does not have ipv4 public config.`);
@@ -279,7 +279,7 @@ class Network {
       return this._accessNodes;
     }
     const accessNodes: number[] = [];
-    const allAccessNodes = await this.capacity.getAccessNodes();
+    const allAccessNodes = await this.capacity.getAccessNodes(this.config.twinId);
     for (const accessNode of Object.keys(allAccessNodes)) {
       if (this.nodeExists(+accessNode)) {
         accessNodes.push(+accessNode);

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -112,9 +112,9 @@ class Nodes {
       });
   }
 
-  async getAccessNodes(): Promise<Record<string, unknown>> {
+  async getAccessNodes(availableFor?: number): Promise<Record<string, unknown>> {
     const accessNodes = {};
-    const nodes = await this.filterNodes({ accessNodeV4: true, accessNodeV6: true });
+    const nodes = await this.filterNodes({ accessNodeV4: true, accessNodeV6: true, availableFor });
     for (const node of nodes) {
       const ipv4 = node.publicConfig.ipv4;
       const ipv6 = node.publicConfig.ipv6;

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -131,7 +131,6 @@ class Nodes {
     if (Object.keys(accessNodes).length === 0) {
       throw Error("Couldn't find any node with public config");
     }
-    console.log(accessNodes);
     return accessNodes;
   }
 

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -114,15 +114,20 @@ class Nodes {
 
   async getAccessNodes(availableFor?: number): Promise<Record<string, unknown>> {
     const accessNodes = {};
-    const nodes = await this.filterNodes({ accessNodeV4: true, accessNodeV6: true, availableFor });
-    for (const node of nodes) {
-      const ipv4 = node.publicConfig.ipv4;
-      const ipv6 = node.publicConfig.ipv6;
-      const domain = node.publicConfig.domain;
-      if (PrivateIp(ipv4.split("/")[0]) === false) {
-        accessNodes[+node.nodeId] = { ipv4: ipv4, ipv6: ipv6, domain: domain };
+    let nodes: NodeInfo[] = [];
+    let page = 1;
+    do {
+      nodes = await this.filterNodes({ accessNodeV4: true, accessNodeV6: true, availableFor, page });
+      for (const node of nodes) {
+        const ipv4 = node.publicConfig.ipv4;
+        const ipv6 = node.publicConfig.ipv6;
+        const domain = node.publicConfig.domain;
+        if (PrivateIp(ipv4.split("/")[0]) === false) {
+          accessNodes[+node.nodeId] = { ipv4: ipv4, ipv6: ipv6, domain: domain };
+        }
       }
-    }
+      page++;
+    } while (nodes.length);
     if (Object.keys(accessNodes).length === 0) {
       throw Error("Couldn't find any node with public config");
     }


### PR DESCRIPTION
### Description

Get only the available access nodes for the user while filtering them

### Changes

add `availableFor` in the access nodes query with the user's twin id

### Related Issues

- #1301 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
