### PR TITLE
handle delete deployment errors

### DIFF
--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -407,22 +407,28 @@ watch(activeTab, () => (selectedItems.value = []));
 async function onDelete(k8s = false) {
   deletingDialog.value = false;
   deleting.value = true;
-  const grid = await getGrid(profileManager.profile!);
-  for (const item of selectedItems.value) {
-    try {
-      await deleteDeployment(updateGrid(grid!, { projectName: item.projectName }), {
-        name: item.deploymentName,
-        projectName: item.projectName,
-        k8s,
-      });
-    } catch (e: any) {
-      console.log("Error while deleting deployment", e.message);
+  try {
+    const grid = await getGrid(profileManager.profile!);
+    for (const item of selectedItems.value) {
+      try {
+        await deleteDeployment(updateGrid(grid!, { projectName: item.projectName }), {
+          name: item.deploymentName,
+          projectName: item.projectName,
+          k8s,
+        });
+      } catch (e: any) {
+        createCustomToast(`Failed to delete deployment with name: ${item.deploymentName}`, ToastType.danger);
+        console.log("Error while deleting deployment", e.message);
+        continue;
+      }
+      table.value?.loadDeployments();
     }
+  } catch (e) {
+    createCustomToast((e as Error).message, ToastType.danger);
+  } finally {
+    selectedItems.value = [];
+    deleting.value = false;
   }
-
-  selectedItems.value = [];
-  table.value?.loadDeployments();
-  deleting.value = false;
 }
 
 const VMS: string[] = [ProjectName.Fullvm, ProjectName.VM, ProjectName.NodePilot];
@@ -459,6 +465,7 @@ import ManageGatewayDialog from "../components/manage_gateway_dialog.vue";
 import ManageK8SWorkerDialog from "../components/manage_k8s_worker_dialog.vue";
 import VmDeploymentTable from "../components/vm_deployment_table.vue";
 import { ProjectName } from "../types";
+import { createCustomToast, ToastType } from "../utils/custom_toast";
 
 export default {
   name: "TfDeploymentList",


### PR DESCRIPTION
### Description

The current flow is to loop through the deployments and delete them. If any errors occur, we just log the error to the console.
Also, getGrid is not in try block
 
### Changes

I just added getGrid to try block and added toast to show that something went wrong

[Screencast from 08 نوف, 2023 EET 03:17:17 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/967c4594-bc7f-4ae2-ac4d-bb331326b180)

### Related Issues

- #1360 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
