### PR TITLE
make the tf logo redirect to home

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -116,6 +116,7 @@
                   : baseUrl + 'images/logoTF_light.png'
               }`"
               width="160px"
+              @click="navigateToHome"
             />
           </v-toolbar-title>
 
@@ -378,9 +379,13 @@ function isAuthorized(route: string) {
   return !items.some(substr => route.startsWith(`/${substr}`));
 }
 
+function navigateToHome() {
+  return $router.push("/");
+}
+
 $router.beforeEach((to, from, next) => {
   if (to.path === "/" && hasActiveProfile) {
-    next({ path: "dashboard/twin" });
+    next({ path: "/dashboard/twin" });
   } else {
     next();
   }


### PR DESCRIPTION
### Description

Make the TF logo redirect to home.

[Screencast from 09-01-24 16:40:07.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/a0a4a644-c12c-4f18-a416-b76956f7cad3)

### Changes

- Made the tf logo clickable and now it redirects to the home page.
- Fixed a bug by adding `/` to the default route to prevent it from stacking to other routes instead of replacing them.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1753

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
