### PR TITLE
add hint when no farms

### DIFF
--- a/packages/playground/src/dashboard/components/user_farms.vue
+++ b/packages/playground/src/dashboard/components/user_farms.vue
@@ -7,7 +7,7 @@
       single-line
       hide-details
     ></v-text-field>
-    <v-alert type="info" variant="tonal" v-if="farmsCount == 0">
+    <v-alert type="warning" variant="tonal" v-if="farmsCount == 0" class="my-8">
       Can't see any of your farms? Try changing your key type in your TFChain Wallet above.
     </v-alert>
     <v-data-table-server

--- a/packages/playground/src/dashboard/components/user_farms.vue
+++ b/packages/playground/src/dashboard/components/user_farms.vue
@@ -7,6 +7,9 @@
       single-line
       hide-details
     ></v-text-field>
+    <v-alert type="info" variant="tonal" v-if="farmsCount == 0">
+      Can't see any of your farms? Try changing your key type in your TFChain Wallet above.
+    </v-alert>
     <v-data-table-server
       :loading="loading"
       :items-length="farmsCount"


### PR DESCRIPTION
### Description

added a hint to the user to change key types from TFChain wallet when he/she cannot see their farms. 

### Related Issues

#1707

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/f201b6f8-c635-4eed-986a-e6cc6ee5e0a4)
