### PR TITLE
Fix duplicate contracts when deleting

### DIFF
--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -180,6 +180,7 @@ const headers: VDataTableHeader = [
 ];
 
 async function onMount() {
+  selectedContracts.value = [];
   loading.value = true;
   failedContractId.value = undefined;
   contracts.value = [];
@@ -187,7 +188,6 @@ async function onMount() {
   contracts.value = await getUserContracts(grid.value!);
   nodeStatus.value = await getNodeStatus(nodeIDs.value);
   loading.value = false;
-  selectedContracts.value = [];
 }
 
 const nodeIDs = computed(() => {

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -187,6 +187,7 @@ async function onMount() {
   contracts.value = await getUserContracts(grid.value!);
   nodeStatus.value = await getNodeStatus(nodeIDs.value);
   loading.value = false;
+  selectedContracts.value = [];
 }
 
 const nodeIDs = computed(() => {


### PR DESCRIPTION
### Description
- When user check on contract then refresh and check to delete it, It will appear to be deleted twice.

### Changes
- check `selectedContracts` gets empty when refresh

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1365


- Before 

https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/141d34ac-181c-4dd8-bc2e-9e98c700bef5

- After 


https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/d3b9c2c5-25b1-4791-9338-f6ffbc2e634f

