### PR TITLE
 fix ttl creation in rmb rmb client

### DIFF
--- a/packages/rmb_direct_client/lib/client.ts
+++ b/packages/rmb_direct_client/lib/client.ts
@@ -240,6 +240,9 @@ class Client {
     retries: number = this.retries,
   ) {
     try {
+      // need to check if destination twinId exists by fetching dest twin from chain first
+      this.destTwin = await this.tfclient.twins.get({ id: destinationTwinId });
+
       // create new envelope with given data and destination
       const envelope = new Envelope({
         uid: uuidv4(),
@@ -247,8 +250,6 @@ class Client {
         expiration: expirationMinutes * 60,
         source: this.source,
       });
-      // need to check if destination twinId exists by fetching dest twin from chain first
-      this.destTwin = await this.tfclient.twins.get({ id: destinationTwinId });
       envelope.destination = new Address({ twin: this.destTwin.id });
 
       if (requestCommand) {


### PR DESCRIPTION
make the tfchain request before creating the envelope

### Description

After creating the envelope, we are making a request to get the user twin, this request takes some time of the envelope ttl.

### Changes

we just make the tfchain request before create the envelope.

### Related Issues

- #1379

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
