### PR TITLE
fix: make the countries count equals to nodeDistribution

### DIFF
--- a/packages/new_stats/src/utils/stats.ts
+++ b/packages/new_stats/src/utils/stats.ts
@@ -8,7 +8,6 @@ function mergeAllStatsData(stats: Stats[]): Stats {
     res.accessNodes += stats[i].accessNodes;
     res.dedicatedNodes += stats[i].dedicatedNodes;
     res.contracts += stats[i].contracts;
-    res.countries += stats[i].countries;
     res.farms += stats[i].farms;
     res.gateways += stats[i].gateways;
     res.nodes += stats[i].nodes;
@@ -20,6 +19,7 @@ function mergeAllStatsData(stats: Stats[]): Stats {
     res.gpus += stats[i].gpus;
     res.twins += stats[i].twins;
     res.nodesDistribution = mergeNodeDistribution([res.nodesDistribution, stats[i].nodesDistribution]);
+    res.countries = Object.keys(res.nodesDistribution).length;
   }
 
   return res;


### PR DESCRIPTION
### Description

no need to add all counties in each network, the `mergeNodeDistribution` function already return the unique countries, so we just need to get its length.


### Related Issues

- #2002 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
