### PR TITLE
remove latest alert as it appears in keypair tooltip

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -282,9 +282,6 @@
               <v-alert type="error" variant="tonal" class="mt-2 mb-4" v-if="loginError">
                 {{ loginError }}
               </v-alert>
-              <v-alert variant="tonal" type="warning" class="mb-6" v-if="activeTab === 1">
-                <p>Using different keypair types will lead to a completely different account.</p>
-              </v-alert>
             </FormValidator>
 
             <div class="d-flex justify-center mt-2">


### PR DESCRIPTION
### Description

- The alert of `Using different keypair types will lead to a completely different account.` should appear once as tooltip.
### Changes

- remove it from alert

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/c3f20e0f-9067-4180-ab32-b661490abe52)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
