### PR TITLE
Handle max length in resource pricing calculator

### DIFF
--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -26,10 +26,11 @@
               <v-text-field
                 label="CPU (vCores)"
                 suffix="vCores"
-                type="text"
+                type="number"
                 v-model.number="CRU"
                 v-bind="props"
                 ref="valid"
+                maxlength="3"
               />
             </input-tooltip>
           </input-validator>
@@ -47,11 +48,12 @@
             <input-tooltip tooltip="The amount of RAM (Random Access Memory) in GB.">
               <v-text-field
                 label="Memory (GB)"
-                type="text"
+                type="number"
                 suffix="GB"
                 v-model.number="MRU"
                 v-bind="props"
                 ref="valid"
+                maxlength="4"
               />
             </input-tooltip>
           </input-validator>
@@ -70,7 +72,15 @@
             #="{ props }"
           >
             <input-tooltip tooltip="The SSD capacity storage.">
-              <v-text-field label="Disk SSD" suffix="GB" type="text" v-model.number="SRU" v-bind="props" ref="valid" />
+              <v-text-field
+                label="Disk SSD"
+                suffix="GB"
+                type="text"
+                v-model.number="SRU"
+                v-bind="props"
+                ref="valid"
+                maxlength="7"
+              />
             </input-tooltip>
           </input-validator>
         </v-col>
@@ -85,7 +95,15 @@
             #="{ props }"
           >
             <input-tooltip tooltip="The HDD capacity storage.">
-              <v-text-field label="Disk HDD" suffix="GB" type="text" v-model.number="HRU" v-bind="props" ref="valid" />
+              <v-text-field
+                label="Disk HDD"
+                suffix="GB"
+                type="number"
+                v-model.number="HRU"
+                v-bind="props"
+                ref="valid"
+                maxlength="7"
+              />
             </input-tooltip>
           </input-validator>
         </v-col>

--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -26,7 +26,7 @@
               <v-text-field
                 label="CPU (vCores)"
                 suffix="vCores"
-                type="number"
+                type="text"
                 v-model.number="CRU"
                 v-bind="props"
                 ref="valid"
@@ -48,7 +48,7 @@
             <input-tooltip tooltip="The amount of RAM (Random Access Memory) in GB.">
               <v-text-field
                 label="Memory (GB)"
-                type="number"
+                type="text"
                 suffix="GB"
                 v-model.number="MRU"
                 v-bind="props"
@@ -98,7 +98,7 @@
               <v-text-field
                 label="Disk HDD"
                 suffix="GB"
-                type="number"
+                type="text"
                 v-model.number="HRU"
                 v-bind="props"
                 ref="valid"

--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -26,11 +26,13 @@
               <v-text-field
                 label="CPU (vCores)"
                 suffix="vCores"
-                type="text"
+                type="number"
+                min="1"
+                max="256"
+                oninput="if(Number(this.value) > 256) this.value = 256;"
                 v-model.number="CRU"
                 v-bind="props"
                 ref="valid"
-                maxlength="3"
               />
             </input-tooltip>
           </input-validator>
@@ -48,12 +50,14 @@
             <input-tooltip tooltip="The amount of RAM (Random Access Memory) in GB.">
               <v-text-field
                 label="Memory (GB)"
-                type="text"
+                type="number"
                 suffix="GB"
+                min="1"
+                max="1024"
+                oninput="if(Number(this.value) > 1024) this.value = 1024;"
                 v-model.number="MRU"
                 v-bind="props"
                 ref="valid"
-                maxlength="4"
               />
             </input-tooltip>
           </input-validator>
@@ -75,11 +79,13 @@
               <v-text-field
                 label="Disk SSD"
                 suffix="GB"
-                type="text"
+                type="number"
+                min="1"
+                max="1000000"
+                oninput="if(Number(this.value) > 1000000) this.value = 1000000;"
                 v-model.number="SRU"
                 v-bind="props"
                 ref="valid"
-                maxlength="7"
               />
             </input-tooltip>
           </input-validator>
@@ -98,11 +104,13 @@
               <v-text-field
                 label="Disk HDD"
                 suffix="GB"
-                type="text"
+                type="number"
+                min="1"
+                max="1000000"
+                oninput="if(Number(this.value) > 1000000) this.value = 1000000;"
                 v-model.number="HRU"
                 v-bind="props"
                 ref="valid"
-                maxlength="7"
               />
             </input-tooltip>
           </input-validator>

--- a/packages/playground/src/calculator/resource_pricing.vue
+++ b/packages/playground/src/calculator/resource_pricing.vue
@@ -26,7 +26,7 @@
               <v-text-field
                 label="CPU (vCores)"
                 suffix="vCores"
-                type="number"
+                type="text"
                 v-model.number="CRU"
                 v-bind="props"
                 ref="valid"
@@ -47,7 +47,7 @@
             <input-tooltip tooltip="The amount of RAM (Random Access Memory) in GB.">
               <v-text-field
                 label="Memory (GB)"
-                type="number"
+                type="text"
                 suffix="GB"
                 v-model.number="MRU"
                 v-bind="props"
@@ -70,14 +70,7 @@
             #="{ props }"
           >
             <input-tooltip tooltip="The SSD capacity storage.">
-              <v-text-field
-                label="Disk SSD"
-                suffix="GB"
-                type="number"
-                v-model.number="SRU"
-                v-bind="props"
-                ref="valid"
-              />
+              <v-text-field label="Disk SSD" suffix="GB" type="text" v-model.number="SRU" v-bind="props" ref="valid" />
             </input-tooltip>
           </input-validator>
         </v-col>
@@ -92,14 +85,7 @@
             #="{ props }"
           >
             <input-tooltip tooltip="The HDD capacity storage.">
-              <v-text-field
-                label="Disk HDD"
-                suffix="GB"
-                type="number"
-                v-model.number="HRU"
-                v-bind="props"
-                ref="valid"
-              />
+              <v-text-field label="Disk HDD" suffix="GB" type="text" v-model.number="HRU" v-bind="props" ref="valid" />
             </input-tooltip>
           </input-validator>
         </v-col>


### PR DESCRIPTION
### Description
- at first the behavior when entering big number says that `CPU is required` as in the video below and not preventing user from adding huge numbers.

[Screencast from 08 ينا, 2024 EET 04:36:29 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/0e8894ca-d00a-4887-b215-9b7def577faf)

### Changes
- added max length to each field equal to length of its maximum value


file:///home/alaa/Videos/Screencasts/Screencast%20from%2001-14-2024%2004:26:18%20PM.webm



### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1900

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
