### PR TITLE
enable send btn once address is validated

### DIFF
--- a/packages/playground/src/dashboard/bridge_view.vue
+++ b/packages/playground/src/dashboard/bridge_view.vue
@@ -152,7 +152,10 @@ function navigation() {
 
 function swapAddressCheck() {
   targetError.value = "";
-  if (!target.value) return true;
+  if (!target.value) {
+    isValidSwap.value = false;
+    return true;
+  }
   const isValid = StrKey.isValidEd25519PublicKey(target.value);
   const blockedAddresses = [
     "GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC",
@@ -164,11 +167,12 @@ function swapAddressCheck() {
   }
   if (!isValid || target.value.match(/\W/)) {
     targetError.value = "invalid address";
+    isValidSwap.value = false;
     return false;
   }
   targetError.value = "";
   validatingAddress.value = true;
-  isValidSwap.value = false;
+  isValidSwap.value = true;
   if (selectedName.value == "stellar") validateAddress();
   return true;
 }
@@ -194,6 +198,7 @@ async function validateAddress() {
   }
 
   validatingAddress.value = false;
+  isValidSwap.value = true;
   return;
 }
 


### PR DESCRIPTION
### Description
- After entering the address and without changing the amount (TFT), you can't send without making any changes to the amount input.

### Changes
- Check that `isValidaSwap` condition is changed to true once address is valid.

### Related Issues
#1991 

[Screencast from 01-18-2024 10:50:51 AM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/ab9e62ee-f19c-403a-9fe0-29046e98bc72)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
