### PR TITLE
Fix status filter on update

### DIFF
--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -64,7 +64,7 @@
                           label="Select Nodes Status"
                           variant="underlined"
                           :disabled="isFormLoading"
-                          @update:model-value="statusReset"
+                          @update:model-value="paginationReset"
                           open-on-clear
                           clearable
                         ></v-select>
@@ -178,13 +178,10 @@ export default {
       filterOptions.value = optionsInitializer();
     };
 
-    const statusReset = () => {
+    const paginationReset = () => {
       const options = mixedFilters.value.options;
       options.page = 1;
       options.size = 10;
-      // reset filters
-
-      filterInputs.value = inputsInitializer();
     };
     const checkSelectedNode = async () => {
       if (route.query.nodeId) {
@@ -221,7 +218,7 @@ export default {
 
       selectedNodeId,
       nodeStatusOptions,
-      statusReset,
+      paginationReset,
 
       filterInputs,
       filterOptions,

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -6,12 +6,7 @@
   </div>
 
   <view-layout>
-    <filters
-      :form-disabled="isFormLoading"
-      v-model:model-value="filterInputs"
-      v-model:valid="isValidForm"
-      @update:model-value="inputFiltersReset"
-    />
+    <filters :form-disabled="isFormLoading" v-model:model-value="filterInputs" v-model:valid="isValidForm" />
     <div class="nodes mt-5">
       <div class="nodes-inner">
         <v-row>
@@ -172,12 +167,6 @@ export default {
       { deep: true },
     );
 
-    // The filters should reset to the default value again..
-    const inputFiltersReset = (filtersInputValues: FilterInputs) => {
-      filterInputs.value = filtersInputValues;
-      filterOptions.value = optionsInitializer();
-    };
-
     const paginationReset = () => {
       const options = mixedFilters.value.options;
       options.page = 1;
@@ -228,7 +217,6 @@ export default {
       openDialog,
       closeDialog,
       requestNodes,
-      inputFiltersReset,
     };
   },
 };


### PR DESCRIPTION
### Description

Status filter value was changed to its initial value on update. Fixed by removing this part.

[status-filter.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/b0eed3e5-bbe8-490e-93c1-d1fc7ff52841)

###
 Changes

- Remove update status to initial on update
- Rename statusReset to paginationReset

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/770

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
