### PR TITLE
adding node options command to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ yarn install
 yarn lerna run build
 ```
 
+> If the build fails due to a memory issue, please use the following command
+
+```bash
+export NODE_OPTIONS="--max-old-space-size=8192"
+```
+
 ## Related Documentations
 
 - [Configure the editor/IDE](./docs/editor_config.md)

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -27,6 +27,12 @@ Playground is a Vue application that helps with deploying solutions on TF Grid v
   make build
   ```
 
+  > If the build fails due to a memory issue, please use the following command
+
+```bash
+export NODE_OPTIONS="--max-old-space-size=8192"
+```
+
 ## Getting Started
 
 > For detailed information you can read the [Getting Started](./docs/getting_started.md) documentation.


### PR DESCRIPTION
### Description

Added the node options command to the readme.

### Changes

- Added the following command to the sdk ts and playground readme files.

  ```
  export NODE_OPTIONS="--max-old-space-size=8192"
  ```
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1624

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
