### PR TITLE
available farms randomization 

### DIFF
--- a/packages/grid_client/src/helpers/requests.ts
+++ b/packages/grid_client/src/helpers/requests.ts
@@ -13,4 +13,17 @@ async function send(method: Method, url: string, body: string, headers: Record<s
   }
   return response.data;
 }
-export { send };
+async function sendWithFullResponse(method: Method, url: string, body: string, headers: Record<string, string>) {
+  const options = {
+    method: method,
+    url: url,
+    data: body,
+    headers: headers,
+  };
+  const response = await axios(options);
+  if (response.status >= 400) {
+    throw Error(`HTTP request failed with status code: ${response.status} due to: ${response.data}`);
+  }
+  return response;
+}
+export { send, sendWithFullResponse };

--- a/packages/grid_client/src/helpers/requests.ts
+++ b/packages/grid_client/src/helpers/requests.ts
@@ -1,18 +1,5 @@
 import { default as axios, Method } from "axios";
 
-async function send(method: Method, url: string, body: string, headers: Record<string, string>) {
-  const options = {
-    method: method,
-    url: url,
-    data: body,
-    headers: headers,
-  };
-  const response = await axios(options);
-  if (response.status >= 400) {
-    throw Error(`HTTP request failed with status code: ${response.status} due to: ${response.data}`);
-  }
-  return response.data;
-}
 async function sendWithFullResponse(method: Method, url: string, body: string, headers: Record<string, string>) {
   const options = {
     method: method,
@@ -26,4 +13,10 @@ async function sendWithFullResponse(method: Method, url: string, body: string, h
   }
   return response;
 }
+
+async function send(method: Method, url: string, body: string, headers: Record<string, string>) {
+  const response = await sendWithFullResponse(method, url, body, headers);
+  return response.data;
+}
+
 export { send, sendWithFullResponse };

--- a/packages/grid_client/src/modules/capacity.ts
+++ b/packages/grid_client/src/modules/capacity.ts
@@ -96,6 +96,12 @@ class Capacity {
 
   @expose
   @validateInput
+  async getFarmsCount(options?: FarmFilterOptions): Promise<string> {
+    return await this.nodes.getFarmsCount(options);
+  }
+
+  @expose
+  @validateInput
   async checkFarmHasFreePublicIps(options?: FarmHasFreePublicIPsModel): Promise<boolean> {
     return await this.nodes.checkFarmHasFreePublicIps(options.farmId);
   }

--- a/packages/grid_client/src/modules/capacity.ts
+++ b/packages/grid_client/src/modules/capacity.ts
@@ -96,7 +96,7 @@ class Capacity {
 
   @expose
   @validateInput
-  async getFarmsCount(options?: FarmFilterOptions): Promise<string> {
+  async getFarmsCount(options?: FarmFilterOptions): Promise<number> {
     return await this.nodes.getFarmsCount(options);
   }
 

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -619,6 +619,7 @@ class FarmFilterOptions {
   @Expose() @IsOptional() @IsInt() ownedBy?: number;
   @Expose() @IsOptional() @IsInt() farmId?: number;
   @Expose() @IsOptional() @IsBoolean() randomize?: boolean;
+  @Expose() @IsOptional() @IsBoolean() ret_count?: boolean;
 }
 
 class CalculatorModel {

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -592,6 +592,7 @@ class FilterOptions {
   @Expose() @IsOptional() @IsBoolean() rentable?: boolean;
   @Expose() @IsOptional() @IsInt() @Min(1) rentedBy?: number;
   @Expose() @IsOptional() @IsBoolean() randomize?: boolean;
+  @Expose() @IsOptional() @IsBoolean() ret_count?: boolean;
   @Expose() @IsOptional() @Transform(({ value }) => NodeStatus[value]) @IsEnum(NodeStatus) status?: NodeStatus;
 }
 

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -328,6 +328,7 @@ class Nodes {
   async getFarmsCount(options: FilterOptions = {}, url = ""): Promise<number> {
     url = url || this.proxyURL;
     options.ret_count = true;
+    options.page = 1;
     const query = this.getFarmUrlQuery(options);
     try {
       return +(await sendWithFullResponse("get", urlJoin(url, `/farms?${query}`), "", {})).headers["count"];

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -317,11 +317,19 @@ class Nodes {
     return farms;
   }
 
-  async getFarmsCount(options: FilterOptions = {}, url = ""): Promise<string> {
+  /**
+   * Retrieves the count of available farms with optional filter options.
+   *
+   * @param options - An object containing filter options to refine the farm count.
+   * @param url - (Optional) The URL to send the request to. If not provided, it defaults to the proxy URL defined in the class.
+   * @returns A Promise that resolves to the count of available farms as a number.
+   * @throws Error if there is an issue with the HTTP request or response.
+   */
+  async getFarmsCount(options: FilterOptions = {}, url = ""): Promise<number> {
     url = url || this.proxyURL;
     const query = this.getFarmUrlQuery({ ...options, ret_count: true });
     try {
-      return (await sendWithFullResponse("get", urlJoin(url, `/farms?${query}`), "", {})).headers["count"];
+      return +(await sendWithFullResponse("get", urlJoin(url, `/farms?${query}`), "", {})).headers["count"];
     } catch (err) {
       throw Error(`Error while requesting the grid proxy due ${err}`);
     }

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -5,7 +5,7 @@ import urlJoin from "url-join";
 
 import { RMB } from "../clients";
 import { Graphql } from "../clients/graphql/client";
-import { send } from "../helpers/requests";
+import { send, sendWithFullResponse } from "../helpers/requests";
 import { FarmFilterOptions, FilterOptions, NodeStatus } from "../modules/models";
 
 interface FarmInfo {
@@ -317,6 +317,16 @@ class Nodes {
     return farms;
   }
 
+  async getFarmsCount(options: FilterOptions = {}, url = ""): Promise<string> {
+    url = url || this.proxyURL;
+    const query = this.getFarmUrlQuery({ ...options, ret_count: true });
+    try {
+      return (await sendWithFullResponse("get", urlJoin(url, `/farms?${query}`), "", {})).headers["count"];
+    } catch (err) {
+      throw Error(`Error while requesting the grid proxy due ${err}`);
+    }
+  }
+
   /**
    * Get farm id from farm name.
    * It returns 0 in case the farm name is not found.
@@ -388,6 +398,7 @@ class Nodes {
       node_certified: options.nodeCertified,
       farm_id: options.farmId,
       randomize: options.randomize,
+      ret_count: options.ret_count,
     };
     return Object.entries(params)
       .map(param => param.join("="))

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -327,7 +327,8 @@ class Nodes {
    */
   async getFarmsCount(options: FilterOptions = {}, url = ""): Promise<number> {
     url = url || this.proxyURL;
-    const query = this.getFarmUrlQuery({ ...options, ret_count: true });
+    options.ret_count = true;
+    const query = this.getFarmUrlQuery(options);
     try {
       return +(await sendWithFullResponse("get", urlJoin(url, `/farms?${query}`), "", {})).headers["count"];
     } catch (err) {

--- a/packages/playground/src/components/select_farm.vue
+++ b/packages/playground/src/components/select_farm.vue
@@ -137,6 +137,12 @@ async function loadFarms() {
   const _farms = await getFarms(grid!, prepareFilters(props.filters, grid!.twinId), {
     exclusiveFor: props.exclusiveFor,
   });
+  selectedPages.value.push(page.value);
+  if (!_farms.length && selectedPages.value.length !== pagesCount.value) {
+    page.value = setRandomPage();
+    await loadFarms();
+    return;
+  }
   farms.value = farms.value.concat(_farms);
 
   if (oldFarm) {
@@ -155,7 +161,7 @@ async function loadFarms() {
       initialized = true;
     }
   }
-  selectedPages.value.push(page.value);
+
   page.value = selectedPages.value.length === pagesCount.value ? -1 : setRandomPage();
   loading.value = false;
 }

--- a/packages/playground/src/components/select_farm.vue
+++ b/packages/playground/src/components/select_farm.vue
@@ -166,6 +166,7 @@ function setRandomPage() {
   return randPage;
 }
 async function resetPages() {
+  farms.value = [];
   loading.value = true;
   farmInput.value?.setStatus(ValidatorStatus.Pending);
   selectedPages.value = [];

--- a/packages/playground/src/utils/get_farms.ts
+++ b/packages/playground/src/utils/get_farms.ts
@@ -8,11 +8,10 @@ export interface GetFarmsOptions {
   exclusiveFor?: string;
 }
 
-export async function getFarmsPages(grid: GridClient, filters: FarmFilterOptions): Promise<number> {
+export async function getFarmsPages(grid: GridClient, filters: FarmFilterOptions, pageSize: number): Promise<number> {
   try {
     const count = (await grid.capacity.getFarmsCount(filters)) || 1;
-    console.log(count, filters);
-    return Math.ceil(count / 50);
+    return Math.ceil(count / pageSize);
   } catch {
     return 1;
   }

--- a/packages/playground/src/utils/get_farms.ts
+++ b/packages/playground/src/utils/get_farms.ts
@@ -7,6 +7,17 @@ import { gqlClient, gridProxyClient } from "../clients";
 export interface GetFarmsOptions {
   exclusiveFor?: string;
 }
+
+export async function getFarmsPages(grid: GridClient, filters: FarmFilterOptions): Promise<number> {
+  try {
+    const count = (await grid.capacity.getFarmsCount(filters)) || 1;
+    console.log(count, filters);
+    return Math.ceil(count / 50);
+  } catch {
+    return 1;
+  }
+}
+
 export async function getFarms(
   grid: GridClient,
   filters: FarmFilterOptions,


### PR DESCRIPTION
### Description
##### Please make sure to test this pr against mainnet because it has a large number of farms
Select random page based on the total available pages and the already visited pages

### Changes
- gridclient
  - create `sendWithFullResponse` function that returns the whole response not just the `data`
  - create `getFarmsCount` that uses the `sendWithFullResponse` function, the passed filters, `ret_count = true` and set page to 1; to get the total count of farms 
- playground
  - `getFarmsPages` uses the gridclient to get the total farms pages 
  - changed the flow of getting farms to be: 
      1.   -  on mount or `shouldBeUpdated == true`: reset the variables and get the farmCount then set page to a randomvalue then loadfarms, and store the current page to `selectedpages `array
      2. create a new random page number in the range of pageCount that does not exist in selectedpages array
      3. if the response of get farms is empty and we can load more [ this case is happens when the  farms on the current page are blocked farms and we didn't visit all available pages ] we set a new random value and `loadFarms` again

### Related Issues

- #1312 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
