### PR TITLE
add info alert to generate/update ssh-key

### DIFF
--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -3,7 +3,7 @@
     <v-alert v-if="hasEnoughBalance" type="info" variant="tonal" class="ma-4">
       Updating or generating SSH key will cost you up to 0.01 TFT
     </v-alert>
-    <v-alert v-else type="warning" variant="tonal" class="ma-4">
+    <v-alert v-else-if="balance" type="warning" variant="tonal" class="ma-4">
       Your balance is not enough to {{ profileManager.profile?.ssh ? "update the" : `generate a` }} SSH key; please make
       sure you have at least 0.01 TFT.
     </v-alert>

--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -1,5 +1,8 @@
 <template>
   <v-card>
+    <v-alert type="info" variant="tonal" class="ma-4">
+      Updating or generating SSH key will cost you up to 0.01 TFT
+    </v-alert>
     <VTooltip
       text="SSH Keys are used to authenticate you to the deployment instance for management purposes. If you don't have an SSH Key or are not familiar, we can generate one for you."
       location="bottom"
@@ -22,7 +25,10 @@
                 : SSHKeyHint
             "
             :persistent-hint="updatingSSH || generatingSSH || !!SSHKeyHint"
-            :rules="[value => !!value || 'SSH key is required']"
+            :rules="[
+              () => isEnoughBalance(balance) || 'Your balance is not enough to update your ssh key',
+              value => !!value || 'SSH key is required',
+            ]"
           />
         </CopyInputWrapper>
 
@@ -31,7 +37,7 @@
             class="mr-2 text-subtitle-2"
             color="secondary"
             variant="outlined"
-            :disabled="!!ssh || updatingSSH || generatingSSH || !isEnoughBalance(balance)"
+            :disabled="!!ssh || updatingSSH || generatingSSH || !isEnoughBalance(balance, 0.01)"
             :loading="generatingSSH"
             @click="generateSSH"
           >
@@ -42,7 +48,7 @@
             color="secondary"
             variant="outlined"
             @click="updateSSH"
-            :disabled="!ssh || profileManager.profile?.ssh === ssh || updatingSSH || !isEnoughBalance(balance)"
+            :disabled="!ssh || profileManager.profile?.ssh === ssh || updatingSSH || !isEnoughBalance(balance, 0.01)"
             :loading="updatingSSH"
           >
             Update Public SSH Key


### PR DESCRIPTION

### Description

Now the user will got notified that updating or creating ssh key will cost up to 0.01 tft

### Changes

- remove low balance toast; 
   - if the user logged in at the sshkey page, two toast will be triggered, so I removed the one from sshkey 
- add warning alert in case of low balance, and disable the sshkey field
  ![Screenshot from 2024-01-18 12-15-27](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/e3c7acaf-3814-46cf-88ed-4d02d19d65ea)
  ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/b2c6971f-da5b-4cdd-8c33-abe6d3eada8f)



- add info alert to inform the user that update or generate ssh key will cost up to 0.01 tft
   ![Screenshot from 2024-01-18 11-52-25](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/55462e4c-6720-4107-8129-2ae0f90d98fc)
### Related Issues

- #1995 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
