### PR TITLE
Reorder sidebar & add sshkey, orchestrators, vms pages

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -277,6 +277,11 @@ const routes: AppRoute[] = [
         route: "/vms",
       },
       {
+        title: "Orchestrators",
+        icon: "mdi-group",
+        route: "/orchestrators",
+      },
+      {
         title: "Dedicated Machines",
         icon: "mdi-resistor-nodes",
         route: "/dashboard/dedicated-nodes",

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -236,42 +236,75 @@ function navigateToPrevRoute(path: any) {
 
 const routes: AppRoute[] = [
   {
-    title: "Dashboard",
-    icon: "mdi-account-convert-outline",
+    title: "TFGrid",
+    icon: "mdi-database-search-outline",
+
     items: [
       {
-        title: "Your Twin",
-        icon: "mdi-account-supervisor-outline",
-        route: "/dashboard/twin",
-      },
-      { title: "Your Farms", icon: "mdi-silo", route: "/dashboard/farms" },
-      {
-        title: "Your Contracts",
-        icon: "mdi-file-document-edit",
-        route: "/dashboard/contracts-list",
-      },
-      { title: "Bridge", icon: "mdi-swap-horizontal", route: "/dashboard/bridge" },
-      {
-        title: "Transfer",
-        icon: "mdi-account-arrow-right-outline",
-        route: "/dashboard/transfer",
+        title: "Grid Status",
+        icon: "mdi-grid-large",
+        url: "https://status.grid.tf/status/threefold",
+        tooltip: "Status of Threefold Grid",
       },
       {
-        title: "Dedicated Nodes",
-        icon: "mdi-resistor-nodes",
-        route: "/dashboard/dedicated-nodes",
+        title: "Node Statistics",
+        icon: "mdi-chart-scatter-plot",
+        route: "/stats",
+        tooltip: "View Node Statistics",
       },
-      { title: "DAO", icon: "mdi-note-check-outline", route: "/dashboard/dao" },
+      {
+        title: "Node Monitoring",
+        icon: "mdi-equalizer",
+        url: "https://metrics.grid.tf/d/rYdddlPWkfqwf/zos-host-metrics?orgId=2&refresh=30s",
+        tooltip: "Monitor Zero-OS Nodes",
+      },
     ],
   },
   {
-    title: "Calculators",
-    icon: "mdi-calculator",
+    title: "Deploy",
+    icon: "mdi-silo",
     items: [
       {
         title: "Pricing Calculator",
         icon: "mdi-currency-usd",
         route: "/calculator/pricing",
+      },
+      { title: "Node Finder", icon: "mdi-access-point", route: "/nodes" },
+      /// need to add VMs
+      {
+        title: "Virtual Machines",
+        icon: "vm.png",
+        route: "/vms",
+      },
+      {
+        title: "Dedicated Machines",
+        icon: "mdi-resistor-nodes",
+        route: "/dashboard/dedicated-nodes",
+      },
+      { title: "Applications", icon: "mdi-lightbulb-on-outline", route: "/solutions" },
+      {
+        title: "Your Contracts",
+        icon: "mdi-file-document-edit",
+        route: "/dashboard/contracts-list",
+      },
+      {
+        title: "Images",
+        icon: "mdi-open-in-new",
+        url: "https://hub.grid.tf/",
+        tooltip: "Find or Publish your Flist on 0-Hub",
+      },
+    ],
+  },
+  {
+    title: "Farms",
+    icon: "mdi-access-point",
+    items: [
+      { title: "Farms", icon: "mdi-lan-connect", route: "/farms" },
+      {
+        title: "Node Installer",
+        icon: "mdi-earth",
+        url: "https://bootstrap.grid.tf/",
+        tooltip: "Download Zero-OS Images",
       },
       {
         title: "Simulator",
@@ -281,63 +314,26 @@ const routes: AppRoute[] = [
     ],
   },
   {
-    title: "Playground",
-    items: [{ title: "Solutions", icon: "mdi-lightbulb-on-outline", route: "/solutions" }],
-  },
-  {
-    icon: "mdi-database-search-outline",
-    title: "Statistics",
+    title: "TFChain",
+    icon: "mdi-account-convert-outline",
     items: [
       {
-        title: "Statistics",
-        icon: "mdi-chart-scatter-plot",
-        route: "/stats",
+        title: "My Profile",
+        icon: "mdi-account-supervisor-outline",
+        route: "/dashboard/twin",
       },
-    ],
-  },
-  {
-    icon: "mdi-access-point",
-    title: "Nodes",
-    items: [{ title: "Nodes", icon: "mdi-access-point", route: "/nodes" }],
-  },
-  {
-    icon: "mdi-access-point",
-    title: "Farms",
-    items: [{ title: "Farms", icon: "mdi-lan-connect", route: "/farms" }],
-  },
-  {
-    icon: "mdi-toolbox-outline",
-    title: "Services",
-    items: [
+      { title: "TF DAO", icon: "mdi-note-check-outline", route: "/dashboard/dao" },
+      { title: "TF Token Bridge", icon: "mdi-swap-horizontal", route: "/dashboard/bridge" },
       {
-        title: "0-Bootstrap",
-        icon: "mdi-earth",
-        url: "https://bootstrap.grid.tf/",
-        tooltip: "Download Zero-OS Images",
+        title: "TF Token Transfer",
+        icon: "mdi-account-arrow-right-outline",
+        route: "/dashboard/transfer",
       },
       {
-        title: "0-Hub",
-        icon: "mdi-open-in-new",
-        url: "https://hub.grid.tf/",
-        tooltip: "Find or Publish your Flist",
-      },
-      {
-        title: "Minting",
+        title: "TF Minting Reports",
         icon: "mdi-file-document-edit",
         route: "/minting",
         tooltip: "TFGrid Minting Explorer",
-      },
-      {
-        title: "Monitoring",
-        icon: "mdi-equalizer",
-        url: "https://metrics.grid.tf/d/rYdddlPWkfqwf/zos-host-metrics?orgId=2&refresh=30s",
-        tooltip: "Monitor Zero-OS nodes",
-      },
-      {
-        title: "Grid Health",
-        icon: "mdi-grid-large",
-        url: "https://status.grid.tf/status/threefold",
-        tooltip: "Status of Threefold Services",
       },
     ],
   },

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -270,7 +270,7 @@ const routes: AppRoute[] = [
         route: "/calculator/pricing",
       },
       { title: "Node Finder", icon: "mdi-access-point", route: "/nodes" },
-      /// need to add VMs
+
       {
         title: "Virtual Machines",
         icon: "vm.png",
@@ -292,6 +292,11 @@ const routes: AppRoute[] = [
         icon: "mdi-open-in-new",
         url: "https://hub.grid.tf/",
         tooltip: "Find or Publish your Flist on 0-Hub",
+      },
+      {
+        title: "SSHKey",
+        icon: "mdi-key-plus",
+        route: "/sshkey",
       },
     ],
   },

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -369,7 +369,7 @@ function clickHandler({ route, url }: AppRouteItem): void {
 }
 
 function isAuthorized(route: string) {
-  const items = ["dashboard", "solutions"];
+  const items = ["dashboard", "solutions", "sshkey"];
   return !items.some(substr => route.startsWith(`/${substr}`));
 }
 

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -273,7 +273,7 @@ const routes: AppRoute[] = [
 
       {
         title: "Virtual Machines",
-        icon: "vm.png",
+        icon: "mdi-television",
         route: "/vms",
       },
       {

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -85,6 +85,12 @@ const router = createRouter({
       meta: { title: "Virtual Machines" },
       children: [],
     },
+    {
+      path: "/sshkey",
+      component: () => import("../views/sshkey_view.vue"),
+      meta: { title: "SSHKey" },
+      children: [],
+    },
 
     {
       path: "/solutions",

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -79,6 +79,12 @@ const router = createRouter({
         },
       ],
     },
+    {
+      path: "/vms",
+      component: () => import("../views/vms_view.vue"),
+      meta: { title: "Virtual Machines" },
+      children: [],
+    },
 
     {
       path: "/solutions",

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -91,6 +91,12 @@ const router = createRouter({
       meta: { title: "SSHKey" },
       children: [],
     },
+    {
+      path: "/orchestrators",
+      component: () => import("../views/orchestrators_view.vue"),
+      meta: { title: "Orchestrators" },
+      children: [],
+    },
 
     {
       path: "/solutions",

--- a/packages/playground/src/views/orchestrators_view.vue
+++ b/packages/playground/src/views/orchestrators_view.vue
@@ -1,0 +1,80 @@
+<template>
+  <view-layout>
+    <v-row>
+      <v-col v-for="card in cards" :key="card.title">
+        <router-link :to="'/solutions' + card.route">
+          <v-hover>
+            <template v-slot:default="{ isHovering, props }">
+              <v-card class="pa-3 pt-6" height="200" v-bind="props" :class="isHovering ? 'card-opacity' : undefined">
+                <v-img
+                  class="d-inline-block ml-3 mb-2"
+                  width="35"
+                  :src="baseURL + 'images/icons/' + card.icon"
+                  :alt="card.title"
+                  :style="{
+                    filter: `brightness(${$vuetify.theme.global.name === 'light' ? 0.2 : 1})`,
+                    lineHeight: 1,
+                  }"
+                />
+                <v-card-title class="d-inline-block">
+                  {{ card.title }}
+                  <v-chip v-if="card.flare" class="ml-2 pulse-animation" color="#1AA18F" small text-color="white">
+                    Community
+                  </v-chip>
+                </v-card-title>
+                <v-card-text class="mt-2"> {{ card.excerpt }} </v-card-text>
+              </v-card>
+            </template></v-hover
+          >
+        </router-link>
+      </v-col>
+    </v-row>
+  </view-layout>
+</template>
+<script lang="ts">
+interface Card {
+  title: string;
+  excerpt: string;
+  icon: string;
+  route: string;
+  flare?: string;
+}
+
+export default {
+  name: "VmsView",
+  setup() {
+    const cards: Card[] = [
+      {
+        title: "Kubernetes",
+        excerpt:
+          "Kubernetes is the standard container orchestration tool. On the TF grid, Kubernetes clusters can be deployed out of the box. We have implemented K3S, a full-blown Kubernetes offering that uses only half of the memory footprint.",
+        icon: "kubernetes.png",
+        route: "/kubernetes",
+      },
+      {
+        title: "CapRover",
+        excerpt:
+          "CapRover is an extremely easy to use app/database deployment & web server manager for your NodeJS, Python, PHP, ASP.NET, Ruby, MySQL, MongoDB, Postgres, WordPress (and etc…) applications!",
+        icon: "caprover.png",
+        route: "/caprover",
+      },
+    ];
+    const baseURL = import.meta.env.BASE_URL;
+
+    return {
+      cards,
+      baseURL,
+    };
+  },
+};
+</script>
+
+<style scoped>
+a {
+  text-decoration: none !important;
+}
+
+.card-opacity {
+  background-color: rgba(125, 227, 200, 0.12);
+}
+</style>

--- a/packages/playground/src/views/orchestrators_view.vue
+++ b/packages/playground/src/views/orchestrators_view.vue
@@ -41,7 +41,7 @@ interface Card {
 }
 
 export default {
-  name: "VmsView",
+  name: "Orchestrators View",
   setup() {
     const cards: Card[] = [
       {

--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -1,57 +1,59 @@
 <template>
-  <VTooltip
-    text="SSH Keys are used to authenticate you to the deployment instance for management purposes. If you don't have an SSH Key or are not familiar, we can generate one for you."
-    location="bottom"
-    max-width="600px"
-  >
-    <template #activator="{ props }">
-      <CopyInputWrapper :data="profileManager.profile?.ssh" #="{ props: copyInputProps }">
-        <VTextarea
-          label="Public SSH Key"
-          no-resize
-          :spellcheck="false"
-          v-model.trim="ssh"
-          v-bind="{ ...props, ...copyInputProps }"
-          :disabled="updatingSSH || generatingSSH"
-          :hint="
-            updatingSSH
-              ? 'Updating your public ssh key.'
-              : generatingSSH
-              ? 'Generating a new public ssh key.'
-              : SSHKeyHint
-          "
-          :persistent-hint="updatingSSH || generatingSSH || !!SSHKeyHint"
-          :rules="[value => !!value || 'SSH key is required']"
-        />
-      </CopyInputWrapper>
+  <v-card>
+    <VTooltip
+      text="SSH Keys are used to authenticate you to the deployment instance for management purposes. If you don't have an SSH Key or are not familiar, we can generate one for you."
+      location="bottom"
+      max-width="600px"
+    >
+      <template #activator="{ props }">
+        <CopyInputWrapper :data="profileManager.profile?.ssh" #="{ props: copyInputProps }">
+          <VTextarea
+            label="Public SSH Key"
+            no-resize
+            :spellcheck="false"
+            v-model.trim="ssh"
+            v-bind="{ ...props, ...copyInputProps }"
+            :disabled="updatingSSH || generatingSSH"
+            :hint="
+              updatingSSH
+                ? 'Updating your public ssh key.'
+                : generatingSSH
+                ? 'Generating a new public ssh key.'
+                : SSHKeyHint
+            "
+            :persistent-hint="updatingSSH || generatingSSH || !!SSHKeyHint"
+            :rules="[value => !!value || 'SSH key is required']"
+          />
+        </CopyInputWrapper>
 
-      <div class="d-flex justify-end mb-5">
-        <VBtn
-          class="mr-2 text-subtitle-2"
-          color="secondary"
-          variant="outlined"
-          :disabled="!!ssh || updatingSSH || generatingSSH || !isEnoughBalance(balance)"
-          :loading="generatingSSH"
-          @click="generateSSH"
-        >
-          Generate SSH Keys
-        </VBtn>
-        <VBtn
-          class="text-subtitle-2"
-          color="secondary"
-          variant="outlined"
-          @click="updateSSH"
-          :disabled="!ssh || profileManager.profile?.ssh === ssh || updatingSSH || !isEnoughBalance(balance)"
-          :loading="updatingSSH"
-        >
-          Update Public SSH Key
-        </VBtn>
-      </div>
-    </template>
-  </VTooltip>
+        <div class="d-flex justify-end mb-5">
+          <VBtn
+            class="mr-2 text-subtitle-2"
+            color="secondary"
+            variant="outlined"
+            :disabled="!!ssh || updatingSSH || generatingSSH || !isEnoughBalance(balance)"
+            :loading="generatingSSH"
+            @click="generateSSH"
+          >
+            Generate SSH Keys
+          </VBtn>
+          <VBtn
+            class="text-subtitle-2"
+            color="secondary"
+            variant="outlined"
+            @click="updateSSH"
+            :disabled="!ssh || profileManager.profile?.ssh === ssh || updatingSSH || !isEnoughBalance(balance)"
+            :loading="updatingSSH"
+          >
+            Update Public SSH Key
+          </VBtn>
+        </div>
+      </template>
+    </VTooltip>
+  </v-card>
 </template>
 <script lang="ts" setup>
-import { onMounted, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import { generateKeyPair } from "web-ssh-keygen";
 
 import { createCustomToast, ToastType } from "@/utils/custom_toast";
@@ -66,17 +68,13 @@ const balance = ref<Balance>();
 const SSHKeyHint = ref("");
 const generatingSSH = ref(false);
 const profileManager = useProfileManager();
-const ssh = ref("");
+const ssh = ref(profileManager.profile!.ssh);
 const updatingSSH = ref(false);
 let BalanceWarningRaised = false;
 const loadingBalance = ref(false);
-const profile = ref<Profile>();
+
 let interval: any;
-onMounted(async () => {
-  profile.value = profileManager.profile!;
-  if (!profile.value) return;
-  const grid = await getGrid(profile);
-});
+
 async function __loadBalance(profile?: Profile, tries = 1) {
   profile = profile || profileManager.profile!;
   if (!profile) return;
@@ -139,4 +137,9 @@ async function generateSSH() {
   generatingSSH.value = false;
   SSHKeyHint.value = "SSH key generated successfully.";
 }
+</script>
+<script lang="ts">
+export default {
+  name: "SSHkey",
+};
 </script>

--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -1,0 +1,142 @@
+<template>
+  <VTooltip
+    text="SSH Keys are used to authenticate you to the deployment instance for management purposes. If you don't have an SSH Key or are not familiar, we can generate one for you."
+    location="bottom"
+    max-width="600px"
+  >
+    <template #activator="{ props }">
+      <CopyInputWrapper :data="profileManager.profile?.ssh" #="{ props: copyInputProps }">
+        <VTextarea
+          label="Public SSH Key"
+          no-resize
+          :spellcheck="false"
+          v-model.trim="ssh"
+          v-bind="{ ...props, ...copyInputProps }"
+          :disabled="updatingSSH || generatingSSH"
+          :hint="
+            updatingSSH
+              ? 'Updating your public ssh key.'
+              : generatingSSH
+              ? 'Generating a new public ssh key.'
+              : SSHKeyHint
+          "
+          :persistent-hint="updatingSSH || generatingSSH || !!SSHKeyHint"
+          :rules="[value => !!value || 'SSH key is required']"
+        />
+      </CopyInputWrapper>
+
+      <div class="d-flex justify-end mb-5">
+        <VBtn
+          class="mr-2 text-subtitle-2"
+          color="secondary"
+          variant="outlined"
+          :disabled="!!ssh || updatingSSH || generatingSSH || !isEnoughBalance(balance)"
+          :loading="generatingSSH"
+          @click="generateSSH"
+        >
+          Generate SSH Keys
+        </VBtn>
+        <VBtn
+          class="text-subtitle-2"
+          color="secondary"
+          variant="outlined"
+          @click="updateSSH"
+          :disabled="!ssh || profileManager.profile?.ssh === ssh || updatingSSH || !isEnoughBalance(balance)"
+          :loading="updatingSSH"
+        >
+          Update Public SSH Key
+        </VBtn>
+      </div>
+    </template>
+  </VTooltip>
+</template>
+<script lang="ts" setup>
+import { onMounted, ref, watch } from "vue";
+import { generateKeyPair } from "web-ssh-keygen";
+
+import { createCustomToast, ToastType } from "@/utils/custom_toast";
+
+import { useProfileManager } from "../stores";
+import type { Profile } from "../stores/profile_manager";
+import { type Balance, getGrid, loadBalance, storeSSH } from "../utils/grid";
+import { downloadAsFile } from "../utils/helpers";
+import { isEnoughBalance } from "../utils/helpers";
+
+const balance = ref<Balance>();
+const SSHKeyHint = ref("");
+const generatingSSH = ref(false);
+const profileManager = useProfileManager();
+const ssh = ref("");
+const updatingSSH = ref(false);
+let BalanceWarningRaised = false;
+const loadingBalance = ref(false);
+const profile = ref<Profile>();
+let interval: any;
+onMounted(async () => {
+  profile.value = profileManager.profile!;
+  if (!profile.value) return;
+  const grid = await getGrid(profile);
+});
+async function __loadBalance(profile?: Profile, tries = 1) {
+  profile = profile || profileManager.profile!;
+  if (!profile) return;
+
+  try {
+    loadingBalance.value = true;
+    const grid = await getGrid(profile);
+    balance.value = await loadBalance(grid!);
+    if (!BalanceWarningRaised && balance.value?.free) {
+      if (balance.value?.free < 0.01) {
+        createCustomToast("Your balance is too low, Please fund your account.", ToastType.warning);
+        BalanceWarningRaised = true;
+      }
+    }
+    loadingBalance.value = false;
+  } catch {
+    if (tries > 10) {
+      loadingBalance.value = false;
+      return;
+    }
+
+    setTimeout(() => __loadBalance(profile, tries + 1), Math.floor(Math.exp(tries) * 1_000));
+  }
+}
+watch(
+  () => profileManager.profile,
+  profile => {
+    if (profile) {
+      __loadBalance(profile);
+      if (interval) clearInterval(interval);
+      interval = setInterval(__loadBalance.bind(undefined, profile), 1000 * 60 * 2);
+    } else {
+      if (interval) clearInterval(interval);
+      balance.value = undefined;
+    }
+  },
+  { immediate: true, deep: true },
+);
+async function updateSSH() {
+  updatingSSH.value = true;
+  const grid = await getGrid(profileManager.profile!);
+  await storeSSH(grid!, ssh.value);
+  profileManager.updateSSH(ssh.value);
+  updatingSSH.value = false;
+  SSHKeyHint.value = "SSH key updated successfully.";
+}
+async function generateSSH() {
+  generatingSSH.value = true;
+  const keys = await generateKeyPair({
+    alg: "RSASSA-PKCS1-v1_5",
+    hash: "SHA-256",
+    name: "Threefold",
+    size: 4096,
+  });
+  const grid = await getGrid(profileManager.profile!);
+  await storeSSH(grid!, keys.publicKey);
+  profileManager.updateSSH(keys.publicKey);
+  ssh.value = profileManager.profile!.ssh;
+  downloadAsFile("id_rsa", keys.privateKey);
+  generatingSSH.value = false;
+  SSHKeyHint.value = "SSH key generated successfully.";
+}
+</script>

--- a/packages/playground/src/views/vms_view.vue
+++ b/packages/playground/src/views/vms_view.vue
@@ -1,0 +1,80 @@
+<template>
+  <view-layout>
+    <v-row>
+      <v-col v-for="card in cards" :key="card.title">
+        <router-link :to="'/solutions' + card.route">
+          <v-hover>
+            <template v-slot:default="{ isHovering, props }">
+              <v-card class="pa-3 pt-6" height="200" v-bind="props" :class="isHovering ? 'card-opacity' : undefined">
+                <v-img
+                  class="d-inline-block ml-3 mb-2"
+                  width="35"
+                  :src="baseURL + 'images/icons/' + card.icon"
+                  :alt="card.title"
+                  :style="{
+                    filter: `brightness(${$vuetify.theme.global.name === 'light' ? 0.2 : 1})`,
+                    lineHeight: 1,
+                  }"
+                />
+                <v-card-title class="d-inline-block">
+                  {{ card.title }}
+                  <v-chip v-if="card.flare" class="ml-2 pulse-animation" color="#1AA18F" small text-color="white">
+                    Community
+                  </v-chip>
+                </v-card-title>
+                <v-card-text class="mt-2"> {{ card.excerpt }} </v-card-text>
+              </v-card>
+            </template></v-hover
+          >
+        </router-link>
+      </v-col>
+    </v-row>
+  </view-layout>
+</template>
+<script lang="ts">
+interface Card {
+  title: string;
+  excerpt: string;
+  icon: string;
+  route: string;
+  flare?: string;
+}
+
+export default {
+  name: "VmsView",
+  setup() {
+    const cards: Card[] = [
+      {
+        title: "Full Virtual Machine",
+        excerpt:
+          "Deploy a full virtual machine on Threefold Grid. Full VM allows you to have a complete image with a custom kernel optimized for your own usecase.",
+        icon: "vm.png",
+        route: "/fullvm",
+      },
+      {
+        title: "Micro Virtual Machine",
+        excerpt:
+          "Deploy a micro virtual machine on Threefold Grid. We provide few images managed by Threefold like Ubuntu 22.04, and NixOS, but you can still use a custom one.",
+        icon: "vm.png",
+        route: "/vm",
+      },
+    ];
+    const baseURL = import.meta.env.BASE_URL;
+
+    return {
+      cards,
+      baseURL,
+    };
+  },
+};
+</script>
+
+<style scoped>
+a {
+  text-decoration: none !important;
+}
+
+.card-opacity {
+  background-color: rgba(125, 227, 200, 0.12);
+}
+</style>

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -53,7 +53,7 @@
               variant="tonal"
               @click.stop="logout"
               v-if="profileManager.profile"
-              :disabled="updatingSSH || generatingSSH || loadingBalance"
+              :disabled="loadingBalance"
               class="ml-2"
               v-bind="props"
               icon="mdi-logout"
@@ -313,56 +313,6 @@
                 :disabled="activating || creatingAccount || activatingAccount"
               />
             </PasswordInputWrapper>
-            <VTooltip
-              text="SSH Keys are used to authenticate you to the deployment instance for management purposes. If you don't have an SSH Key or are not familiar, we can generate one for you."
-              location="bottom"
-              max-width="600px"
-            >
-              <template #activator="{ props }">
-                <CopyInputWrapper :data="profileManager.profile.ssh" #="{ props: copyInputProps }">
-                  <VTextarea
-                    label="Public SSH Key"
-                    no-resize
-                    :spellcheck="false"
-                    v-model.trim="ssh"
-                    v-bind="{ ...props, ...copyInputProps }"
-                    :disabled="updatingSSH || generatingSSH"
-                    :hint="
-                      updatingSSH
-                        ? 'Updating your public ssh key.'
-                        : generatingSSH
-                        ? 'Generating a new public ssh key.'
-                        : SSHKeyHint
-                    "
-                    :persistent-hint="updatingSSH || generatingSSH || !!SSHKeyHint"
-                    :rules="[value => !!value || 'SSH key is required']"
-                  />
-                </CopyInputWrapper>
-              </template>
-            </VTooltip>
-
-            <div class="d-flex justify-end mb-5">
-              <VBtn
-                class="mr-2 text-subtitle-2"
-                color="secondary"
-                variant="outlined"
-                :disabled="!!ssh || updatingSSH || generatingSSH || !isEnoughBalance(balance)"
-                :loading="generatingSSH"
-                @click="generateSSH"
-              >
-                Generate SSH Keys
-              </VBtn>
-              <VBtn
-                class="text-subtitle-2"
-                color="secondary"
-                variant="outlined"
-                @click="updateSSH"
-                :disabled="!ssh || profileManager.profile.ssh === ssh || updatingSSH || !isEnoughBalance(balance)"
-                :loading="updatingSSH"
-              >
-                Update Public SSH Key
-              </VBtn>
-            </div>
 
             <CopyInputWrapper :data="profileManager.profile.twinId.toString()" #="{ props }">
               <VTextField label="Twin ID" readonly v-model="profileManager.profile.twinId" v-bind="props" />
@@ -418,7 +368,7 @@
           @click="logout"
           variant="outlined"
           v-if="profileManager.profile"
-          :disabled="updatingSSH || generatingSSH || loadingBalance"
+          :disabled="loadingBalance"
         >
           Logout
         </VBtn>
@@ -436,7 +386,6 @@ import md5 from "md5";
 import { computed, onMounted, type Ref, ref, watch } from "vue";
 import { nextTick } from "vue";
 import { useTheme } from "vuetify";
-import { generateKeyPair } from "web-ssh-keygen";
 
 import { AppThemeSelection } from "@/utils/app_theme";
 import { createCustomToast, ToastType } from "@/utils/custom_toast";
@@ -452,10 +401,9 @@ import {
   getGrid,
   loadBalance,
   loadProfile,
-  storeSSH,
 } from "../utils/grid";
-import { isEnoughBalance, normalizeError } from "../utils/helpers";
-import { downloadAsFile, normalizeBalance } from "../utils/helpers";
+import { normalizeBalance, normalizeError } from "../utils/helpers";
+
 interface Credentials {
   passwordHash?: string;
   mnemonicHash?: string;
@@ -570,8 +518,7 @@ const profileManager = useProfileManager();
 const openAcceptTerms = ref(false);
 const mnemonic = ref("");
 const isValidForm = ref(false);
-const SSHKeyHint = ref("");
-const ssh = ref("");
+
 const mnemonicInput = useInputRef();
 
 const isNonActiveMnemonic = ref(false);
@@ -581,21 +528,9 @@ const shouldActivateAccount = computed(() => {
   return isNonActiveMnemonic.value;
 });
 
-let sshTimeout: any;
 const isValidConnectConfirmationPassword = computed(() =>
   !validateConfirmPassword(confirmPassword.value) ? false : true,
 );
-
-watch(SSHKeyHint, hint => {
-  if (hint) {
-    if (sshTimeout) {
-      clearTimeout(sshTimeout);
-    }
-    sshTimeout = setTimeout(() => {
-      SSHKeyHint.value = "";
-    }, 3000);
-  }
-});
 
 const balance = ref<Balance>();
 
@@ -661,7 +596,7 @@ async function activate(mnemonic: string, keypairType: KeypairType) {
   try {
     const grid = await getGrid({ mnemonic, keypairType });
     const profile = await loadProfile(grid!);
-    ssh.value = profile.ssh;
+
     profileManager.set({ ...profile, mnemonic });
   } catch (e) {
     loginError.value = normalizeError(e, "Something went wrong while login.");
@@ -726,33 +661,6 @@ async function activateAccount() {
   }
 }
 
-const updatingSSH = ref(false);
-async function updateSSH() {
-  updatingSSH.value = true;
-  const grid = await getGrid(profileManager.profile!);
-  await storeSSH(grid!, ssh.value);
-  profileManager.updateSSH(ssh.value);
-  updatingSSH.value = false;
-  SSHKeyHint.value = "SSH key updated successfully.";
-}
-
-const generatingSSH = ref(false);
-async function generateSSH() {
-  generatingSSH.value = true;
-  const keys = await generateKeyPair({
-    alg: "RSASSA-PKCS1-v1_5",
-    hash: "SHA-256",
-    name: "Threefold",
-    size: 4096,
-  });
-  const grid = await getGrid(profileManager.profile!);
-  await storeSSH(grid!, keys.publicKey);
-  profileManager.updateSSH(keys.publicKey);
-  ssh.value = profileManager.profile!.ssh;
-  downloadAsFile("id_rsa", keys.privateKey);
-  generatingSSH.value = false;
-  SSHKeyHint.value = "SSH key generated successfully.";
-}
 let BalanceWarningRaised = false;
 const loadingBalance = ref(false);
 async function __loadBalance(profile?: Profile, tries = 1) {


### PR DESCRIPTION
### Changes

 - reordered and renamed items in side bar to reflect order in attached issue
 - created sshkey page
 - removed sshkey from profile manager
 - created vms page that contains Full and Micro vms cards
 - created orchestrators page that contains kubernetes and caprover cards

### Related Issues

#1861
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/3231f040-beb8-4864-8d0c-77dfe7a5a2e0)


![Screenshot from 2024-01-04 13-52-27](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/fdb8aa30-769c-43ff-9608-3c4b6abd3bf9)

![Screenshot from 2024-01-04 13-52-41](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/9798ac75-eda9-4a29-bbeb-fad3967abd98)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/ec6afaa5-7165-462e-beca-b8b3d1148ec9)
