### PR TITLE
Fix uptime in dashboard nodes 

### DIFF
--- a/packages/playground/src/dashboard/components/user_nodes.vue
+++ b/packages/playground/src/dashboard/components/user_nodes.vue
@@ -192,7 +192,7 @@ export default {
     const uptime = ref();
     const nodesCount = ref();
 
-    onMounted(async () => await getUserNodes());
+    onMounted(getUserNodes);
 
     async function reloadNodes() {
       setTimeout(async () => {

--- a/packages/playground/src/dashboard/components/user_nodes.vue
+++ b/packages/playground/src/dashboard/components/user_nodes.vue
@@ -106,8 +106,8 @@
           :nodeId="item.raw.nodeId"
           :farmId="item.raw.farmId"
           v-model="item.raw.publicConfig"
-          @remove-config="(item.raw.publicConfig = $event), reloadNodes"
-          @add-config="(item.raw.publicConfig = $event), reloadNodes"
+          @remove-config="(item.raw.publicConfig = $event), reloadNodes()"
+          @add-config="(item.raw.publicConfig = $event), reloadNodes()"
         />
         <SetExtraFee class="me-2" :nodeId="item.raw.nodeId" />
       </template>
@@ -194,9 +194,11 @@ export default {
 
     onMounted(async () => await getUserNodes());
 
-    const reloadNodes = setTimeout(async () => {
-      await getUserNodes();
-    }, 10000);
+    async function reloadNodes() {
+      setTimeout(async () => {
+        await getUserNodes();
+      }, 10000);
+    }
 
     async function getUserNodes() {
       try {

--- a/packages/playground/src/utils/node.ts
+++ b/packages/playground/src/utils/node.ts
@@ -114,9 +114,12 @@ export async function getFarmUptimePercentage(farm: NodeInterface[]) {
   return (uptime / farm.length).toFixed(2);
 }
 
+export function calculateUptime(currentPeriod = 0, downtime = 0) {
+  return (((currentPeriod - downtime) / currentPeriod) * 100).toFixed(2);
+}
 export async function getNodeUptimePercentage(nodeId: number) {
   const availability = await getNodeAvailability(nodeId);
-  return (((availability?.currentPeriod - availability?.downtime) / availability?.currentPeriod) * 100).toFixed(2);
+  return calculateUptime(availability.currentPeriod, availability.downtime);
 }
 export function getTime(num: number | undefined) {
   if (num) {


### PR DESCRIPTION
### Description

- The anonymous function got called on mount automatically, which makes the nodes table reload after 10 seconds of mounting.
- Uptime was calculated on mount only, and if reload nodes were triggered, the uptime would not be valid.



### Related Issues

- #1570 
- #1569 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
