### PR TITLE
Add toFixed to prices calculator

### DIFF
--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -176,7 +176,7 @@
               <span class="package">
                 <b>{{ price.packageName != "none" ? capitalize(price.packageName) + " Package: " : "" }}</b></span
               >
-              <b>${{ Number(price.price).toFixed(6) }}/month, {{ Number(price.TFTs).toFixed(6) }} TFT/month. </b>
+              <b>${{ Number(price.price).toFixed(4) }}/month, {{ Number(price.TFTs).toFixed(4) }} TFT/month. </b>
             </span>
             <span> {{ price.info }}</span>
           </v-card>

--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -176,7 +176,7 @@
               <span class="package">
                 <b>{{ price.packageName != "none" ? capitalize(price.packageName) + " Package: " : "" }}</b></span
               >
-              <b>${{ price.price }}/month, {{ price.TFTs }} TFT/month. </b>
+              <b>${{ Number(price.price).toFixed(6) }}/month, {{ Number(price.TFTs).toFixed(6) }} TFT/month. </b>
             </span>
             <span> {{ price.info }}</span>
           </v-card>


### PR DESCRIPTION
### Description

- The prices in calculator sometimes looks too long, needs to be rounded.
### Changes

- Use `toFixed` to prices.
### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1187#issuecomment-1868527054

- Before 
![Screenshot from 2023-12-24 15-59-05](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/16083592/39535f6f-2a1a-4a9f-98f7-23d820db2961)

- After
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/5cf364cd-8a49-4344-9833-fe63f60efda5)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
