### PR TITLE
Fix shared error in password input in profile manager

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -87,6 +87,7 @@
             clearFields();
           }
         "
+        destroy
       >
         <VContainer>
           <form @submit.prevent="activeTab === 0 ? login() : storeAndLogin()">


### PR DESCRIPTION
### Description
Password input in 1st tab share the same error handling of page 2 password input which doesn't make any sense

### Changes
- fix: add destroy to non active tab in profile_manager

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1323#issuecomment-1869042166
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
