### PR TITLE
handle no error message in response

### DIFF
--- a/packages/grid_client/src/helpers/requests.ts
+++ b/packages/grid_client/src/helpers/requests.ts
@@ -12,7 +12,10 @@ async function sendWithFullResponse(method: Method, url: string, body: string, h
     return await axios(options);
   } catch (e) {
     const { response } = e as AxiosError;
-    const errorMessage = (response?.data as { error: string }).error;
+    let errorMessage = (response?.data as { error: string })?.error;
+    if (!errorMessage) {
+      errorMessage = (e as AxiosError).message;
+    }
     throw new RequestError(`HTTP request failed ${errorMessage ? "due to " + errorMessage : ""}.`, response?.status);
   }
 }


### PR DESCRIPTION
### Description

The expected behavior was that in case the request failed, we would have an `error` in response.
but as we see, this is not the general behavior; we handled this by getting the error message from the `AxiosError`



### Related Issues

- #1641 
- #1585 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
