### PR TITLE
renaming dashboard farms to your farms to avoid confusion

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -250,7 +250,7 @@ const routes: AppRoute[] = [
         icon: "mdi-account-arrow-right-outline",
         route: "/dashboard/transfer",
       },
-      { title: "Farms", icon: "mdi-silo", route: "/dashboard/farms" },
+      { title: "Your Farms", icon: "mdi-silo", route: "/dashboard/farms" },
       {
         title: "Dedicated Nodes",
         icon: "mdi-resistor-nodes",

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -240,9 +240,15 @@ const routes: AppRoute[] = [
     icon: "mdi-account-convert-outline",
     items: [
       {
-        title: "Twin",
+        title: "Your Twin",
         icon: "mdi-account-supervisor-outline",
         route: "/dashboard/twin",
+      },
+      { title: "Your Farms", icon: "mdi-silo", route: "/dashboard/farms" },
+      {
+        title: "Your Contracts",
+        icon: "mdi-file-document-edit",
+        route: "/dashboard/contracts-list",
       },
       { title: "Bridge", icon: "mdi-swap-horizontal", route: "/dashboard/bridge" },
       {
@@ -250,18 +256,12 @@ const routes: AppRoute[] = [
         icon: "mdi-account-arrow-right-outline",
         route: "/dashboard/transfer",
       },
-      { title: "Your Farms", icon: "mdi-silo", route: "/dashboard/farms" },
       {
         title: "Dedicated Nodes",
         icon: "mdi-resistor-nodes",
         route: "/dashboard/dedicated-nodes",
       },
       { title: "DAO", icon: "mdi-note-check-outline", route: "/dashboard/dao" },
-      {
-        title: "Contracts",
-        icon: "mdi-file-document-edit",
-        route: "/dashboard/contracts-list",
-      },
     ],
   },
   {

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -45,7 +45,7 @@ const router = createRouter({
         {
           path: "farms",
           component: () => import("../dashboard/farms_view.vue"),
-          meta: { title: "Farms" },
+          meta: { title: "Your Farms" },
         },
         {
           path: "dedicated-nodes",

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -25,7 +25,20 @@ const router = createRouter({
           name: "Twin",
           path: "twin",
           component: () => import("../dashboard/twin_view.vue"),
-          meta: { title: "Twin" },
+          meta: { title: "Your Twin" },
+        },
+        {
+          path: "farms",
+          component: () => import("../dashboard/farms_view.vue"),
+          meta: { title: "Your Farms" },
+        },
+        {
+          path: "contracts-list",
+          component: () => import("../dashboard/contracts_list.vue"),
+          meta: {
+            title: "Your Contracts List",
+            info: { page: "info/contracts_list.md" },
+          },
         },
         {
           path: "dao",
@@ -43,22 +56,9 @@ const router = createRouter({
           meta: { title: "Transfer" },
         },
         {
-          path: "farms",
-          component: () => import("../dashboard/farms_view.vue"),
-          meta: { title: "Your Farms" },
-        },
-        {
           path: "dedicated-nodes",
           component: () => import("../dashboard/dedicated_nodes_view.vue"),
           meta: { title: "Dedicated Nodes" },
-        },
-        {
-          path: "contracts-list",
-          component: () => import("../dashboard/contracts_list.vue"),
-          meta: {
-            title: "Contracts List",
-            info: { page: "info/contracts_list.md" },
-          },
         },
       ],
     },


### PR DESCRIPTION
### Description

Renaming Farms tab in dashboard to ``` Your Farms``` to avoid confusion

![2023-12-10_16-28](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/01bce0e3-a7ad-42d2-9209-ca55d9ae29e4)

### Related Issues

#1587
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
