### PR TITLE
add error msg in faild deployments dialog

### DIFF
--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -16,6 +16,16 @@
           <v-card-title style="color: #ffcc00; font-weight: bold">Failed Deployments</v-card-title>
           <v-divider color="#FFCC00" />
           <v-card-text>
+            Failed to load <strong>{{ count - items.length }}</strong> deployment{{
+              count - items.length > 1 ? "s" : ""
+            }}.
+
+            <span>
+              This might happen because the node is down or it's not reachable
+              <span v-if="showEncryption"
+                >or the deployment{{ count - items.length > 1 ? "s are" : " is" }} encrypted by another key</span
+              >.
+            </span>
             <li v-for="deployment in failedDeployments" :key="deployment.name">
               {{
                 deployment.nodes.length > 0

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -16,6 +16,16 @@
           <v-card-title style="color: #ffcc00; font-weight: bold">Failed Deployments</v-card-title>
           <v-divider color="#FFCC00" />
           <v-card-text>
+            Failed to load <strong>{{ count - items.length }}</strong> deployment{{
+              count - items.length > 1 ? "s" : ""
+            }}.
+
+            <span>
+              This might happen because the node is down or it's not reachable
+              <span v-if="showEncryption"
+                >or the deployment{{ count - items.length > 1 ? "s are" : " is" }} encrypted by another key</span
+              >.
+            </span>
             <v-list :items="failedDeploymentList" item-props lines="three">
               <template v-slot:subtitle="{ subtitle }">
                 <div v-html="subtitle"></div>

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -239,6 +239,9 @@ const failedDeploymentList = computed(() => {
         nodeMessage + contractMessage === ""
           ? `<span class="ml-4 text-error font-weight-bold">Error:</span> Failed to decrypt deployment data.`
           : nodeMessage + contractMessage;
+      if (subtitle.includes("Failed to decrypt deployment data.")) {
+        showEncryption.value = true;
+      }
 
       const item: any[] = [{ title: name, subtitle }];
 


### PR DESCRIPTION
### Description
- Add Error msg in failed deployments dialog to make it more clear to user in both vm and k8s.

### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1214#issuecomment-1873472213

![Screenshot from 2024-01-02 12-21-23](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/7884ffa2-3926-45b9-b12c-e634bc65716d)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
