### PR TITLE
Fix check node health URL

### DIFF
--- a/packages/playground/src/utils/get_metrics_url.ts
+++ b/packages/playground/src/utils/get_metrics_url.ts
@@ -1,4 +1,7 @@
-import GridProxyClient, { type GridNode, type TwinsQuery } from "@threefold/gridproxy_client";
+import type GridProxyClient from "@threefold/gridproxy_client";
+import type { GridNode, TwinsQuery } from "@threefold/gridproxy_client";
+
+import { gridProxyClient } from "@/clients";
 
 export interface IGrafanaArgs {
   farmID: number;
@@ -18,11 +21,11 @@ export class GrafanaStatistics {
   constructor(node: GridNode, orgID = 2) {
     this.node = node;
     const network = process.env.NETWORK || (window as any).env.NETWORK;
-    const client = new GridProxyClient(network);
+    const client = gridProxyClient;
     this.client = client;
     this.twinID = node.twinId;
     this.farmID = node.farmId;
-    this.network = process.env.NETWORK || (window as any).env.NETWORK;
+    this.network = network;
     this.updateNetwork();
     this.orgID = orgID;
     this.accountID = "";


### PR DESCRIPTION
### Description

- Issue happened because the created instance didn't have a URL. Fixed by using an already-made one.

### Changes

- Use created Proxy instance when get node metrics instead of created new one
- refactor this.network

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1748

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
