### PR TITLE
Adding a new card for dedicated nodes

### DIFF
--- a/packages/new_stats/src/components/stats_table.vue
+++ b/packages/new_stats/src/components/stats_table.vue
@@ -80,6 +80,7 @@ const Istats = computed((): IStatistics[] => {
   {
     return [
       { data: formattedStats.value.nodes, title: "Nodes Online", icon: "mdi-laptop" },
+      { data: formattedStats.value.dedicatedNodes, title: "Dedicated Nodes", icon: "mdi-resistor-nodes" },
       { data: formattedStats.value.farms, title: "Farms", icon: "mdi-tractor" },
       { data: formattedStats.value.countries, title: "Countries", icon: "mdi-earth" },
       { data: formattedStats.value.totalCru, title: "CPUs", icon: "mdi-cpu-64-bit" },

--- a/packages/new_stats/src/utils/stats.ts
+++ b/packages/new_stats/src/utils/stats.ts
@@ -6,6 +6,7 @@ function mergeStatsData(stats: Stats[]): Stats {
   const res = stats[0];
   for (let i = 1; i < stats.length; i++) {
     res.accessNodes += stats[i].accessNodes;
+    res.dedicatedNodes += stats[i].dedicatedNodes;
     res.contracts += stats[i].contracts;
     res.countries += stats[i].countries;
     res.farms += stats[i].farms;
@@ -61,10 +62,14 @@ export function formatData(network: Network[] = [Network.Main], totalStat: Netwo
     twins: 0,
     contracts: 0,
     nodesDistribution: {},
+    dedicatedNodes: 0,
   };
   for (let i = 0; i < network.length; i++) {
     const currentStats = totalStat[network[i]];
     if (!currentStats) continue;
+    if (Number.isNaN(currentStats.dedicatedNodes)) {
+      currentStats.dedicatedNodes = 0;
+    }
     res = mergeStatsData([res, currentStats]);
   }
 

--- a/packages/playground/src/explorer/stats.vue
+++ b/packages/playground/src/explorer/stats.vue
@@ -90,6 +90,7 @@ const fetchData = async () => {
       nodesDistribution.value = JSON.stringify(stats!.nodesDistribution);
       Istats.value = [
         { data: stats!.nodes, title: "Nodes Online", icon: "mdi-laptop" },
+        { data: stats!.dedicatedNodes, title: "Dedicated Nodes", icon: "mdi-resistor-nodes" },
         { data: stats!.farms, title: "Farms", icon: "mdi-tractor" },
         { data: stats!.countries, title: "Countries", icon: "mdi-earth" },
         { data: stats!.totalCru, title: "CPUs", icon: "mdi-cpu-64-bit" },


### PR DESCRIPTION
### Description
Adding a new card for dedicated nodes in explorer stats.

![Screenshot from 2023-11-19 15-33-31](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/97882ff2-e667-4628-b251-8410b3d19015)

### Changes

-Added a dedicated nodes variable to the Stats interface 
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1230
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
