### PR TITLE
Change route to dedicated nodes instead of old dashboard

### DIFF
--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -40,8 +40,8 @@
 
     <template v-if="dedicated && !status">
       <v-alert class="mb-4 mx-4" type="info" variant="tonal">
-        You need to rent a dedicated node from our
-        <a :href="dashboardURL" target="_blank" class="app-link"> Dashboard </a>
+        You need to rent a node from the
+        <router-link to="/portal/dedicated-nodes" class="app-link">Dedicated Nodes page</router-link>
         before deploying on it.
       </v-alert>
     </template>


### PR DESCRIPTION
### Description

- When user chooses Dedicated when deploying, this alert shows and directs to Dashbaord.

### Changes
- Change redirection to dedicated nodes page insteas.

### Related Issues

-  https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1406
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)


