### PR TITLE
fix typo in the warning message and improve font size

### DIFF
--- a/packages/playground/src/components/mosha_toast/offline_nodes_toast.vue
+++ b/packages/playground/src/components/mosha_toast/offline_nodes_toast.vue
@@ -59,5 +59,6 @@ export default {
   display: flex !important;
   justify-content: center !important;
   align-items: center !important;
+  font-size: 16px;
 }
 </style>

--- a/packages/playground/src/components/tf_notification.vue
+++ b/packages/playground/src/components/tf_notification.vue
@@ -66,7 +66,13 @@ onMounted(async () => {
     ) {
       contractsCount.value =
         contracts.nameContracts.length + contracts.nodeContracts.length + contracts.rentContracts.length;
-      createCustomToast("You have " + contractsCount.value + " contracts in grace period", ToastType.warning);
+      createCustomToast(
+        "You have " +
+          contractsCount.value +
+          (contractsCount.value > 1 ? " contracts" : " contract") +
+          " in grace period",
+        ToastType.warning,
+      );
     }
     await new Promise(resolve => setTimeout(resolve, 15 * 60 * 1000));
   }


### PR DESCRIPTION
### Description

Fix typo in the grace period warning message. and make the font size for both messages consistent.

![2023-12-07_13-00](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/6542d2f0-5222-48f4-afee-2adfe0ac413e)

![2023-12-07_13-00_1](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/dc442512-7b35-4c1c-b41d-631a8ddb023c)

### Changes

-  added a condition to check if the contracts length is > 1 then the text should be `contracts` else it should be `contract`.
- Updated the font size to be consistent with the other message.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1560

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
