### PR TITLE
Fix: Discount level on the dedicate node isn't updating

### DIFF
--- a/packages/playground/src/dashboard/dedicated_nodes_view.vue
+++ b/packages/playground/src/dashboard/dedicated_nodes_view.vue
@@ -157,7 +157,7 @@ const _loadData = async () => {
       return {
         ...item,
         price: (price?.dedicatedPrice ?? 0 + (fee || 0)).toFixed(3),
-        discount: price?.sharedPackage.discount,
+        discount: price?.dedicatedPackage.discount,
       };
     });
 

--- a/packages/playground/src/dashboard/dedicated_nodes_view.vue
+++ b/packages/playground/src/dashboard/dedicated_nodes_view.vue
@@ -131,7 +131,7 @@ const _loadData = async () => {
       totalCru: totalCruValue ? +totalCruValue : undefined,
       gpuVendorName: filterInputs.value.gpu_vendor_name.value || "",
       gpuDeviceName: filterInputs.value.gpu_device_name.value || "",
-      hasGpu: filterOptions.value.gpu,
+      hasGpu: filterOptions.value.gpu ? filterOptions.value.gpu : undefined,
     });
 
     if (data.count === 0) {


### PR DESCRIPTION
### Description

1. **Discount Issue Fix:** Resolves the issue with the discount calculation. The fix involves accessing the correct property, `dedicatedPackage.discount`, instead of using `sharedPackage.discount`.

2. **GPU Switch Filter Fix:** Fixes the GPU switch filter by updating the way the GPU value is sent. Now, when the GPU isn't required, it is sent as 'undefined' instead of `false`.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1880

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
