### PR TITLE
Fix: Discount level on the dedicate node isn't updating

### DIFF
--- a/packages/playground/src/dashboard/dedicated_nodes_view.vue
+++ b/packages/playground/src/dashboard/dedicated_nodes_view.vue
@@ -157,7 +157,7 @@ const _loadData = async () => {
       return {
         ...item,
         price: (price?.dedicatedPrice ?? 0 + (fee || 0)).toFixed(3),
-        discount: price?.sharedPackage.discount ?? 0,
+        discount: price?.sharedPackage.discount,
       };
     });
 


### PR DESCRIPTION
### Description

An unnecessary condition was causing the discount level to always display as 0%. This condition has now been removed.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1880

### Screenshots/Video

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/c5ddb81c-76e0-4e50-82a8-3687fb47802c)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
