### PR TITLE
update tooltip icon for clickable icons

### DIFF
--- a/packages/playground/src/components/input_tooltip.vue
+++ b/packages/playground/src/components/input_tooltip.vue
@@ -13,13 +13,9 @@
             @focus="propsRef?.onFocus"
             @blur="propsRef?.onBlur"
           >
-            <a v-if="href" :href="href" target="_blank">
-              <v-icon>mdi-information</v-icon>
-            </a>
-
-            <template v-else>
+            <a :href="href" target="_blank">
               <v-icon>mdi-information-outline</v-icon>
-            </template>
+            </a>
           </span>
         </div>
       </template>


### PR DESCRIPTION
### Description

Updated the tooltip icon for clickable icons to be the same for the sake of consistency.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/c9d3fdc8-e4e2-45fa-9b2e-511d9deb4f8d)

### Changes

Removed the condition that displayed different icon for clickable tooltips.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1521

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
