### PR TITLE
When switching between tabs validation isn't reset

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -230,11 +230,7 @@
               <PasswordInputWrapper #="{ props: passwordInputProps }">
                 <InputValidator
                   :value="password"
-                  :rules="[
-                    validators.required('Password is required.'),
-                    validators.minLength('Password must be at least 6 characters.', 6),
-                    validatePassword,
-                  ]"
+                  :rules="[validators.minLength('Password must be at least 6 characters.', 6), validatePassword]"
                   #="{ props: validationProps }"
                   ref="passwordInput"
                 >


### PR DESCRIPTION
### Description

- When switching between tabs in profile manager, the password validation isn't reset
### Changes

- This happens as the password field shared between 2 tabs, when switching we clear the value so the `Password is required` validation is triggered.
- I think the solution is to remove it, as long as we can't login or create account without password it won't affect the flow
### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1323#issuecomment-1869042166

[Screencast from 12-27-2023 12:11:48 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/a5513b0f-2351-43b7-bf10-938d6f503c0c)



### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
