### PR TITLE
remove on-mount in user nodes

### DIFF
--- a/packages/playground/src/dashboard/components/user_nodes.vue
+++ b/packages/playground/src/dashboard/components/user_nodes.vue
@@ -117,7 +117,7 @@
 
 <script lang="ts">
 import moment from "moment";
-import { onMounted, ref } from "vue";
+import { ref } from "vue";
 import { capitalize } from "vue";
 
 import { gridProxyClient } from "@/clients";
@@ -191,8 +191,6 @@ export default {
     const receiptsPanel = ref([]);
     const uptime = ref();
     const nodesCount = ref();
-
-    onMounted(getUserNodes);
 
     async function reloadNodes() {
       setTimeout(async () => {


### PR DESCRIPTION
@update:options got triggered at `onmount` so the `getUserNodes` called twice


### Related Issues

- #1570

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
