### PR TITLE
add close button to manage domains dialog

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -174,6 +174,7 @@
         </div>
 
         <template #footer-actions>
+          <v-btn color="error" variant="tonal" @click="$emit('close')">Close</v-btn>
           <v-btn
             color="error"
             variant="outlined"


### PR DESCRIPTION

### Changes

Added a close button to the manage domains dialog in solutions in playground:
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/a5b64ddd-304f-4932-983f-46f277cb2867)

### Related Issues

#1307





