### PR TITLE
tooltip color2

### DIFF
--- a/packages/playground/src/plugins/vuetify.ts
+++ b/packages/playground/src/plugins/vuetify.ts
@@ -25,7 +25,7 @@ const vuetify = createVuetify({
           info: "#7de3c8",
           warning: "#FFCC00",
           link: "#5695ff",
-          anchor: "#d4d4d4",
+          anchor: "#fff",
         },
       },
       light: {


### PR DESCRIPTION
fixed The title of the info section for the solutions is clipped #1600

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/d0fd2b64-a239-4cfa-94e8-550f27c5c2e1)

fixed all hint (tooltip) Dedicated nodes: difficult to read the hint on the price #1478
![Untitled-1](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/10a8c8df-3c27-46aa-ac64-13987af617a4)

made it more whiter Change the close button UI in Connect your wallet #1591
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/b1714113-55e6-4b6f-ba76-19e7aefa3c23)
