### PR TITLE
disable loading after the details are loaded

### DIFF
--- a/packages/playground/src/components/node_details_cards/twin_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/twin_details_card.vue
@@ -1,5 +1,5 @@
 <template>
-  <card-details :loading="loading" title="Node Twin Details" :items="twinFields" icon="mdi-account" />
+  <card-details :loading="loading" title="Twin Details" :items="twinFields" icon="mdi-account" />
 </template>
 
 <script lang="ts">
@@ -44,6 +44,8 @@ export default {
           );
           loading.value = false;
           return;
+        } finally {
+          loading.value = false;
         }
       } else if (props.node) {
         twin.value = props.node.twin;

--- a/packages/playground/src/components/node_details_cards/twin_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/twin_details_card.vue
@@ -42,8 +42,6 @@ export default {
             "Failed to load Twin details due to Slow Network. Please try again later.",
             ToastType.danger,
           );
-          loading.value = false;
-          return;
         } finally {
           loading.value = false;
         }


### PR DESCRIPTION
### Description

Fix the infinite loading in the twin details card.

[Screencast from 03-12-23 14:59:17.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/2c8f9b7f-ff21-4183-8d89-9bf40bf807bf)


### Changes

- Disabled the loading in a finally block after the try/catch since it wasn't disabled after the twin details are returned.
- Changed the name of the card to `Twin Details` instead of `Node Twin Details`

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1472

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
