### PR TITLE
Use error types in graphql client 

### DIFF
--- a/packages/graphql_client/package.json
+++ b/packages/graphql_client/package.json
@@ -8,7 +8,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "ts-mixer": "^6.0.2"
+    "ts-mixer": "^6.0.2",
+    "@threefold/types": "^1.0.0"
   },
   "devDependencies": {
     "typescript": "^4.9.3"

--- a/packages/graphql_client/src/utils/index.ts
+++ b/packages/graphql_client/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "@threefold/types";
 type AssertReturn = void | never;
 function panic(message: string): never {
   throw new Error(message);
@@ -8,15 +9,16 @@ function panic(message: string): never {
  * Assertion
  */
 export function assertHasField(fields: any): AssertReturn {
-  if (Object.keys(fields).length === 0) panic(`[Object] must contain at least 1 field.`);
+  if (Object.keys(fields).length === 0) throw new ValidationError(`[Object] must contain at least 1 field.`);
   for (const key in fields) {
     if (fields[key] instanceof Object) assertHasField(fields[key]);
-    else if (fields[key] !== true) panic(`Expected "${key}" of type [true | string] but got [${typeof fields[key]}]`);
+    else if (fields[key] !== true)
+      throw new ValidationError(`Expected "${key}" of type [true | string] but got [${typeof fields[key]}]`);
   }
 }
 
 export function assertID(value: any): AssertReturn {
   if (value === "" || value === undefined || value === null) {
-    panic(`Expected a valid [ID] but got [${value}].`);
+    throw new ValidationError(`Expected a valid [ID] but got [${value}].`);
   }
 }

--- a/packages/graphql_client/src/utils/index.ts
+++ b/packages/graphql_client/src/utils/index.ts
@@ -9,7 +9,9 @@ function panic(message: string): never {
  * Assertion
  */
 export function assertHasField(fields: any): AssertReturn {
-  if (Object.keys(fields).length === 0) throw new ValidationError(`[Object] must contain at least 1 field.`);
+  if (Object.keys(fields).length === 0) {
+    throw new ValidationError(`[Object] must contain at least 1 field.`);
+  }
   for (const key in fields) {
     if (fields[key] instanceof Object) assertHasField(fields[key]);
     else if (fields[key] !== true)


### PR DESCRIPTION
### Description

only in this cases we have invalid input so we should use ValidationError class  

### Changes

use `throw new ValidationError` instead of `panic`
> panic function is not used anymore but I will leave it in case if it needed 

### Related Issues

#995 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
