### PR TITLE
add dao voting manual link to dao information

### DIFF
--- a/packages/playground/src/dashboard/dao_view.vue
+++ b/packages/playground/src/dashboard/dao_view.vue
@@ -221,8 +221,9 @@
                 considered valid.
               </span>
               <span>
-                If the vote count is insufficient and the time limit is reached, the proposal will be rejected.</span
-              >
+                If the vote count is insufficient and the time limit is reached, the proposal will be rejected.
+              </span>
+              <a href="https://manual.grid.tf/dashboard/dao_voting/dao_voting.html" target="_blank">How to vote.</a>
               <br />
               <br />
               <h3>How do we count weight:</h3>

--- a/packages/playground/src/dashboard/dao_view.vue
+++ b/packages/playground/src/dashboard/dao_view.vue
@@ -223,7 +223,7 @@
               <span>
                 If the vote count is insufficient and the time limit is reached, the proposal will be rejected.
               </span>
-              <a href="https://manual.grid.tf/dashboard/dao_voting/dao_voting.html" target="_blank">How to vote.</a>
+              <a href="https://manual.grid.tf/dashboard/dao_voting/dao_voting.html" target="_blank">How to vote?</a>
               <br />
               <br />
               <h3>How do we count weight:</h3>


### PR DESCRIPTION
### Description

Add dao voting manual link to dao information

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/e59c9f5f-2a9b-4c52-8002-eed87585ea91)

### Changes

- Added manual link for dao voting in the dao page information.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1989

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
