### PR TITLE
Enhance loading node details, display the actual status, node stats as NA

### DIFF
--- a/packages/playground/src/components/node_details.vue
+++ b/packages/playground/src/components/node_details.vue
@@ -139,6 +139,7 @@ export default {
       isError.value = false;
       isLiveStats.value = false;
       errorLoadingStatsMessage.value = undefined;
+      nodeOptions.loadStats = true;
 
       if (props.nodeId > 0) {
         try {
@@ -155,11 +156,7 @@ export default {
           errorLoadingStatsMessage.value =
             "The node appears like it's up but it is physically down maybe because it's gone to offline mode.";
           nodeOptions.loadStats = false;
-
-          if (props.filterOptions.gpu && !nodeOptions.loadGpu) {
-            nodeOptions.loadGpu = true;
-          }
-
+          nodeOptions.loadGpu = false;
           try {
             const _node: GridNode = await getNode(props.nodeId, nodeOptions);
             node.value = _node;

--- a/packages/playground/src/components/node_details.vue
+++ b/packages/playground/src/components/node_details.vue
@@ -53,7 +53,7 @@
             <interfaces-details-card :node="node" />
           </v-col>
           <v-col v-if="node.cards?.length || node.num_gpu > 0" cols="12" md="6" sm="8">
-            <gpu-details-card :node="node" />
+            <gpu-details-card :node="node" :nodeOptions="nodeOptions" />
           </v-col>
           <v-col v-if="node.publicConfig && node.publicConfig.domain" cols="12" md="6" sm="8">
             <public-config-details-card :node="node" />
@@ -190,6 +190,7 @@ export default {
       errorMessage,
       isLiveStats,
       errorLoadingStatsMessage,
+      nodeOptions,
       requestNode,
       closeDialog,
       getNodeStatusColor,

--- a/packages/playground/src/components/node_details.vue
+++ b/packages/playground/src/components/node_details.vue
@@ -13,14 +13,12 @@
         </v-btn>
       </div>
     </v-toolbar>
-
     <template v-if="loading">
       <v-card class="d-flex justify-center align-center h-screen">
         <v-progress-circular color="primary" indeterminate :size="128" :width="5" />
         <p class="mt-2">Loading node details...</p>
       </v-card>
     </template>
-
     <template v-else-if="isError">
       <v-card class="d-flex justify-center align-center h-screen">
         <div class="text-center w-100 pa-3">
@@ -54,7 +52,7 @@
           <v-col cols="12" md="6" sm="8">
             <interfaces-details-card :node="node" />
           </v-col>
-          <v-col v-if="node.cards?.length" cols="12" md="6" sm="8">
+          <v-col v-if="node.cards?.length || node.num_gpu > 0" cols="12" md="6" sm="8">
             <gpu-details-card :node="node" />
           </v-col>
           <v-col v-if="node.publicConfig && node.publicConfig.domain" cols="12" md="6" sm="8">

--- a/packages/playground/src/components/node_details.vue
+++ b/packages/playground/src/components/node_details.vue
@@ -41,7 +41,7 @@
           </v-col>
           <v-col cols="12" md="6" sm="8">
             <country-details-card :node="node" />
-            <location-details-card :node="node" />
+            <location-details-card class="mt-5" :node="node" />
           </v-col>
           <v-col cols="12" md="6" sm="8">
             <farm-details-card :node="node" />

--- a/packages/playground/src/components/node_details_cards/gpu_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/gpu_details_card.vue
@@ -6,7 +6,7 @@
     :items="gpuFields"
     icon="mdi-credit-card-settings-outline"
   >
-    <template #gpu-hint-message>
+    <template #gpu-hint-message v-if="node.cards?.length">
       <v-chip class="d-flex justify-center ma-4 mt-1" color="info">
         Select a GPU card ID from the below selection to load its data.
       </v-chip>
@@ -23,6 +23,19 @@
         </v-col>
       </v-row>
     </template>
+
+    <!-- <template v-else-if="isError">
+      <v-card class="d-flex justify-center align-center h-screen">
+        <div class="text-center w-100 pa-3">
+          <v-icon variant="tonal" color="error" style="font-size: 50px" icon="mdi-close-circle-outline" />
+          <p class="mt-4 mb-4 font-weight-bold text-error">
+            {{ errorMessage }}
+          </p>
+          <v-btn class="mr-4" @click="requestNode" color="primary" text="Try Again" />
+          <v-btn @click="(val:boolean) => closeDialog(val)" color="error" variant="outlined" text="Cancel" />
+        </div>
+      </v-card>
+    </template> -->
   </card-details>
 </template>
 
@@ -61,12 +74,14 @@ export default {
 
     const mount = () => {
       loading.value = true;
-      selectedCard.value = props.node.cards[0];
-      props.node.cards.map((card: GPUCard) => {
-        cardsIds.value.push(card.id);
-      });
-      cardId.value = cardsIds.value[0];
-      gpuFields.value = getNodeTwinDetailsCard();
+      if (props.node.cards?.length > 0) {
+        selectedCard.value = props.node.cards[0];
+        props.node.cards.map((card: GPUCard) => {
+          cardsIds.value.push(card.id);
+        });
+        cardId.value = cardsIds.value[0];
+        gpuFields.value = getNodeTwinDetailsCard();
+      }
       loading.value = false;
     };
 

--- a/packages/playground/src/components/node_details_cards/gpu_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/gpu_details_card.vue
@@ -61,7 +61,7 @@ export default {
     },
     nodeOptions: {
       type: Object as PropType<GridProxyRequestConfig>,
-      required: true,
+      required: false,
     },
   },
 
@@ -101,16 +101,15 @@ export default {
     onMounted(mount);
 
     async function RerequestNode() {
-      nodeOptions.value.loadGpu = true;
       errorMessage.value = "";
       isError.value = false;
-      if (node.value.nodeId > 0) {
+      if (node.value.nodeId > 0 && nodeOptions.value) {
+        nodeOptions.value.loadGpu = true;
         try {
           loading.value = true;
 
           const _node: GridNode = await getNode(node.value.nodeId, nodeOptions.value);
           node.value = _node;
-          // console.log("node", node.value);
           mount();
         } catch (_) {
           isError.value = true;

--- a/packages/playground/src/components/node_details_cards/gpu_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/gpu_details_card.vue
@@ -6,36 +6,36 @@
     :items="gpuFields"
     icon="mdi-credit-card-settings-outline"
   >
-    <template #gpu-hint-message v-if="node.cards?.length">
-      <v-chip class="d-flex justify-center ma-4 mt-1" color="info">
-        Select a GPU card ID from the below selection to load its data.
-      </v-chip>
-      <v-row class="bb-gray">
-        <v-col class="ml-3 d-flex justify-start align-center">
-          Card ID
-          <v-chip class="ml-4" :color="selectedCard.contract ? 'warning' : 'primary'">
-            {{ selectedCard.contract ? "Reserved" : "Available" }}
-          </v-chip>
-        </v-col>
-        <v-col class="mr-3 d-flex justify-end align-center">
-          <v-select chips clearable hide-details="auto" v-model="cardId" :items="cardsIds" variant="outlined" />
-          <v-icon class="ml-1" :icon="'mdi-content-copy'" @click="copy(cardId)" />
-        </v-col>
-      </v-row>
+    <template #gpu-hint-message>
+      <div v-if="node.cards?.length">
+        <v-chip class="d-flex justify-center ma-4 mt-1" color="info">
+          Select a GPU card ID from the below selection to load its data.
+        </v-chip>
+        <v-row class="bb-gray">
+          <v-col class="ml-3 d-flex justify-start align-center">
+            Card ID
+            <v-chip class="ml-4" :color="selectedCard.contract ? 'warning' : 'primary'">
+              {{ selectedCard.contract ? "Reserved" : "Available" }}
+            </v-chip>
+          </v-col>
+          <v-col class="mr-3 d-flex justify-end align-center">
+            <v-select chips clearable hide-details="auto" v-model="cardId" :items="cardsIds" variant="outlined" />
+            <v-icon class="ml-1" :icon="'mdi-content-copy'" @click="copy(cardId)" />
+          </v-col>
+        </v-row>
+      </div>
+      <div v-if="isError">
+        <v-card class="d-flex justify-center align-center">
+          <div class="text-center">
+            <v-icon variant="tonal" color="error" style="font-size: 50px" icon="mdi-close-circle-outline" />
+            <p class="mt-4 mb-4 font-weight-bold text-error">
+              {{ errorMessage }}
+            </p>
+            <!-- <v-btn class="mr-4" @click="requestNode" color="primary" text="Try Again" /> -->
+          </div>
+        </v-card>
+      </div>
     </template>
-
-    <!-- <template v-else-if="isError">
-      <v-card class="d-flex justify-center align-center h-screen">
-        <div class="text-center w-100 pa-3">
-          <v-icon variant="tonal" color="error" style="font-size: 50px" icon="mdi-close-circle-outline" />
-          <p class="mt-4 mb-4 font-weight-bold text-error">
-            {{ errorMessage }}
-          </p>
-          <v-btn class="mr-4" @click="requestNode" color="primary" text="Try Again" />
-          <v-btn @click="(val:boolean) => closeDialog(val)" color="error" variant="outlined" text="Cancel" />
-        </div>
-      </v-card>
-    </template> -->
   </card-details>
 </template>
 
@@ -65,6 +65,8 @@ export default {
     const cardsIds = ref<string[]>([]);
     const cardId = ref<string>("");
     const selectedCard = ref<GPUCard>(props.node.cards[0]);
+    const isError = ref<boolean>(false);
+    const errorMessage = ref("");
 
     watch(cardId, newCardId => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -81,6 +83,9 @@ export default {
         });
         cardId.value = cardsIds.value[0];
         gpuFields.value = getNodeTwinDetailsCard();
+      } else {
+        isError.value = true;
+        errorMessage.value = `Failed to load node with ID ${props.node.nodeId}. The node might be offline or unresponsive. You can try requesting it again.`;
       }
       loading.value = false;
     };
@@ -117,6 +122,8 @@ export default {
       cardsIds,
       cardId,
       selectedCard,
+      isError,
+      errorMessage,
       copy,
     };
   },

--- a/packages/playground/src/components/node_details_cards/interfaces_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/interfaces_details_card.vue
@@ -1,5 +1,6 @@
 <template>
   <card-details
+    v-if="interfacesDetails"
     :loading="loading"
     title="Interfaces Details"
     :items="interfaceFields"
@@ -76,6 +77,7 @@ export default {
     return {
       interfaceFields,
       loading,
+      interfacesDetails,
     };
   },
 };

--- a/packages/playground/src/components/node_resources_charts.vue
+++ b/packages/playground/src/components/node_resources_charts.vue
@@ -92,7 +92,7 @@ export default {
               Reflect.get(props.node.stats.total, i)) *
             100;
         } else {
-          value = NaN;
+          value = (Reflect.get(props.node.used_resources, i) / Reflect.get(props.node.total_resources, i)) * 100;
         }
         loading.value = false;
         return {

--- a/packages/playground/src/components/node_resources_charts.vue
+++ b/packages/playground/src/components/node_resources_charts.vue
@@ -5,9 +5,12 @@
         <h2 class="node-resources-title text-center text-h5 flex justify-center items-center">
           <v-icon size="32" class="mr-2">mdi-chart-pie</v-icon>
           Node {{ node.nodeId }} Resources
-          <v-chip :color="getNodeStatusColor(node.status).color">
+
+          <v-chip v-if="isLiveStats" :color="getNodeStatusColor(node.status).color">
             {{ node.status === NodeStatus.Up ? "Online" : node.status === NodeStatus.Standby ? "Standby" : "Offline" }}
           </v-chip>
+          <!-- As isLiveStats=False means we can't reach the node to get the stats from it live. -->
+          <v-chip v-else :color="getNodeStatusColor(NodeStatus.Down).color"> Offline </v-chip>
         </h2>
       </v-col>
     </v-row>
@@ -25,17 +28,19 @@
 
     <v-row justify="center">
       <v-progress-circular v-if="loading" indeterminate color="primary" :size="50" class="mt-10 mb-10" />
-
       <v-btn
         rounded="md"
         variant="flat"
         color="primary"
         v-if="isNodeReadyToVisit()"
-        class="mt-15"
+        class="mt-10"
         @click="getNodeHealthUrl"
       >
         Check Node Health
       </v-btn>
+    </v-row>
+    <v-row justify="center" class="w-50 mt-10" style="margin: 0 auto">
+      <v-alert variant="tonal" type="warning" v-if="hintMessage">{{ hintMessage }}</v-alert>
     </v-row>
   </div>
 </template>
@@ -52,6 +57,14 @@ export default {
   props: {
     node: {
       type: Object as PropType<GridNode>,
+      required: true,
+    },
+    isLiveStats: {
+      type: Boolean,
+      required: true,
+    },
+    hintMessage: {
+      type: Object as PropType<string | undefined>,
       required: true,
     },
   },

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -92,7 +92,7 @@
       </div>
     </div>
     <node-details
-      :options="selectedNodeoptions"
+      :filter-options="filterOptions"
       :nodeId="selectedNodeId"
       :openDialog="isDialogOpened"
       @close-dialog="closeDialog"
@@ -104,8 +104,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { type GridNode, type NodesQuery, NodeStatus } from "@threefold/gridproxy_client";
 import debounce from "lodash/debounce.js";
-import { capitalize, onMounted, ref, watch } from "vue";
-import { computed } from "vue";
+import { capitalize, computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
 import NodeDetails from "@/components/node_details.vue";
@@ -137,12 +136,6 @@ export default {
     const nodesCount = ref<number>(0);
 
     const selectedNodeId = ref<number>(0);
-    const selectedNodeoptions = ref<GridProxyRequestConfig>({
-      loadFarm: true,
-      loadTwin: true,
-      loadStats: true,
-      loadGpu: true,
-    });
 
     const isDialogOpened = ref<boolean>(false);
     const isValidForm = ref<boolean>(false);
@@ -157,7 +150,7 @@ export default {
         try {
           const { count, data } = await requestNodes(queries, config);
           nodes.value = data;
-            nodesCount.value = count ?? 0
+          nodesCount.value = count ?? 0;
         } catch (err) {
           console.log(err);
         } finally {
@@ -225,7 +218,6 @@ export default {
       nodesCount,
 
       selectedNodeId,
-      selectedNodeoptions,
       nodeStatusOptions,
 
       filterInputs,


### PR DESCRIPTION
…
### Description

Improved the node details page by dynamically fetching node information from the grid proxy, eliminating error displays. Additionally, introduced a warning alert to notify users when the node seems operational but is physically offline—possibly due to entering an offline mode. This enhancement aims to provide a more seamless user experience and informative feedback on the node's status.

- Modified the node details page to fetch node information from the grid proxy.
- Added a warning alert to inform users when the node appears to be up but is physically down, suggesting it may be in an offline mode.
- Improved error handling for a more user-friendly experience.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1651

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/8617af77-1d47-4ff8-8d34-fc860572b895)


### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
