### PR TITLE
Enhance performance of workloads validating

### DIFF
--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -7,7 +7,6 @@ import {
   TimeoutError,
   ValidationError,
 } from "@threefold/types";
-import groupBy from "lodash/fp/groupBy.js";
 
 import { RMB } from "../clients";
 import { TFClient } from "../clients/tf-grid/client";
@@ -318,7 +317,11 @@ class TwinDeploymentHandler {
   }
 
   async checkNodesCapacity(twinDeployments: TwinDeployment[]) {
-    const deployments = groupBy(x => x.nodeId, twinDeployments);
+    const deployments = twinDeployments.reduce((res, twinDeployment) => {
+      res[twinDeployment.nodeId] = res[twinDeployment.nodeId] || [];
+      res[twinDeployment.nodeId].push(twinDeployment);
+      return res;
+    }, {} as { [nodeId: number]: TwinDeployment[] });
     await Promise.all(Object.keys(deployments).map(nodeId => this._checkNodeCapacity(+nodeId, deployments[nodeId])));
   }
 

--- a/packages/grid_client/src/high_level/twinDeploymentHandler.ts
+++ b/packages/grid_client/src/high_level/twinDeploymentHandler.ts
@@ -317,57 +317,59 @@ class TwinDeploymentHandler {
   }
 
   async checkNodesCapacity(twinDeployments: TwinDeployment[]) {
-    for (const twinDeployment of twinDeployments) {
-      let workloads: Workload[] = [];
+    await Promise.all(twinDeployments.map(d => this.checkNodeCapacity(d)));
+  }
 
-      if (twinDeployment.operation == Operations.deploy) {
-        workloads = twinDeployment.deployment.workloads;
-      }
+  async checkNodeCapacity(twinDeployment: TwinDeployment) {
+    let workloads: Workload[] = [];
 
-      if (twinDeployment.operation == Operations.update) {
-        const deployment_version = twinDeployment.deployment.version;
-        workloads = twinDeployment.deployment.workloads.filter(workload => workload.version == deployment_version);
-      }
+    if (twinDeployment.operation == Operations.deploy) {
+      workloads = twinDeployment.deployment.workloads;
+    }
 
-      let hru = 0;
-      let sru = 0;
-      let mru = 0;
-      const rootfsDisks: number[] = [];
-      const ssdDisks: number[] = [];
-      const hddDisks: number[] = [];
-      for (const workload of workloads) {
-        if (workload.type == WorkloadTypes.zmachine) {
-          rootfsDisks.push(workload.data["size"]);
-          sru += workload.data["size"];
-        }
-        if (workload.type == WorkloadTypes.zmount) {
-          ssdDisks.push(workload.data["size"]);
-          sru += workload.data["size"];
-        }
-        if (workload.type == WorkloadTypes.zdb) {
-          hddDisks.push(workload.data["size"]);
-          hru += workload.data["size"];
-        }
-        if (workload.type == WorkloadTypes.zmachine) {
-          mru += workload.data["compute_capacity"].memory;
-        }
-      }
+    if (twinDeployment.operation == Operations.update) {
+      const deployment_version = twinDeployment.deployment.version;
+      workloads = twinDeployment.deployment.workloads.filter(workload => workload.version == deployment_version);
+    }
 
-      if (
-        workloads.length !== 0 &&
-        !(await this.nodes.nodeHasResources(+twinDeployment.nodeId, {
-          hru: hru / 1024 ** 3,
-          sru: sru / 1024 ** 3,
-          mru: mru / 1024 ** 3,
-        }))
-      ) {
-        throw new GridClientErrors.Nodes.InvalidResourcesError(
-          `Node ${twinDeployment.nodeId} doesn't have enough resources: sru=${sru}, mru=${mru} .`,
-        );
+    let hru = 0;
+    let sru = 0;
+    let mru = 0;
+    const rootfsDisks: number[] = [];
+    const ssdDisks: number[] = [];
+    const hddDisks: number[] = [];
+    for (const workload of workloads) {
+      if (workload.type == WorkloadTypes.zmachine) {
+        rootfsDisks.push(workload.data["size"]);
+        sru += workload.data["size"];
       }
-      if (workloads.length && (rootfsDisks.length || ssdDisks.length || hddDisks.length)) {
-        await this.nodes.verifyNodeStoragePoolCapacity(ssdDisks, hddDisks, rootfsDisks, +twinDeployment.nodeId);
+      if (workload.type == WorkloadTypes.zmount) {
+        ssdDisks.push(workload.data["size"]);
+        sru += workload.data["size"];
       }
+      if (workload.type == WorkloadTypes.zdb) {
+        hddDisks.push(workload.data["size"]);
+        hru += workload.data["size"];
+      }
+      if (workload.type == WorkloadTypes.zmachine) {
+        mru += workload.data["compute_capacity"].memory;
+      }
+    }
+
+    if (
+      workloads.length !== 0 &&
+      !(await this.nodes.nodeHasResources(+twinDeployment.nodeId, {
+        hru: hru / 1024 ** 3,
+        sru: sru / 1024 ** 3,
+        mru: mru / 1024 ** 3,
+      }))
+    ) {
+      throw new GridClientErrors.Nodes.InvalidResourcesError(
+        `Node ${twinDeployment.nodeId} doesn't have enough resources: sru=${sru}, mru=${mru} .`,
+      );
+    }
+    if (workloads.length && (rootfsDisks.length || ssdDisks.length || hddDisks.length)) {
+      await this.nodes.verifyNodeStoragePoolCapacity(ssdDisks, hddDisks, rootfsDisks, +twinDeployment.nodeId);
     }
   }
 


### PR DESCRIPTION
### Description
Enhance the performance of validating the resource while deploying the workloads

### Changes
- refactor: use Promise.all instead of for await to parallelize execution
- fix: group all deployments with same nodeId and sum all it's resources before validating

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1730

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
