### PR TITLE
fix nodes field infinite loading

### DIFF
--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -218,9 +218,9 @@ async function loadNodes(farmId: number) {
   errorMessage.value = "";
   const filters = props.filters;
   farmManager?.setLoading(true);
-  const grid = await getGrid(profileManager.profile!);
-  if (grid) {
-    try {
+  try {
+    const grid = await getGrid(profileManager.profile!);
+    if (grid) {
       const res = await getFilteredNodes(grid, {
         farmId: farmId,
         cpu: filters.cpu,
@@ -254,15 +254,16 @@ async function loadNodes(farmId: number) {
       } else {
         availableNodes.value = [];
       }
-    } catch (e) {
-      errorMessage.value = normalizeError(e, "Something went wrong while fetching nodes.");
-    } finally {
-      validator.value?.setStatus(ValidatorStatus.Init);
-      loadingNodes.value = false;
-      farmManager?.setLoading(false);
     }
+  } catch (e) {
+    errorMessage.value = normalizeError(e, "Something went wrong while fetching nodes.");
+  } finally {
+    validator.value?.setStatus(ValidatorStatus.Init);
+    loadingNodes.value = false;
+    farmManager?.setLoading(false);
   }
 }
+
 async function validateNodeStoragePool(validatingNode: INode | undefined) {
   if (!validatingNode) return { message: "Node id is required." };
   farmManager?.setLoading(true);


### PR DESCRIPTION
### Description

Fix the infinite loading in the Nodes Id field when a connection error happens.

### Changes

- Moved the grid client object inside the try/catch block to catch network errors instead of loading infinitely 

- Now when a network error happens, the appropriate error message will be displayed instead of loading infinitely.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/b997b4f4-f032-400a-90a0-a663ab5f3c56)
 
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/d4f71d9d-3843-4e17-943b-f4fc1288ebfd)

### Related Issues

#1306 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
