### PR TITLE
show manual link on sign up

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -66,7 +66,7 @@
       <v-card-title class="pa-0">TFChain Wallet</v-card-title>
     </v-card>
     <WebletLayout disable-alerts>
-      <v-alert variant="tonal" class="mb-6" v-if="activeTab === 0">
+      <v-alert variant="tonal" class="mb-6">
         <p :style="{ maxWidth: '880px' }">
           Please visit
           <a class="app-link" href="https://manual.grid.tf/playground/wallet_connector.html" target="_blank">


### PR DESCRIPTION
### Description

Show manual link on signup.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/d0bb1e49-f92e-42da-8884-e1789172213e)


### Changes

- Removed the condition that only showed the manual link in the login page of the profile manager.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1625

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
