### PR TITLE
Use substrate tools instead of bip93 when getting the seed from the mnemonic

### DIFF
--- a/packages/rmb_direct_client/lib/sign.ts
+++ b/packages/rmb_direct_client/lib/sign.ts
@@ -1,5 +1,6 @@
 import { getSharedSecret, utils } from "@noble/secp256k1";
 import { KeyringPair } from "@polkadot/keyring/types";
+import { mnemonicToMiniSecret } from "@polkadot/util-crypto";
 import { isAddress } from "@polkadot/util-crypto";
 import { ValidationError } from "@threefold/types";
 import { mnemonicToSeedSync, validateMnemonic } from "bip39";
@@ -25,7 +26,7 @@ export function createShared(pubKey: Uint8Array, hexSeedOrMnemonic: string) {
   } else if (hexSeedOrMnemonic.length === 64 && isAddress(`0x${hexSeedOrMnemonic}`)) {
     privateKey = hexSeedOrMnemonic;
   } else if (validateMnemonic(hexSeedOrMnemonic)) {
-    const seed = mnemonicToSeedSync(hexSeedOrMnemonic);
+    const seed = mnemonicToMiniSecret(hexSeedOrMnemonic);
     privateKey = new Uint8Array(seed).slice(0, 32);
   } else {
     throw new ValidationError(`Expected a valid mnemonic or hexSeed in "createShared" but got "${hexSeedOrMnemonic}".`);

--- a/packages/rmb_direct_client/lib/util.ts
+++ b/packages/rmb_direct_client/lib/util.ts
@@ -1,4 +1,5 @@
 import * as secp from "@noble/secp256k1";
+import { mnemonicToMiniSecret } from "@polkadot/util-crypto";
 import { ValidationError } from "@threefold/types";
 import * as bip39 from "bip39";
 import { Buffer } from "buffer";
@@ -17,8 +18,7 @@ export function generatePublicKey(secret: string) {
   let privKey;
 
   if (bip39.validateMnemonic(secret)) {
-    const seed = bip39.mnemonicToSeedSync(secret);
-    privKey = new Uint8Array(seed).slice(0, 32);
+    privKey = mnemonicToMiniSecret(secret);
   } else {
     privKey = secret;
     if (secret.startsWith("0x")) {

--- a/packages/rmb_direct_client/tsconfig-node.json
+++ b/packages/rmb_direct_client/tsconfig-node.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     "declaration": true,
     "outDir": "./dist/node",
+    "allowJs": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true


### PR DESCRIPTION
### Description

Use substrate tools instead of bip93 when getting the seed from the mnemonic

### Related Issues

- #1694 
- #1698
 
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
