### PR TITLE
Node Filters

### DIFF
--- a/packages/playground/src/components/filter.vue
+++ b/packages/playground/src/components/filter.vue
@@ -62,57 +62,53 @@
   </form-validator>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { defineComponent, type PropType, ref, watch } from "vue";
 
 import { useFormRef } from "../hooks/form_validator";
 import type { InputFilterType } from "../types";
 
+const props = defineProps({
+  modelValue: {
+    type: Object as PropType<{ [key: string]: InputFilterType }>,
+    required: true,
+  },
+  formDisabled: Boolean,
+  valid: Boolean,
+});
+
+const emit = defineEmits(["update:model-value", "update:valid"]);
+
+const formRef = useFormRef();
+const panel = [0];
+const isFiltersTouched = ref<boolean>(false);
+
+watch(
+  () => props.modelValue,
+  (newValue: PropType<{ [key: string]: InputFilterType }>) => {
+    const hasNonEmptyValue = Object.keys(newValue).some(obj => {
+      return Reflect.get(newValue, obj).value && Reflect.get(newValue, obj).value.length >= 1;
+    });
+
+    isFiltersTouched.value = hasNonEmptyValue;
+  },
+  { deep: true },
+);
+
+const resetFilters = () => {
+  emit(
+    "update:model-value",
+    Object.keys(props.modelValue).reduce((res, key) => {
+      res[key] = { ...props.modelValue[key], value: undefined };
+      return res;
+    }, {} as any),
+  );
+};
+</script>
+
+<script lang="ts">
 export default defineComponent({
   name: "Filters",
-  props: {
-    modelValue: {
-      type: Object as PropType<{ [key: string]: InputFilterType }>,
-      required: true,
-    },
-    formDisabled: Boolean,
-    valid: Boolean,
-  },
-
-  setup(props, { emit }) {
-    const formRef = useFormRef();
-    const panel = [0];
-    const isFiltersTouched = ref<boolean>(false);
-
-    watch(
-      () => props.modelValue,
-      (newValue: PropType<{ [key: string]: InputFilterType }>) => {
-        const hasNonEmptyValue = Object.keys(newValue).some(obj => {
-          return Reflect.get(newValue, obj).value && Reflect.get(newValue, obj).value.length >= 1;
-        });
-
-        isFiltersTouched.value = hasNonEmptyValue;
-      },
-      { deep: true },
-    );
-
-    const resetFilters = () => {
-      emit(
-        "update:model-value",
-        Object.keys(props.modelValue).reduce((res, key) => {
-          res[key] = { ...props.modelValue[key], value: undefined };
-          return res;
-        }, {} as any),
-      );
-    };
-
-    return {
-      resetFilters,
-      isFiltersTouched,
-      formRef,
-      panel,
-    };
-  },
 });
 </script>
 <style scoped>

