### PR TITLE
fix: add limit 1 to validation tries

### DIFF
--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -210,6 +210,7 @@ export default {
     const nodeInputValidateTask = useAsync<true, string, [NodeInfo | undefined]>(
       node => checkNodeCapacityPool(gridStore, node, props.filters),
       {
+        tries: 1,
         shouldRun: () => props.validFilters,
         onBeforeTask: () => bindStatus(ValidatorStatus.Pending),
         onAfterTask: ({ data }) => bindStatus(data ? ValidatorStatus.Valid : ValidatorStatus.Invalid),

--- a/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
@@ -153,6 +153,7 @@ export default {
         return true;
       },
       {
+        tries: 1,
         onReset: bindStatus,
         shouldRun: () => props.validFilters,
         onBeforeTask: () => bindStatus(ValidatorStatus.Pending),


### PR DESCRIPTION
### Description
While working with useAsync I notice that validation is done 3 times (if valid) which not bad in case a user have bad connection but too bad if task takes long time 

### Changes
limit tries to 1 to validation tasks

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1760

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
