### PR TITLE
Fix the disconnection when killing the process

### DIFF
--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -120,7 +120,6 @@ class GridClient {
     }
 
     await this.testConnectionUrls(urls);
-    await this.rmbClient.connect();
 
     if (BackendStorage.isEnvNode()) {
       process.on("SIGTERM", this.disconnectAndExit);
@@ -133,8 +132,8 @@ class GridClient {
       };
       window.onunload = this.disconnect;
     }
-
     this._connect();
+    await this.rmbClient.connect();
     await migrateKeysEncryption.apply(this, [GridClient]);
   }
 

--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -120,6 +120,7 @@ class GridClient {
     }
 
     await this.testConnectionUrls(urls);
+    await this.rmbClient.connect();
 
     if (BackendStorage.isEnvNode()) {
       process.on("SIGTERM", this.disconnectAndExit);
@@ -134,7 +135,6 @@ class GridClient {
     }
 
     this._connect();
-    await this.rmbClient.connect();
     await migrateKeysEncryption.apply(this, [GridClient]);
   }
 
@@ -230,8 +230,7 @@ class GridClient {
   }
 
   async disconnectAndExit(): Promise<void> {
-    if (this.tfclient) await this.tfclient.disconnect();
-    if (this.rmbClient) await this.rmbClient.close();
+    await this.disconnect();
     process.removeAllListeners();
     process.exit(0);
   }

--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -126,8 +126,6 @@ class GridClient {
       process.on("SIGINT", this.disconnectAndExit);
       process.on("SIGUSR1", this.disconnectAndExit);
       process.on("SIGUSR2", this.disconnectAndExit);
-      //TODO move this line to disconnectAndExit
-      process.removeAllListeners();
     } else {
       window.onbeforeunload = () => {
         return "";
@@ -234,6 +232,7 @@ class GridClient {
   async disconnectAndExit(): Promise<void> {
     if (this.tfclient) await this.tfclient.disconnect();
     if (this.rmbClient) await this.rmbClient.close();
+    process.removeAllListeners();
     process.exit(0);
   }
 

--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -120,18 +120,6 @@ class GridClient {
     }
 
     await this.testConnectionUrls(urls);
-
-    if (BackendStorage.isEnvNode()) {
-      process.on("SIGTERM", this.disconnectAndExit);
-      process.on("SIGINT", this.disconnectAndExit);
-      process.on("SIGUSR1", this.disconnectAndExit);
-      process.on("SIGUSR2", this.disconnectAndExit);
-    } else {
-      window.onbeforeunload = () => {
-        return "";
-      };
-      window.onunload = this.disconnect;
-    }
     this._connect();
     await this.rmbClient.connect();
     await migrateKeysEncryption.apply(this, [GridClient]);
@@ -225,13 +213,7 @@ class GridClient {
 
   async disconnect(): Promise<void> {
     if (this.tfclient) await this.tfclient.disconnect();
-    if (this.rmbClient) await this.rmbClient.close();
-  }
-
-  async disconnectAndExit(): Promise<void> {
-    await this.disconnect();
-    process.removeAllListeners();
-    process.exit(0);
+    if (this.rmbClient) await this.rmbClient.disconnect();
   }
 
   async invoke(message, args) {

--- a/packages/tfchain_client/src/client.ts
+++ b/packages/tfchain_client/src/client.ts
@@ -129,13 +129,14 @@ class QueryClient {
     }
   }
 
-  async disconnect(): Promise<void> {
-    if (QueryClient.connections.has(this.url)) {
-      this.api = QueryClient.connections.get(this.url)!.api;
+  async disconnect(url?: string): Promise<void> {
+    const clientUrl = url || this.url;
+    if (QueryClient.connections.has(clientUrl)) {
+      this.api = QueryClient.connections.get(clientUrl)!.api;
     }
     if (this.api && this.api.isConnected) {
       console.log("disconnecting");
-      this.api.off("disconnected", QueryClient.connections.get(this.url)!.disconnectHandler);
+      this.api.off("disconnected", QueryClient.connections.get(clientUrl)!.disconnectHandler);
       await this.api.disconnect();
       await this.wait(false);
     }
@@ -143,8 +144,11 @@ class QueryClient {
 
   async disconnectAndExit(): Promise<void> {
     // this should be only used by nodejs process
-    // TODO: loop on map keys
-    await this.disconnect();
+
+    for (const [key] of QueryClient.connections) {
+      await this.disconnect(key);
+    }
+
     process.removeAllListeners();
     process.exit(0);
   }

--- a/packages/tfchain_client/src/client.ts
+++ b/packages/tfchain_client/src/client.ts
@@ -143,7 +143,9 @@ class QueryClient {
 
   async disconnectAndExit(): Promise<void> {
     // this should be only used by nodejs process
+    // TODO: loop on map keys
     await this.disconnect();
+    process.removeAllListeners();
     process.exit(0);
   }
 

--- a/packages/tfchain_client/src/client.ts
+++ b/packages/tfchain_client/src/client.ts
@@ -317,7 +317,6 @@ class Client extends QueryClient {
     const promise = new Promise(async (resolve, reject) => {
       function callback(res) {
         if (res instanceof Error) {
-          console.error(res);
           reject(res);
         }
         const { events = [], status } = res;


### PR DESCRIPTION
### Description

Fix the disconnection when killing the process

### changes

-  remove event listeners from grid client as each client has its own event listeners 
- remove `disconnectAndExit`; it has no effect as we removed the event listeners, each client now have its `process.removeAllListeners();`
- rmb direct client
  - merge `close` to `disconnect` function in rmb direct client
  - in `catch` in connect method 
    - we remove the `c.close` as it will be done in disconnect 
    - if the user doesn't have enough balance no need to disconnect  
  - in `disconnectAndExit` 
    - clear timeout 
    - close all connections 
    - remove all event listeners as mentioned earlier
- tfchain `disconnectAndExit` : we need to close all connection when killing the process, so now it loops through `QueryClient.connections` map and pass all its urls to close the connection using its `disconnectHandler` 

### Related Issues

- #1781 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
