### PR TITLE
Update max farm name to be 40 chars

### DIFF
--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -20,7 +20,7 @@
                   validators.required('Farm name is required.'),
                   name => validators.isAlpha('Farm name must start with an alphabet char.')(name[0]),
                   validators.minLength('Farm name minimum length is 2 chars.', 2),
-                  validators.maxLength('Farm name maximum length is 15 chars.', 15),
+                  validators.maxLength('Farm name maximum length is 40 chars.', 40),
                   validators.pattern('Farm name  should not contain whitespaces.', {
                     pattern: /^[^\s]+$/,
                   }),


### PR DESCRIPTION
### Description

The current max length of farm name in the new playground in 15 character while it's 40 characters from the chain and the old dashboard also had a max of 40 characters.
### Changes

Update validation length to be 40 not 15 chars.
### Related Issues

List of related issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1568

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
