### PR TITLE
add filter and pagination reset when status is changed

### DIFF
--- a/packages/playground/src/components/filter.vue
+++ b/packages/playground/src/components/filter.vue
@@ -77,7 +77,7 @@ const props = defineProps({
   valid: Boolean,
 });
 
-const emit = defineEmits(["update:model-value", "update:valid", "update:options"]);
+const emit = defineEmits(["update:model-value", "update:valid"]);
 
 const formRef = useFormRef();
 const panel = ref([0]);
@@ -89,9 +89,7 @@ watch(
     const hasNonEmptyValue = Object.keys(newValue).some(obj => {
       return Reflect.get(newValue, obj).value && Reflect.get(newValue, obj).value.length >= 1;
     });
-    emit("update:options");
-
-    isFiltersTouched.value = hasNonEmptyValue;
+    emit("update:model-value", props.modelValue), (isFiltersTouched.value = hasNonEmptyValue);
   },
   { deep: true },
 );

--- a/packages/playground/src/components/filter.vue
+++ b/packages/playground/src/components/filter.vue
@@ -77,7 +77,7 @@ const props = defineProps({
   valid: Boolean,
 });
 
-const emit = defineEmits(["update:model-value", "update:valid"]);
+const emit = defineEmits(["update:model-value", "update:valid", "update:options"]);
 
 const formRef = useFormRef();
 const panel = ref([0]);
@@ -89,6 +89,7 @@ watch(
     const hasNonEmptyValue = Object.keys(newValue).some(obj => {
       return Reflect.get(newValue, obj).value && Reflect.get(newValue, obj).value.length >= 1;
     });
+    emit("update:options");
 
     isFiltersTouched.value = hasNonEmptyValue;
   },

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -10,8 +10,6 @@
       :form-disabled="isFormLoading"
       v-model:model-value="filterInputs"
       v-model:valid="isValidForm"
-      :options="filterOptions"
-      @update:options="pagReset"
       @update:model-value="inputFiltersReset"
     />
     <div class="nodes mt-5">
@@ -186,9 +184,7 @@ export default {
       filterInputs.value = filtersInputValues;
       filterOptions.value = optionsInitializer();
     };
-    const pagReset = () => {
-      filterOptions.value = optionsInitializer();
-    };
+
     const statusReset = () => {
       const options = mixedFilters.value.options;
       options.page = 1;
@@ -234,7 +230,6 @@ export default {
       selectedNodeoptions,
       nodeStatusOptions,
       statusReset,
-      pagReset,
 
       filterInputs,
       filterOptions,

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -8,8 +8,10 @@
   <view-layout>
     <filters
       :form-disabled="isFormLoading"
-      :model-value="filterInputs"
+      v-model:model-value="filterInputs"
       v-model:valid="isValidForm"
+      v-model:options="filterOptions"
+      @update:options="pagReset"
       @update:model-value="inputFiltersReset"
     />
     <div class="nodes mt-5">
@@ -182,16 +184,12 @@ export default {
     // The filters should reset to the default value again..
     const inputFiltersReset = (filtersInputValues: FilterInputs) => {
       filterInputs.value = filtersInputValues;
-      filterOptions.value = {
-        ...filterOptions.value,
-        status: NodeStatus.Up,
-        gpu: undefined,
-        gateway: undefined,
-        page: 1,
-        size: 10,
-      };
+      filterOptions.value = optionsInitializer();
     };
-    const statusReset = (status: NodeStatus) => {
+    const pagReset = () => {
+      filterOptions.value = optionsInitializer();
+    };
+    const statusReset = () => {
       const options = mixedFilters.value.options;
       options.page = 1;
       options.size = 10;
@@ -236,6 +234,7 @@ export default {
       selectedNodeoptions,
       nodeStatusOptions,
       statusReset,
+      pagReset,
 
       filterInputs,
       filterOptions,

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -10,7 +10,7 @@
       :form-disabled="isFormLoading"
       v-model:model-value="filterInputs"
       v-model:valid="isValidForm"
-      v-model:options="filterOptions"
+      :options="filterOptions"
       @update:options="pagReset"
       @update:model-value="inputFiltersReset"
     />

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -64,6 +64,7 @@
                           label="Select Nodes Status"
                           variant="underlined"
                           :disabled="isFormLoading"
+                          @update:model-value="statusReset"
                           open-on-clear
                           clearable
                         ></v-select>
@@ -190,7 +191,14 @@ export default {
         size: 10,
       };
     };
+    const statusReset = (status: NodeStatus) => {
+      const options = mixedFilters.value.options;
+      options.page = 1;
+      options.size = 10;
+      // reset filters
 
+      filterInputs.value = inputsInitializer();
+    };
     const checkSelectedNode = async () => {
       if (route.query.nodeId) {
         selectedNodeId.value = +route.query.nodeId;
@@ -227,6 +235,7 @@ export default {
       selectedNodeId,
       selectedNodeoptions,
       nodeStatusOptions,
+      statusReset,
 
       filterInputs,
       filterOptions,


### PR DESCRIPTION
### Description

added a reset function for status change to reset pagination and filters when the node status selected is changed 

### Changes

- statusReset function: 
      - watches for change in filterOptions.status and resets pagination page and size along with filter inputs 

### Related Issues

#1604 

