### PR TITLE
fix: flatten vm array to fix sort casuing error in caprover and workers based solutions

### DIFF
--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -153,7 +153,12 @@ async function loadDeployments() {
   ];
 
   count.value = vms.count;
-  items.value = vms.items.flat(1);
+  items.value = vms.items.map(([leader, ...workers]) => {
+    if (workers.length) {
+      leader.workers = workers;
+    }
+    return leader;
+  });
 
   loading.value = false;
 }

--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -68,7 +68,7 @@
           <ManageCaproverWorkerDialog
             v-if="dialog === item.value.deploymentName"
             :master="item.value"
-            :data="item.value.workers"
+            :data="item.value.workers || []"
             :project-name="item.value.projectName"
             @close="dialog = undefined"
             @update:caprover="item.value = $event"

--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -67,9 +67,9 @@
 
           <ManageCaproverWorkerDialog
             v-if="dialog === item.value.deploymentName"
-            :master="item.value[0]"
-            :data="item.value.slice(1)"
-            :project-name="item.value.projectName || item.value[0].projectName"
+            :master="item.value"
+            :data="item.value.workers"
+            :project-name="item.value.projectName"
             @close="dialog = undefined"
             @update:caprover="item.value = $event"
           />


### PR DESCRIPTION
### Description
flatten vm array to fix sort casuing error in caprover and workers based solutions

### Changes
- group workers of vms into an array in leader objec

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1726

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
