### PR TITLE
updated cloud docs links

### DIFF
--- a/packages/dashboard/src/calculator/views/Calculator.vue
+++ b/packages/dashboard/src/calculator/views/Calculator.vue
@@ -6,7 +6,7 @@
         <i class="fa fa-calculator" aria-hidden="true"></i>
       </h1>
       <span class="link">
-        <a href="https://manual.grid.tf/cloud/cloudunits_pricing.html" target="_blank">Threefold Pricing</a>
+        <a href="https://manual.grid.tf/wiki/cloudunits/pricing/pricing.html#cloud-unit-pricing" target="_blank">Threefold Pricing</a>
       </span>
     </div>
 

--- a/packages/dashboard/src/portal/components/NodesTable.vue
+++ b/packages/dashboard/src/portal/components/NodesTable.vue
@@ -52,7 +52,7 @@
                 </li>
                 <li>
                   You're receiving {{ item.applyedDiscount.second }}% discount as per the
-                  <a target="_blank" href="https://manual.grid.tf/cloud/cloudunits_pricing.html#discount-levels">
+                  <a target="_blank" href="https://manual.grid.tf/wiki/cloudunits/pricing/pricing.html#staking-discount">
                     <p style="color: blue; display: inline">discount levels</p>
                   </a>
                 </li>

--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -295,7 +295,7 @@ onMounted(async () => {
 });
 
 function openManual() {
-  window.open("https://manual.grid.tf/cloud/cloudunits_pricing.html", "_blank");
+  window.open("https://manual.grid.tf/wiki/cloudunits/pricing/pricing.html#cloud-unit-pricing", "_blank");
 }
 </script>
 

--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -85,7 +85,7 @@
           </div>
         </div>
 
-        <a href="https://manual.grid.tf/cloud/cloudunits_pricing.html" target="_blank" class="app-link">
+        <a href="https://manual.grid.tf/wiki/cloudunits/pricing/pricing.html#cloud-unit-pricing" target="_blank" class="app-link">
           Learn more about the pricing and how to unlock discounts.
         </a>
       </v-alert>


### PR DESCRIPTION
## Issue Answered

To answer issue #1888 

## Work Done

Updated the cloud docs link for the pricing. 
From what I gathered, the broken link was on 4 different files:

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/77026219/10317572-d3e0-4a30-88d8-beb7896a4aeb)

@A-Harby 