### PR TITLE
Make serial numbers consitent

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -38,13 +38,10 @@
 
     <template #title>
       Node ID: {{ node?.nodeId }}
-      <VTooltip
-        text="Node Serial Number"
-        v-if="node && node.serialNumber && node.serialNumber.toLowerCase() !== 'default string'"
-      >
+      <VTooltip text="Node Serial Number" v-if="node && node.serialNumber">
         <template #activator="{ props }">
           <VChip size="x-small" v-bind="props">
-            <span class="font-weight-bold" v-text="node.serialNumber" />
+            <span class="font-weight-bold" v-text="checkSerialNumber(node?.serialNumber)" />
           </VChip>
         </template>
       </VTooltip>
@@ -154,6 +151,14 @@ export default {
       };
     }
 
+    function checkSerialNumber(serialNumber: string) {
+      if (/\d/.test(serialNumber)) {
+        return serialNumber;
+      } else {
+        return "Unknown";
+      }
+    }
+
     const cruText = computed(() =>
       props.node ? `${props.node.used_resources.cru} / ${props.node.total_resources.cru} (Cores)` : "",
     );
@@ -161,7 +166,7 @@ export default {
     const sruText = computed(normalizeBytesResourse("sru"));
     const hruText = computed(normalizeBytesResourse("hru"));
 
-    return { flag, cruText, mruText, sruText, hruText };
+    return { flag, cruText, mruText, sruText, hruText, checkSerialNumber };
   },
 };
 </script>


### PR DESCRIPTION
### Description
- The problem is that serial numbers are not consistent in all nodes.

### Changes

- check if the serial number not containing any numbers, it will be shown as `Unknown`.
- otherwise will show the given serial number
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2025

- serial number in playground:
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/8fa20de2-1969-489a-a758-098e6d09a985)

- returned serial number from gridproxy.
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/d7015d83-ebd4-4c75-a9ee-b66c178fdbdc)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
