### PR TITLE
add reload btn in profile If any error happened

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -123,10 +123,8 @@
                             validateMnemonic(v) ||
                             ((v.length === 64 || v.length === 66) && isAddress(v.length === 66 ? v : `0x${v}`))
                           ) {
-                            isValidMnemonicOrHexSeed = true;
                             return;
                           }
-                          isValidMnemonicOrHexSeed = false;
                           return { message: 'Mnemonic or Hex Seed doesn\'t seem to be valid.' };
                         },
                       ]"
@@ -137,7 +135,17 @@
                       :disable-validation="creatingAccount || activatingAccount || activating"
                     >
                       <v-row>
-                        <v-col cols="10">
+                        <div class="d-flex align-center justify-center pl-2">
+                          <v-icon
+                            v-if="!isValidMnemonicOrHexSeed && !activatingAccount"
+                            @click="reloadValidation"
+                            style="cursor: pointer"
+                            color="white"
+                            >mdi-reload</v-icon
+                          >
+                        </div>
+
+                        <v-col cols="!isValidMnemonicOrHexSeed && !activatingAccount ? 9 : 10">
                           <div v-bind="tooltipProps">
                             <VTextField
                               label="Mnemonic or Hex Seed"
@@ -188,7 +196,8 @@
 
                         <VBtn
                           class="mt-2 ml-3"
-                          color="primary"
+                          color="secondary"
+                          variant="outlined"
                           :disabled="
                             isValidForm || !!mnemonic || shouldActivateAccount || keypairType === KeypairType.ed25519
                           "
@@ -196,15 +205,6 @@
                           @click="openAcceptTerms = termsLoading = true"
                         >
                           create account
-                        </VBtn>
-                        <VBtn
-                          class="mt-2 ml-3"
-                          color="secondary"
-                          variant="outlined"
-                          v-if="!isValidMnemonicOrHexSeed && !activatingAccount"
-                          @click="reloadValidation"
-                        >
-                          Reload
                         </VBtn>
                       </div>
                     </InputValidator>

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -135,24 +135,16 @@
                       :disable-validation="creatingAccount || activatingAccount || activating"
                     >
                       <v-row>
-                        <div class="d-flex align-center justify-center pl-2">
-                          <v-icon
-                            v-if="!enableReload && !activatingAccount && mnemonic !== ''"
-                            @click="reloadValidation"
-                            style="cursor: pointer"
-                            color="white"
-                            >mdi-reload</v-icon
-                          >
-                        </div>
-
-                        <v-col cols="!isValidMnemonicOrHexSeed && !activatingAccount ? 9 : 10">
+                        <v-col cols="10">
                           <div v-bind="tooltipProps">
                             <VTextField
+                              :append-icon="!enableReload && !activatingAccount && mnemonic !== '' ? 'mdi-reload' : ''"
                               label="Mnemonic or Hex Seed"
                               placeholder="Please insert your Mnemonic or Hex Seed"
                               v-model="mnemonic"
                               v-bind="{ ...passwordInputProps, ...validationProps }"
                               :disabled="creatingAccount || activatingAccount || activating"
+                              @click:append="reloadValidation"
                             />
                           </div>
                         </v-col>

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -137,7 +137,7 @@
                       <v-row>
                         <div class="d-flex align-center justify-center pl-2">
                           <v-icon
-                            v-if="!enableReload && !activatingAccount"
+                            v-if="!enableReload && !activatingAccount && mnemonic !== ''"
                             @click="reloadValidation"
                             style="cursor: pointer"
                             color="white"


### PR DESCRIPTION
### Description

- Reload button is required to re-request in case of failure in the profile manager, i have to copy the value then enter it again by myself to re-request.

### Changes
- if the mnemonic or hex seed not valid or any issue happened, the button will appear.
- also will appear if any error happened while sending requests form Activate, Create 
Account or Connect.
- once it's valid the button will disappear.

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1955

[Screencast from 01-15-2024 02:58:23 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/abdfec65-d0dd-4241-a40d-45558cd88f15)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
