### PR TITLE
[Explorer] show health btn in all node status

### DIFF
--- a/packages/playground/src/components/node_resources_charts.vue
+++ b/packages/playground/src/components/node_resources_charts.vue
@@ -28,14 +28,7 @@
 
     <v-row justify="center">
       <v-progress-circular v-if="loading" indeterminate color="primary" :size="50" class="mt-10 mb-10" />
-      <v-btn
-        rounded="md"
-        variant="flat"
-        color="primary"
-        v-if="isNodeReadyToVisit()"
-        class="mt-10"
-        @click="getNodeHealthUrl"
-      >
+      <v-btn rounded="md" variant="flat" color="primary" class="mt-10" @click="getNodeHealthUrl">
         Check Node Health
       </v-btn>
     </v-row>
@@ -103,14 +96,6 @@ export default {
       });
     };
 
-    // Return true if the node is up or standby
-    const isNodeReadyToVisit = () => {
-      return (
-        (!loading.value && props.node.status === NodeStatus.Up) ||
-        (!loading.value && props.node.status === NodeStatus.Standby)
-      );
-    };
-
     return {
       NodeStatus,
       resources,
@@ -118,7 +103,6 @@ export default {
 
       getNodeResources,
       getNodeHealthUrl,
-      isNodeReadyToVisit,
       getNodeStatusColor,
     };
   },


### PR DESCRIPTION
### Description
 
to allow user to check the node history, we enabled the health button in all node status

[Screencast from 01 ينا, 2024 EET 02:20:03 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/07f23957-6456-4416-b16b-daa456482b94)


### Changes

reomve `isNodeReadyToVisit` function as we will show the btn in all cases

### Related Issues

- #1831

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
