### PR TITLE
remove total from filter titles in dedicated nodes page

### DIFF
--- a/packages/playground/src/utils/filter_nodes.ts
+++ b/packages/playground/src/utils/filter_nodes.ts
@@ -161,7 +161,7 @@ export const inputsInitializer: () => FilterNodeInputs = () => ({
 
 export const DedicatedNodeInitializer: () => DedicatedNodeFilters = () => ({
   total_cru: {
-    label: "Total CPU (Cores)",
+    label: "CPU (Cores)",
     placeholder: "Filter by total Cores.",
     type: "text",
     rules: [
@@ -173,7 +173,7 @@ export const DedicatedNodeInitializer: () => DedicatedNodeFilters = () => ({
     ],
   },
   total_mru: {
-    label: "Total RAM (GB)",
+    label: "RAM (GB)",
     placeholder: "Filter by total Memory.",
     type: "text",
     rules: [
@@ -185,7 +185,7 @@ export const DedicatedNodeInitializer: () => DedicatedNodeFilters = () => ({
     ],
   },
   total_sru: {
-    label: "Total SSD (GB)",
+    label: "SSD (GB)",
     placeholder: "Filter by total SSD.",
     type: "text",
     rules: [
@@ -197,7 +197,7 @@ export const DedicatedNodeInitializer: () => DedicatedNodeFilters = () => ({
     ],
   },
   total_hru: {
-    label: "Total HDD (GB)",
+    label: "HDD (GB)",
     placeholder: "Filter by total HDD.",
     type: "text",
     rules: [


### PR DESCRIPTION
### Description

Remove `Total` from filter titles in the dedicated nodes page.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/d82eaa4f-6f0a-4208-b51c-e5afc28a9182)

### Changes

removed total from the titles of the filters.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1867

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
