### PR TITLE
rename field to hex seed if a hex seed is entered

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -311,7 +311,7 @@
           <v-col cols="7" sm="12" md="12" lg="7">
             <PasswordInputWrapper #="{ props }">
               <VTextField
-                label="Your Mnemonic"
+                :label="profileManager.profile.mnemonic.startsWith('0x') ? 'Your Hex Seed' : 'Your Mnemonic'"
                 readonly
                 v-model="profileManager.profile.mnemonic"
                 v-bind="props"


### PR DESCRIPTION
### Description

rename field to hex seed if a hex seed is entered

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/922a7d60-2211-426a-92aa-2533faabbe16)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/6a37ac52-4ecb-41ce-b687-cab819008c8e)

### Changes

Added a condition to check if the entered is a hex seed or mnemonic to rename the field accordingly.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1959

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
