### PR TITLE
[Domain Name] add machine name to prefix

### DIFF
--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -215,7 +215,7 @@ class QSFSZDBGetModel extends BaseGetDeleteModel {}
 class QSFSZDBDeleteModel extends BaseGetDeleteModel {}
 
 class BaseGatewayNameModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength + 10) name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength + 20) name: string;
 }
 
 class GatewayFQDNModel extends BaseGatewayNameModel {

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -79,8 +79,8 @@
                   validators.minLength('Subdomain must be at least 4 characters.', 4),
                   subdomain =>
                     validators.maxLength(
-                      `Subdomain cannot exceed ${15 - prefix.length} characters.`,
-                      15 - prefix.length,
+                      `Subdomain cannot exceed ${35 - prefix.length} characters.`,
+                      35 - prefix.length,
                     )(subdomain),
                 ]"
                 #="{ props }"
@@ -213,8 +213,9 @@ export default {
       const grid = await getGrid(profileManager.profile!);
       prefix.value =
         (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
-        grid!.config.twinId;
-      subdomain.value = generateName({}, 15 - prefix.value.length);
+        grid!.config.twinId +
+        props.vm?.[0]?.name;
+      subdomain.value = generateName({}, 35 - prefix.value.length > 7 ? 7 : 35 - prefix.value.length);
       await grid!.disconnect();
       await loadGateways();
     });


### PR DESCRIPTION
### Description

- prefix now includes solution code + twin id + machine name.
- we had to increase gateway name max length to 35.
- the auto generated domain name now is 7 char maximum
 
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/7daad84a-e7a3-4859-aee2-f415de2e5a65)


### Related Issues

- #1538 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