--- a/packages/playground/src/components/filter.vue
+++ b/packages/playground/src/components/filter.vue
@@ -80,7 +80,7 @@ const props = defineProps({
 const emit = defineEmits(["update:model-value", "update:valid"]);
 
 const formRef = useFormRef();
-const panel = [0];
+const panel = ref([0]);
 const isFiltersTouched = ref<boolean>(false);
 
 watch(

--- a/packages/playground/src/components/filter.vue
+++ b/packages/playground/src/components/filter.vue
@@ -1,6 +1,7 @@
 <template>
   <form-validator valid-on-init ref="formRef" @update:model-value="$emit('update:valid', $event)">
     <v-expansion-panels
+      v-model="panel"
       class="mb-3"
       @update:model-value="
         e => {
@@ -80,6 +81,7 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const formRef = useFormRef();
+    const panel = [0];
     const isFiltersTouched = ref<boolean>(false);
 
     watch(
@@ -108,6 +110,7 @@ export default defineComponent({
       resetFilters,
       isFiltersTouched,
       formRef,
+      panel,
     };
   },
 });

--- a/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
+++ b/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
@@ -169,8 +169,8 @@ const tabParams = {
 };
 
 // The mixed filters should reset to the default value again..
-const inputFiltersReset = (nFltrNptsVal: DedicatedNodeFilters) => {
-  filterInputs.value = nFltrNptsVal;
+const inputFiltersReset = (filtersInputValues: DedicatedNodeFilters) => {
+  filterInputs.value = filtersInputValues;
   gpuFilter.value = undefined;
 };
 

--- a/packages/playground/src/types/index.ts
+++ b/packages/playground/src/types/index.ts
@@ -223,13 +223,13 @@ export type FilterInputs = {
   freeMru: NodeInputFilterType;
 };
 
-export const optionsInitializer: FilterOptions = {
+export const optionsInitializer: () => FilterOptions = () => ({
   gateway: undefined,
   gpu: undefined,
   page: 1,
   size: 10,
   status: capitalize(NodeStatus.Up) as NodeStatus,
-};
+});
 
 import type { FilterFarmInputs } from "@/utils/filter_farms";
 import type { FilterNodeInputs } from "@/utils/filter_nodes";

--- a/packages/playground/src/utils/filter_farms.ts
+++ b/packages/playground/src/utils/filter_farms.ts
@@ -1,42 +1,45 @@
 import type { InputFilterType } from "../types";
-import { isInt, isNumeric, isString, min } from "./validators";
+import { isInt, isNumeric, isString, min, validateResourceMaxNumber } from "./validators";
 
 export type FilterFarmInputs = {
   farmId: InputFilterType;
   name: InputFilterType;
-
   freeIps: InputFilterType;
 };
-export const inputsInitializer: FilterFarmInputs = {
+
+export const inputsInitializer: () => FilterFarmInputs = () => ({
   farmId: {
-    label: "Farm IDs",
-    placeholder: "e.g. 1,2,3.",
+    label: "Farm ID",
+    placeholder: "Filter by farm id",
     rules: [
       [
         isNumeric("This field accepts numbers only.", { no_symbols: true }),
         min("The ID should be larger than zero.", 1),
         isInt("should be an integer"),
+        validateResourceMaxNumber("This is not a valid ID."),
       ],
     ],
     type: "text",
   },
+
   name: {
     label: "Farm Name",
-    placeholder: "e.g myfarm",
+    placeholder: "Farm name, e.g myfarm",
     rules: [[isString("Farm name should be made of either numbers or letters")]],
     type: "text",
   },
 
   freeIps: {
     label: "Free PubIPs",
-    placeholder: "e.g. 1,2,3.",
+    placeholder: "Filter by free public ips",
     rules: [
       [
         isNumeric("This field accepts numbers only.", { no_symbols: true }),
         min("Free Public IP should be larger than zero.", 1),
         isInt("should be an integer"),
+        validateResourceMaxNumber("This is not a valid public ip."),
       ],
     ],
     type: "text",
   },
-};
+});

--- a/packages/playground/src/utils/filter_farms.ts
+++ b/packages/playground/src/utils/filter_farms.ts
@@ -31,13 +31,13 @@ export const inputsInitializer: () => FilterFarmInputs = () => ({
 
   freeIps: {
     label: "Free PubIPs",
-    placeholder: "Filter by free public ips",
+    placeholder: "Filter by free public IPs",
     rules: [
       [
         isNumeric("This field accepts numbers only.", { no_symbols: true }),
         min("Free Public IP should be larger than zero.", 1),
         isInt("should be an integer"),
-        validateResourceMaxNumber("This is not a valid public ip."),
+        validateResourceMaxNumber("This is not a valid public IP."),
       ],
     ],
     type: "text",

--- a/packages/playground/src/utils/filter_nodes.ts
+++ b/packages/playground/src/utils/filter_nodes.ts
@@ -70,6 +70,7 @@ export const inputsInitializer: () => FilterNodeInputs = () => ({
         isNumeric("This field accepts numbers only.", { no_symbols: true }),
         min("The node id should be larger then zero.", 1),
         startsWith("The node id start with zero.", "0"),
+        validateResourceMaxNumber("This is not a valid ID."),
       ],
     ],
     type: "text",
@@ -154,7 +155,11 @@ export const DedicatedNodeInitializer: () => DedicatedNodeFilters = () => ({
     placeholder: "Filter by total Cores.",
     type: "text",
     rules: [
-      [isNumeric("This Field accepts only a valid number."), min("This Field must be a number larger than 0.", 1)],
+      [
+        isNumeric("This Field accepts only a valid number."),
+        min("This Field must be a number larger than 0.", 1),
+        validateResourceMaxNumber("This value is out of range."),
+      ],
     ],
   },
   total_mru: {

--- a/packages/playground/src/utils/filter_nodes.ts
+++ b/packages/playground/src/utils/filter_nodes.ts
@@ -61,7 +61,7 @@ export type DedicatedNodeFilters = {
 };
 
 // Default input Initialization
-export const inputsInitializer: FilterNodeInputs = {
+export const inputsInitializer: () => FilterNodeInputs = () => ({
   nodeId: {
     label: "Node ID",
     placeholder: "Filter by node id.",
@@ -146,9 +146,9 @@ export const inputsInitializer: FilterNodeInputs = {
     ],
     type: "text",
   },
-};
+});
 
-export const DedicatedNodeInitializer: DedicatedNodeFilters = {
+export const DedicatedNodeInitializer: () => DedicatedNodeFilters = () => ({
   total_cru: {
     label: "Total CPU (Cores)",
     placeholder: "Filter by total Cores.",
@@ -224,4 +224,4 @@ export const DedicatedNodeInitializer: DedicatedNodeFilters = {
       ],
     ],
   },
-};
+});

--- a/packages/playground/src/utils/validators.ts
+++ b/packages/playground/src/utils/validators.ts
@@ -80,8 +80,7 @@ export function startsWith(msg: string, char: string) {
 
 export function validateResourceMaxNumber(msg: string) {
   return (value: string) => {
-    const valueInBytes = toBytes(+value);
-    if (+valueInBytes > BigInt(2 ** 64 - 1)) {
+    if (+value > BigInt(2 ** 32 - 1)) {
       return { message: msg };
     }
   };

--- a/packages/playground/src/views/farms.vue
+++ b/packages/playground/src/views/farms.vue
@@ -148,15 +148,15 @@ const updateSorting = () => {
 const updateQueries = async () => {
   const inputs = mixedFarmFilters.value.inputs;
   if (inputs && filterFarmInputs.value) {
-    const nFltrNptsVal = filterFarmInputs.value;
-    if (nFltrNptsVal.farmId) {
-      inputs.farmId.value = nFltrNptsVal.farmId.value;
+    const filtersInputValues = filterFarmInputs.value;
+    if (filtersInputValues.farmId) {
+      inputs.farmId.value = filtersInputValues.farmId.value;
     }
-    if (nFltrNptsVal.name) {
-      inputs.name.value = nFltrNptsVal.name.value;
+    if (filtersInputValues.name) {
+      inputs.name.value = filtersInputValues.name.value;
     }
-    if (nFltrNptsVal.freeIps) {
-      inputs.freeIps.value = nFltrNptsVal.freeIps.value;
+    if (filtersInputValues.freeIps) {
+      inputs.freeIps.value = filtersInputValues.freeIps.value;
     }
   }
   const options = mixedFarmFilters.value.options;
@@ -174,8 +174,8 @@ watch(page, updateQueries);
 watch(size, updateQueries);
 
 // The filters should reset to the default value again..
-const inputFiltersReset = (nFltrNptsVal: FilterFarmInputs) => {
-  filterFarmInputs.value = nFltrNptsVal;
+const inputFiltersReset = (filtersInputValues: FilterFarmInputs) => {
+  filterFarmInputs.value = filtersInputValues;
   filterOptions.value = {
     page: 1,
     size: 10,

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -181,8 +181,8 @@ export default {
     );
 
     // The filters should reset to the default value again..
-    const inputFiltersReset = (nFltrNptsVal: FilterInputs) => {
-      filterInputs.value = nFltrNptsVal;
+    const inputFiltersReset = (filtersInputValues: FilterInputs) => {
+      filterInputs.value = filtersInputValues;
       filterOptions.value = {
         ...filterOptions.value,
         status: NodeStatus.Up,

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -129,7 +129,7 @@ export default {
   setup() {
     const filterInputs = ref<FilterInputs>(inputsInitializer());
     const filterOptions = ref<FilterOptions>(optionsInitializer());
-    const mixedFilters = computed(() => ({ inputs: filterInputs.value, options: filterOptions.value }));
+    const mixedFilters = computed<MixedFilter>(() => ({ inputs: filterInputs.value, options: filterOptions.value }));
 
     const loading = ref<boolean>(true);
     const isFormLoading = ref<boolean>(true);
@@ -180,7 +180,7 @@ export default {
       { deep: true },
     );
 
-    // The mixed filters should reset to the default value again..
+    // The filters should reset to the default value again..
     const inputFiltersReset = (nFltrNptsVal: FilterInputs) => {
       filterInputs.value = nFltrNptsVal;
       filterOptions.value = {

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -8,7 +8,7 @@
   <view-layout>
     <filters
       :form-disabled="isFormLoading"
-      v-model="filterInputs"
+      :model-value="filterInputs"
       v-model:valid="isValidForm"
       @update:model-value="inputFiltersReset"
     />
@@ -105,6 +105,7 @@
 import { type GridNode, type NodesQuery, NodeStatus } from "@threefold/gridproxy_client";
 import debounce from "lodash/debounce.js";
 import { capitalize, onMounted, ref, watch } from "vue";
+import { computed } from "vue";
 import { useRoute } from "vue-router";
 
 import NodeDetails from "@/components/node_details.vue";
@@ -126,9 +127,9 @@ export default {
     NodeDetails,
   },
   setup() {
-    const filterInputs = ref<FilterInputs>(inputsInitializer);
-    const filterOptions = ref<FilterOptions>(optionsInitializer);
-    const mixedFilters = ref<MixedFilter>({ inputs: filterInputs.value, options: filterOptions.value });
+    const filterInputs = ref<FilterInputs>(inputsInitializer());
+    const filterOptions = ref<FilterOptions>(optionsInitializer());
+    const mixedFilters = computed(() => ({ inputs: filterInputs.value, options: filterOptions.value }));
 
     const loading = ref<boolean>(true);
     const isFormLoading = ref<boolean>(true);
@@ -181,12 +182,15 @@ export default {
 
     // The mixed filters should reset to the default value again..
     const inputFiltersReset = (nFltrNptsVal: FilterInputs) => {
-      mixedFilters.value.inputs = nFltrNptsVal;
-      mixedFilters.value.options.status = NodeStatus.Up;
-      mixedFilters.value.options.gpu = undefined;
-      mixedFilters.value.options.gateway = undefined;
-      mixedFilters.value.options.page = 1;
-      mixedFilters.value.options.size = 10;
+      filterInputs.value = nFltrNptsVal;
+      filterOptions.value = {
+        ...filterOptions.value,
+        status: NodeStatus.Up,
+        gpu: undefined,
+        gateway: undefined,
+        page: 1,
+        size: 10,
+      };
     };
 
     const checkSelectedNode = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4323,6 +4323,11 @@
   resolved "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz"
   integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
 
+"@types/crypto-js@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.1.tgz#480edd76991a63050cb88db1a8840758c55a7135"
+  integrity sha512-FSPGd9+OcSok3RsM0UZ/9fcvMOXJ1ENE/ZbLfOPlBWj7BgXtEAM8VYfTtT760GiLbQIMoVozwVuisjvsVwqYWw==
+
 "@types/debounce@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.1.tgz#79b65710bc8b6d44094d286aecf38e44f9627852"
@@ -8368,6 +8373,11 @@ crypto-js@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz"
   integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 crypto-random-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description

- Resolved the reset filter issues by implementing a function that returns an object with the default values. This approach replaces the previous direct object usage `() => obj`.
- Reset filters in the farms page, updated the nodes page, and addressed an issue related to the max integer value in the filters.

### Changes

- Update Node Filters and Conversion to Vue 3 Composition API
- Fix Reset Filter Issues using a Function that returns an object instead of using a direct object
- Reset Filters in the Farms Page, Nodes Page Update, and Max Int Value Fix


### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1561
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1494

### Screenshots/Video

[Screencast from 12-05-2023 03:01:35 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/eb4b9f3d-092c-472b-8ca5-8baa859a768c)

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
