### PR TITLE
Fix tooltip color and others

### DIFF
--- a/packages/playground/src/components/app_info.vue
+++ b/packages/playground/src/components/app_info.vue
@@ -8,23 +8,23 @@
   <v-dialog
     :model-value="openInfo"
     @update:model-value="setOpenInfo($event)"
-    :width="loading ? 'auto' : '75%'"
+    :width="loading ? 'auto' : '60%'"
     scrollable
   >
     <v-card v-if="loading" class="d-flex justify-center align-center pa-10">
       <v-progress-circular indeterminate size="50" color="primary" />
     </v-card>
     <v-card v-else class="markdown">
-      <v-card-title class="pb-0 font-weight-bold d-flex align-center text-h4 my-3" v-if="title">
+      <v-card-title class="font-weight-bold d-flex align-center text-h5 my-2" v-if="title">
         {{ title }}
       </v-card-title>
       <v-card-subtitle :style="{ whiteSpace: 'initial' }" v-if="subtitle">{{ subtitle }}</v-card-subtitle>
-      <v-divider class="mt-2" v-if="title || subtitle" />
-      <v-card-text class="pb-16" v-html="html" />
+      <v-divider v-if="title || subtitle" />
+      <v-card-text class="pb-8" v-html="html" />
 
-      <v-divider />
+      <v-divider class="mb-2" />
       <v-card-actions class="d-flex justify-end">
-        <v-btn color="error" variant="tonal" @click="setOpenInfo(false)">Close</v-btn>
+        <v-btn color="anchor" variant="outlined" @click="setOpenInfo(false)">Close</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/packages/playground/src/global.css
+++ b/packages/playground/src/global.css
@@ -46,9 +46,9 @@
   border-width: thin !important;
   border-style: solid !important;
   z-index: 99;
-  background-color: rgb(var(--v-theme-background));
-  color: var(--v-theme-text);
-  font-weight: 900;
+  background-color: rgb(var(--v-theme-background)) !important;
+  color: var(--v-theme-text) !important;
+  font-weight: 500 !important;
 }
 
 a {

--- a/packages/playground/src/plugins/vuetify.ts
+++ b/packages/playground/src/plugins/vuetify.ts
@@ -25,7 +25,7 @@ const vuetify = createVuetify({
           info: "#7de3c8",
           warning: "#FFCC00",
           link: "#5695ff",
-          anchor: "#9e9e9e",
+          anchor: "#d4d4d4",
         },
       },
       light: {


### PR DESCRIPTION
fixed The title of the info section for the solutions is clipped #1600

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/d0fd2b64-a239-4cfa-94e8-550f27c5c2e1)

fixed all hint(tooltip) Dedicated nodes: difficult to read the hint on the price #1478
![Untitled-1](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/10a8c8df-3c27-46aa-ac64-13987af617a4)

made it more whiter Change the close button UI in Connect your wallet #1591
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/b1714113-55e6-4b6f-ba76-19e7aefa3c23)
