### PR TITLE
disable loading after loading the twin data

### DIFF
--- a/packages/playground/src/components/node_details_cards/twin_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/twin_details_card.vue
@@ -47,6 +47,7 @@ export default {
         }
       } else if (props.node) {
         twin.value = props.node.twin;
+        loading.value = false;
       }
       twinFields.value = getNodeTwinDetailsCard();
     });


### PR DESCRIPTION
### Description

Fix infinite loading of the twin data in the node details.

[Screencast from 11-12-23 14:07:38.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/d8bf29fa-7f6a-4e99-867e-2173f6814dfb)

### Changes

- Disabled loading after loading the twin data.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1603

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
