### PR TITLE
Enhancement: Expand the row on click instead of clicking on the icon.

### DIFF
--- a/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
+++ b/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
@@ -54,6 +54,7 @@
         ]"
         v-model:page="filterOptions.page"
         return-object
+        @click:row="toggleExpand"
       >
         <template v-slot:[`item.actions`]="{ item }">
           <reserve-btn :node="(item.raw as unknown as GridNode)" @updateTable="reloadTable" />
@@ -150,7 +151,7 @@ const headers: VDataTable["headers"] = [
 ];
 const profileManager = useProfileManager();
 
-const expanded = ref([]);
+const expanded = ref<any[]>([]);
 const tabs = [{ label: "Rentable" }, { label: "Mine" }];
 const activeTab = ref(0);
 const loading = ref(false);
@@ -289,6 +290,12 @@ async function reloadTable() {
     setTimeout(resolve, 20000);
   });
   await _loadData();
+}
+function toggleExpand(e: any, data: any) {
+  if (expanded.value.length) {
+    expanded.value = [];
+  }
+  expanded.value.push(data.item.props.title);
 }
 </script>
 

--- a/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
+++ b/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
@@ -41,7 +41,6 @@
         :items="nodes"
         v-model:items-per-page="filterOptions.size"
         v-model:expanded="expanded"
-        show-expand
         :hide-no-data="false"
         :disable-sort="true"
         class="elevation-1"
@@ -152,6 +151,7 @@ const headers: VDataTable["headers"] = [
 const profileManager = useProfileManager();
 
 const expanded = ref<any[]>([]);
+const expandedId = ref<string>("");
 const tabs = [{ label: "Rentable" }, { label: "Mine" }];
 const activeTab = ref(0);
 const loading = ref(false);
@@ -292,10 +292,19 @@ async function reloadTable() {
   await _loadData();
 }
 function toggleExpand(e: any, data: any) {
+  if (data.item.props.title.id === expandedId.value) {
+    expanded.value = [];
+    expandedId.value = "";
+    return;
+  }
+
   if (expanded.value.length) {
     expanded.value = [];
+    expandedId.value = "";
   }
+
   expanded.value.push(data.item.props.title);
+  expandedId.value = data.item.props.title.id;
 }
 </script>
 


### PR DESCRIPTION
### Description

Remove the dropdown icon and add another logic instead `Clicking on the row displays the whole node`

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1926

### Screenshots/Video

 [Screencast from 01-11-2024 03:36:34 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/f30c3ee9-25f8-4c51-9186-d9a2eb7fedd2)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
