### PR TITLE
reorder sidebar

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -19,7 +19,15 @@
                 <v-list-group v-if="route.items.length > 1" :value="route.title">
                   <template v-slot:activator="{ props }">
                     <v-list-item style="font-weight: 500" v-bind="props" :prepend-icon="route.icon">
-                      <v-list-item-title class="font-weight-bold">{{ route.title }}</v-list-item-title>
+                      <v-list-item-title class="font-weight-bold">
+                        <v-tooltip :text="route.tooltip" :disabled="!route.tooltip">
+                          <template #activator="{ props }">
+                            <span v-bind="props">
+                              {{ route.title }}
+                            </span>
+                          </template>
+                        </v-tooltip>
+                      </v-list-item-title>
                     </v-list-item>
                   </template>
                   <v-list-item
@@ -41,7 +49,15 @@
                       <v-icon v-else width="26">{{ item.icon }}</v-icon>
                     </template>
 
-                    <v-list-item-title class="font-weight-bold">{{ item.title }}</v-list-item-title>
+                    <v-list-item-title class="font-weight-bold">
+                      <v-tooltip :text="item.tooltip" :disabled="!item.tooltip">
+                        <template #activator="{ props }">
+                          <span v-bind="props">
+                            {{ item.title }}
+                          </span>
+                        </template>
+                      </v-tooltip>
+                    </v-list-item-title>
                   </v-list-item>
                 </v-list-group>
                 <v-list-item
@@ -64,9 +80,15 @@
                     <v-icon v-else width="26">{{ item.icon }}</v-icon>
                   </template>
 
-                  <v-tooltip :text="item.tooltip">
-                    <v-list-item-title class="font-weight-bold">{{ item.title }}</v-list-item-title>
-                  </v-tooltip>
+                  <v-list-item-title class="font-weight-bold">
+                    <v-tooltip :text="item.tooltip" :disabled="!item.tooltip">
+                      <template #activator="{ props }">
+                        <span v-bind="props">
+                          {{ item.title }}
+                        </span>
+                      </template>
+                    </v-tooltip>
+                  </v-list-item-title>
                 </v-list-item>
               </template>
             </v-list>
@@ -367,6 +389,7 @@ interface AppRoute {
   title: string;
   items: AppRouteItem[];
   icon?: string;
+  tooltip?: string;
 }
 
 interface AppRouteItem {

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -64,7 +64,9 @@
                     <v-icon v-else width="26">{{ item.icon }}</v-icon>
                   </template>
 
-                  <v-list-item-title class="font-weight-bold">{{ item.title }}</v-list-item-title>
+                  <v-tooltip :text="item.tooltip">
+                    <v-list-item-title class="font-weight-bold">{{ item.title }}</v-list-item-title>
+                  </v-tooltip>
                 </v-list-item>
               </template>
             </v-list>
@@ -279,34 +281,44 @@ const routes: AppRoute[] = [
     title: "Services",
     items: [
       {
-        title: "0-Hub",
-        icon: "mdi-open-in-new",
-        url: "https://hub.grid.tf/",
-      },
-      {
-        title: "Monitoring",
-        icon: "mdi-equalizer",
-        url: "https://metrics.grid.tf/d/rYdddlPWkfqwf/zos-host-metrics?orgId=2&refresh=30s",
-      },
-      {
         title: "0-Bootstrap",
         icon: "mdi-earth",
         url: "https://bootstrap.grid.tf/",
+        tooltip: "Download Zero-OS Images",
       },
       {
-        title: "Grid Services",
-        icon: "mdi-grid-large",
-        url: "https://status.grid.tf/status/threefold",
-      },
-      {
-        title: "Manual",
-        icon: "mdi-book-open-page-variant-outline",
-        url: "https://manual.grid.tf/",
+        title: "0-Hub",
+        icon: "mdi-open-in-new",
+        url: "https://hub.grid.tf/",
+        tooltip: "Find or Publish your Flist",
       },
       {
         title: "Minting",
         icon: "mdi-file-document-edit",
         route: "/minting",
+        tooltip: "TFGrid Minting Explorer",
+      },
+      {
+        title: "Monitoring",
+        icon: "mdi-equalizer",
+        url: "https://metrics.grid.tf/d/rYdddlPWkfqwf/zos-host-metrics?orgId=2&refresh=30s",
+        tooltip: "Monitor Zero-OS nodes",
+      },
+      {
+        title: "Grid Health",
+        icon: "mdi-grid-large",
+        url: "https://status.grid.tf/status/threefold",
+        tooltip: "Status of Threefold Services",
+      },
+    ],
+  },
+  {
+    title: "Manual",
+    items: [
+      {
+        title: "Manual",
+        icon: "mdi-book-open-page-variant-outline",
+        url: "https://manual.grid.tf/",
       },
     ],
   },
@@ -362,6 +374,7 @@ interface AppRouteItem {
   route?: string;
   url?: string;
   icon?: string;
+  tooltip?: string;
 }
 
 export default {


### PR DESCRIPTION
### Description

Reordering the sidebar and adding hints for the services items.

### Changes

- Moved the manual to the last item in the top level.
- Renamed grid services to grid health.
- re-ordered the services items.
- Added tooltip support for sidebar items.
- Added tooltips for grid services items

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1565

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
