### PR TITLE
Filter out the undefined extrinsics

### DIFF
--- a/packages/tfchain_client/src/utility.ts
+++ b/packages/tfchain_client/src/utility.ts
@@ -11,6 +11,7 @@ class Utility {
 
   @checkConnection
   async batch<T>(extrinsics: ExtrinsicResult<T>[]): Promise<T[]> {
+    extrinsics = extrinsics.filter(Boolean);
     if (extrinsics.length > 0) {
       const { resultSections, resultEvents } = this.extractResultSectionsAndEvents(extrinsics);
       const batchExtrinsic = await this.client.api.tx.utility.batch(extrinsics);
@@ -21,6 +22,7 @@ class Utility {
 
   @checkConnection
   async batchAll<T>(extrinsics: ExtrinsicResult<T>[]): Promise<T[]> {
+    extrinsics = extrinsics.filter(Boolean);
     if (extrinsics.length > 0) {
       const { resultSections, resultEvents } = this.extractResultSectionsAndEvents(extrinsics);
       const batchAllExtrinsic = await this.client.api.tx.utility.batchAll(extrinsics);


### PR DESCRIPTION
### Description

in case deleting an already deleted contract, this leads to an undefined element in the list of the batch call. Filter them out fixes the issue

### Related Issues

- #1636 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
