### PR TITLE
fix transfer validation

### DIFF
--- a/packages/playground/src/dashboard/transfer_view.vue
+++ b/packages/playground/src/dashboard/transfer_view.vue
@@ -37,9 +37,9 @@
                 :rules="[
                   validators.required('Transfer amount is required '),
                   validators.isNumeric('Amount should be a number.'),
-                  validators.min('Amount must be greater than 0.', 0.001),
+                  validators.min('Amount must be greater than 0.001', 0.001),
                   validators.isDecimal('Amount can have 3 decimals only.', { decimal_digits: '0,3' }),
-                  validators.max('Insufficient funds.', freeBalance),
+                  validators.max('Insufficient funds.', freeBalance - 0.01),
                 ]"
                 #="{ props }"
               >
@@ -88,9 +88,9 @@
                 :rules="[
                   validators.required('Transfer amount is required '),
                   validators.isNumeric('Amount should be a number.'),
-                  validators.min('Amount must be greater than 0.', 0.001),
+                  validators.min('Amount must be greater than 0.001', 0.001),
                   validators.isDecimal('Amount can have 3 decimals only.', { decimal_digits: '0,3' }),
-                  validators.max('Insufficient funds.', freeBalance),
+                  validators.max('Insufficient funds.', freeBalance - 0.01),
                 ]"
                 #="{ props }"
               >


### PR DESCRIPTION
### Description

- validation on max amount to be `freeBalance - 0.01`, as the 0.01 is the max  extrinsic cost.
  
![Screenshot from 2023-12-31 16-06-01](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/6bb7943c-5b2b-4c36-81d9-4bd6a9328849)

- fix error message to be min amount 0.001
![Screenshot from 2023-12-31 16-09-25](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/8df2a769-10de-401b-a109-7cf1a1ccc43b)



### Related Issues

- #1793

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
