### PR TITLE
Set defaut theme if there is no theme selected by the user.

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -130,6 +130,7 @@ const profileManager = useProfileManager();
 
 const openProfile = ref(true);
 const hasActiveProfile = computed(() => !!profileManager.profile);
+checkAppTheme();
 
 watch(
   () => $route.meta,
@@ -196,6 +197,15 @@ function clickHandler({ route, url }: AppRouteItem): void {
     window.open(url, "_blank");
   }
 }
+
+function checkAppTheme() {
+  const THEME_KEY = "APP_CURRENT_THEME";
+  const theme = localStorage.getItem(THEME_KEY);
+  if (!theme) {
+    // Users visit the website for the first time or clear the cache.
+    localStorage.setItem(THEME_KEY, "dark");
+  }
+}
 </script>
 
 <script lang="ts">
@@ -206,14 +216,6 @@ import DeploymentListManager from "./components/deployment_list_manager.vue";
 import DisclaimerToolbar from "./components/disclaimer_toolbar.vue";
 import TFNotification from "./components/tf_notification.vue";
 import ProfileManager from "./weblets/profile_manager.vue";
-
-const THEME_KEY = "APP_CURRENT_THEME";
-
-const theme = localStorage.getItem(THEME_KEY);
-if (!theme) {
-  // Users visit the website for the first time or clear the cache.
-  localStorage.setItem(THEME_KEY, "dark");
-}
 
 interface AppRoute {
   title: string;

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -207,6 +207,14 @@ import DisclaimerToolbar from "./components/disclaimer_toolbar.vue";
 import TFNotification from "./components/tf_notification.vue";
 import ProfileManager from "./weblets/profile_manager.vue";
 
+const THEME_KEY = "APP_CURRENT_THEME";
+
+const theme = localStorage.getItem(THEME_KEY);
+if (!theme) {
+  // Users visit the website for the first time or clear the cache.
+  localStorage.setItem(THEME_KEY, "dark");
+}
+
 interface AppRoute {
   title: string;
   items: AppRouteItem[];

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -130,7 +130,6 @@ const profileManager = useProfileManager();
 
 const openProfile = ref(true);
 const hasActiveProfile = computed(() => !!profileManager.profile);
-checkAppTheme();
 
 watch(
   () => $route.meta,
@@ -195,15 +194,6 @@ function clickHandler({ route, url }: AppRouteItem): void {
     $router.push(route);
   } else if (url) {
     window.open(url, "_blank");
-  }
-}
-
-function checkAppTheme() {
-  const THEME_KEY = "APP_CURRENT_THEME";
-  const theme = localStorage.getItem(THEME_KEY);
-  if (!theme) {
-    // Users visit the website for the first time or clear the cache.
-    localStorage.setItem(THEME_KEY, "dark");
   }
 }
 </script>

--- a/packages/playground/src/utils/custom_toast.ts
+++ b/packages/playground/src/utils/custom_toast.ts
@@ -36,7 +36,7 @@ export function createCustomToast(
   type: ToastType,
   componentProps?: Record<string, unknown>,
 ) {
-  const theme = localStorage.getItem("APP_CURRENT_THEME");
+  const theme = localStorage.getItem("APP_CURRENT_THEME") || "dark";
   const colors = theme === "dark" ? darkModeColors : lightModeColors;
 
   const toastOptions: ToastOptions = {


### PR DESCRIPTION
### Description

The problem occurred due to the absence of a default value for the `app theme`. Without a user-selected theme, the system cannot determine the appropriate class, such as `mosha__icon__dark__warning`, to load based on the theme.

### Changes

set an initialization of the app theme variable that is stored in the local storage with the default `dark` value.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1338

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
