### PR TITLE
Handled error in list deployment's domains

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -113,7 +113,7 @@
         <div v-show="gatewayTab === 1">
           <form-validator v-model="valid">
             <input-tooltip
-              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix(${prefix}) is solution name, twin ID and deployment name.`"
+              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix(${prefix}) is solution name, twin ID, and deployment name.`"
             >
               <input-validator
                 :value="subdomain"

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -215,19 +215,23 @@ export default {
         (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
         grid!.config.twinId;
       subdomain.value = generateName({}, 15 - prefix.value.length);
-      await grid!.disconnect();
       await loadGateways();
     });
 
     const loadingGateways = ref(false);
     const gateways = ref<GridGateway[]>([]);
     async function loadGateways() {
-      gateways.value = [];
-      gatewaysToDelete.value = [];
-      loadingGateways.value = true;
-      const grid = await getGrid(profileManager.profile!, props.vm.projectName);
-      gateways.value = await loadDeploymentGateways(grid!);
-      loadingGateways.value = false;
+      try {
+        gateways.value = [];
+        gatewaysToDelete.value = [];
+        loadingGateways.value = true;
+        const grid = await getGrid(profileManager.profile!, props.vm.projectName);
+        gateways.value = await loadDeploymentGateways(grid!);
+      } catch (error) {
+        layout.value.setStatus("failed", normalizeError(error, "Failed to list this deployment's domains."));
+      } finally {
+        loadingGateways.value = false;
+      }
     }
 
     async function deployGateway() {

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -113,7 +113,7 @@
         <div v-show="gatewayTab === 1">
           <form-validator v-model="valid">
             <input-tooltip
-              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix(${prefix}) is project name, twin ID and deployment name.`"
+              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix(${prefix}) is solution name, twin ID and deployment name.`"
             >
               <input-validator
                 :value="subdomain"

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -41,16 +41,16 @@
           </template>
         </v-alert>
 
-        <v-dialog v-model="failedDomainDialog" max-width="400px">
+        <v-dialog v-model="failedDomainDialog" max-width="400px" scrollable>
           <v-card>
             <v-card-title class="bg-warning">Failed Domains</v-card-title>
 
             <v-card-text>
-              <v-list lines="one">
-                <v-list-item v-for="gw in failedToListGws" :key="gw">
-                  <span>* {{ gw }}</span>
-                </v-list-item>
-              </v-list>
+              <ul style="list-style: square">
+                <li v-for="gw in failedToListGws" :key="gw">
+                  <span>{{ gw.slice(prefix.length) }}</span>
+                </li>
+              </ul>
             </v-card-text>
           </v-card>
         </v-dialog>

--- a/packages/playground/src/components/select_gateway_node.vue
+++ b/packages/playground/src/components/select_gateway_node.vue
@@ -2,15 +2,15 @@
   <input-validator
     ref="validator"
     :value="$props.modelValue?.id"
-    :rules="[validators.required('Gateway node is required.')]"
+    :rules="[validators.required('Domain is required.')]"
     #="{ props }"
   >
     <input-tooltip
       tooltip="Creates a subdomain for your instance on the selected domain to be able to access your instance from the browser."
     >
       <v-autocomplete
-        label="Select gateway"
-        placeholder="Please select a gateway."
+        label="Select domain"
+        placeholder="Please select a domain."
         :items="items"
         item-title="domain"
         return-object
@@ -27,7 +27,6 @@
         <template v-slot:append-item v-if="page !== -1">
           <div class="px-4 mt-4">
             <v-btn
-              v-if="gatewayOption == 'farm'"
               block
               color="secondary"
               variant="tonal"
@@ -36,31 +35,7 @@
               @click="loadNextPage"
               :loading="loading"
             >
-              Load More Gateway Nodes in {{ farmData?.name }}
-            </v-btn>
-            <v-btn
-              v-else-if="gatewayOption == 'country'"
-              block
-              color="secondary"
-              variant="tonal"
-              rounded="large"
-              size="large"
-              @click="loadNextPage"
-              :loading="loading"
-            >
-              Load More Gateway Nodes in {{ farmData?.country }}
-            </v-btn>
-            <v-btn
-              v-else
-              block
-              color="secondary"
-              variant="tonal"
-              rounded="large"
-              size="large"
-              @click="loadNextPage"
-              :loading="loading"
-            >
-              Load More Gateway Nodes
+              {{ loadMoreText }}
             </v-btn>
           </div>
         </template>
@@ -71,7 +46,7 @@
 
 <script lang="ts" setup>
 import type { FilterOptions } from "@threefold/grid_client";
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { ValidatorStatus } from "@/hooks/form_validator";
 
@@ -155,6 +130,18 @@ function normalizeGatewayNode(item: any): GatewayNode {
     ip: item.publicConfig.ipv4.split("/")[0],
   };
 }
+
+const loadMoreText = computed(() => {
+  const farm = props.farmData;
+  const base = "Load More Domains";
+
+  if (farm) {
+    if (gatewayOption.value === "farm") return `${base} in ${farm.name}`;
+    if (gatewayOption.value === "country") return `${base} in ${farm.country}`;
+  }
+
+  return base;
+});
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/utils/delete_deployment.ts
+++ b/packages/playground/src/utils/delete_deployment.ts
@@ -93,7 +93,7 @@ function isVm(projectName: string) {
 }
 
 async function deleteVmGateways(grid: GridClient) {
-  const gateways = await loadDeploymentGateways(grid);
+  const { gateways } = await loadDeploymentGateways(grid);
   for (const gateway of gateways) {
     try {
       if (gateway.type.includes("name")) {


### PR DESCRIPTION
### Description
- Handled error in list deployment's domains

### Changes
- Add try/catch block to show error in `weblet layout` whenever we fail to list
- Remove disconnecting from gridclient from `onMount`
- Add checking for prefix to match omar's pr
- add global timeout
- update tooltip to match omar's pr (add and deployment name) to prefix
- rename gateway to domain

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1531
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1518

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
