### PR TITLE
separate nework errors and storage pools errors

### DIFF
--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -289,11 +289,11 @@ async function validateNodeStoragePool(validatingNode: INode | undefined) {
 
     if (e?.toString().includes("Cannot fit the required SSD disk with size")) {
       return {
-        message: `Couldn't fit the required disks in Node ${validatingNode.nodeId} storage pools, please select another node`,
+        message: `Although node ${validatingNode.nodeId} appears to have sufficient storage capacity for your workload, it lacks a single internal partition capable of accommodating it. Please select a different node.`,
       };
     } else {
       return {
-        message: "Something went wrong while checking storage pools. Please check your connection and try again.",
+        message: "Something went wrong while checking status of the node. Please check your connection and try again.",
       };
     }
   } finally {

--- a/packages/playground/src/components/select_node.vue
+++ b/packages/playground/src/components/select_node.vue
@@ -286,9 +286,16 @@ async function validateNodeStoragePool(validatingNode: INode | undefined) {
     availableNodes.value = availableNodes.value.filter(node => node.nodeId !== validatingNode.nodeId);
     validator.value?.setStatus(ValidatorStatus.Invalid);
     emptyResult.value = true;
-    return {
-      message: `Couldn't fit the required disks in Node ${validatingNode.nodeId} storage pools, please select another node`,
-    };
+
+    if (e?.toString().includes("Cannot fit the required SSD disk with size")) {
+      return {
+        message: `Couldn't fit the required disks in Node ${validatingNode.nodeId} storage pools, please select another node`,
+      };
+    } else {
+      return {
+        message: "Something went wrong while checking storage pools. Please check your connection and try again.",
+      };
+    }
   } finally {
     pingingNode.value = false;
     farmManager?.setLoading(false);


### PR DESCRIPTION
### Description

Separate network errors and storage pools errors while checking the storage pools of a node.

### Changes

- When the returned error is a storage pools error then it'll be:

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/98d5a201-8455-4f05-9887-dc8bdccaf7df)

- When the returned error is a network error then it'll be:

   ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/afc36a94-1aec-4db2-92d4-97c2dd62f4b7)


### Related Issues

#1341 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
