### PR TITLE
close profile manager after login and logout

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -609,7 +609,7 @@ function logout() {
   if (router.currentRoute.value.path.includes("/overview")) {
     router.push("/");
   }
-  emit("update:model-value", false);
+  emit("update:modelValue", false);
 }
 
 const activating = ref(false);
@@ -638,7 +638,7 @@ async function activate(mnemonic: string, keypairType: KeypairType) {
     const profile = await loadProfile(grid!);
 
     profileManager.set({ ...profile, mnemonic });
-    emit("update:model-value", false);
+    emit("update:modelValue", false);
   } catch (e) {
     loginError.value = normalizeError(e, "Something went wrong while login.");
   } finally {

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -407,7 +407,6 @@ import { normalizeBalance, normalizeError } from "../utils/helpers";
 const items = ref([{ id: 1, name: "stellar" }]);
 const depositWallet = ref("");
 const selectedName = ref("");
-const openDepositDialog = ref(false);
 const selectedItem = ref(items.value[0]);
 const depositFee = ref(0);
 interface Credentials {
@@ -427,7 +426,7 @@ const props = defineProps({
     type: Boolean,
   },
 });
-defineEmits<{ (event: "update:modelValue", value: boolean): void }>();
+const emit = defineEmits<{ (event: "update:modelValue", value: boolean): void }>();
 const bridge = (window as any).env.BRIDGE_TFT_ADDRESS;
 
 const apps = [
@@ -486,6 +485,7 @@ async function mounted() {
     if (grid) {
       const DepositFee = await grid.bridge.getDepositFee();
       depositFee.value = DepositFee;
+      return;
     }
   } catch (e) {
     console.log(e);
@@ -609,6 +609,7 @@ function logout() {
   if (router.currentRoute.value.path.includes("/overview")) {
     router.push("/");
   }
+  emit("update:model-value", false);
 }
 
 const activating = ref(false);
@@ -637,6 +638,7 @@ async function activate(mnemonic: string, keypairType: KeypairType) {
     const profile = await loadProfile(grid!);
 
     profileManager.set({ ...profile, mnemonic });
+    emit("update:model-value", false);
   } catch (e) {
     loginError.value = normalizeError(e, "Something went wrong while login.");
   } finally {


### PR DESCRIPTION
### Description

Close profile manager after login and logout

[Screencast from 14-01-24 15:09:11.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/38ea1ae0-064f-487f-92a9-6af64cb5bb27)

### Changes

- Close profile manager after login and logout
- Removed unused `openDepositDialog` variable

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1964

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
