### PR TITLE
set nodes count to 0 if there're no nodes to display

### DIFF
--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -160,6 +160,9 @@ export default {
           if (count) {
             nodesCount.value = count;
           }
+          if (count == 0) {
+            nodesCount.value = 0;
+          }
         } catch (err) {
           console.log(err);
         } finally {


### PR DESCRIPTION
### Description

Fix count  if there're no nodes to display in the Nodes table.

[Screencast from 13-12-23 11:25:18.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/15be94c2-3002-4a12-bbec-14acf005a9d1)


### Changes

- Added a condition to set the nodesCount to 0 if the count is equal to 0.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1604

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
