### PR TITLE
remove sorting in farms table

### DIFF
--- a/packages/playground/src/types/index.ts
+++ b/packages/playground/src/types/index.ts
@@ -245,14 +245,10 @@ export type NodeFilterOptions = {
   page: number;
   size: number;
 };
-type TableSortOption = {
-  key: string | undefined;
-  order: boolean | "desc" | "asc" | undefined;
-};
+
 export type FarmFilterOptions = {
   page?: number;
   size?: number;
-  sortBy?: TableSortOption[];
 };
 
 export const nodeOptionsInitializer: NodeFilterOptions = {

--- a/packages/playground/src/views/farms.vue
+++ b/packages/playground/src/views/farms.vue
@@ -13,8 +13,6 @@
           :loading="loading"
           :headers="headers"
           :items="farms"
-          :sort-asc-icon="false"
-          :sort-desc-icon="false"
           :items-length="totalFarms"
           :items-per-page-options="[
             { value: 5, title: '5' },
@@ -23,9 +21,7 @@
           ]"
           v-model:items-per-page="size"
           v-model:page="page"
-          v-bind:sortable="false"
-          :on-update:sort-by="undefined"
-          class="elevation-1"
+          :disable-sort="true"
           :on-update:model-value="updateQueries"
           @click:row="openSheet"
         >
@@ -165,8 +161,8 @@ const closeDialog = () => {
 };
 
 const headers: VDataTableHeader = [
-  { title: "ID", key: "farmId" },
-  { title: "Name", key: "name" },
+  { title: "ID", key: "farmId", sortable: false },
+  { title: "Name", key: "name", sortable: false },
   {
     title: "Total Public IPs",
     key: "totalPublicIp",

--- a/packages/playground/src/views/farms.vue
+++ b/packages/playground/src/views/farms.vue
@@ -26,9 +26,7 @@
           v-bind:sortable="false"
           :on-update:sort-by="undefined"
           class="elevation-1"
-          :on-update:items-per-page="updateQueries"
           :on-update:model-value="updateQueries"
-          :on-update:page="updateQueries"
           @click:row="openSheet"
         >
           <template #loading />


### PR DESCRIPTION
### Description

removed sorting farms table

### Changes

- remove sorting icons on farm ID and name
- remove sorting functions and types
- change watcher to update table only on page,size or filter changes

### Related Issues
#45

