### PR TITLE
close farm dialog after the farm is created

### DIFF
--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -83,6 +83,7 @@ export default {
         await gridStore.grid.farms.create({ name: props.name });
         createCustomToast("Farm created successfully.", ToastType.success);
         createCustomToast("Table may take sometime to update the changes.", ToastType.info);
+        showDialogue.value = false;
         await props.userFarms.reloadFarms();
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
### Description

Close farm dialog after the farm is created.

[Screencast from 11-12-23 15:30:17.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/5321b31f-6a5f-4483-9cbf-bc3332b66122)

### Changes

- Updated the `showDialogue` value to false after the farm is created.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1609

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
