### PR TITLE
reset withdraw dialog when its closed

### DIFF
--- a/packages/playground/src/components/withdraw_dialog.vue
+++ b/packages/playground/src/components/withdraw_dialog.vue
@@ -1,0 +1,181 @@
+<template>
+  <v-container>
+    <v-dialog
+      transition="dialog-bottom-transition"
+      max-width="1000"
+      v-model="withdrawDialog"
+      @update:model-value="closeDialog"
+    >
+      <v-card>
+        <v-toolbar color="primary" dark class="bold-text justify-center"> Withdraw TFT </v-toolbar>
+        <v-card-text>
+          Interact with the bridge in order to withdraw your TFT to
+          {{ selectedName?.charAt(0).toUpperCase() + selectedName!.slice(1) }} (withdraw fee is: {{ withdrawFee }} TFT)
+        </v-card-text>
+        <v-card-text>
+          <v-form v-model="isValidSwap">
+            <v-text-field
+              v-model="target"
+              :label="selectedName?.charAt(0).toUpperCase() + selectedName!.slice(1) + ' Target Wallet Address'"
+              :error-messages="targetError"
+              :disabled="validatingAddress"
+              :loading="validatingAddress"
+              :rules="[() => !!target || 'This field is required', swapAddressCheck]"
+            >
+            </v-text-field>
+            <v-text-field
+              @paste.prevent
+              label="Amount (TFT)"
+              v-model="amount"
+              type="number"
+              onkeydown="javascript: return event.keyCode == 69 || /^\+$/.test(event.key) ? false : true"
+              :rules="[
+                () => !!amount || 'This field is required',
+                () =>
+                  (amount.toString().split('.').length > 1 ? amount.toString().split('.')[1].length <= 3 : true) ||
+                  'Amount must have 3 decimals only',
+                () => amount >= 2 || 'Amount should be at least 2 TFT',
+                () => amount < freeBalance! || 'Amount cannot exceed balance',
+              ]"
+            >
+            </v-text-field>
+          </v-form>
+        </v-card-text>
+        <v-card-actions class="justify-end pb-4 px-6">
+          <v-btn variant="outlined" color="anchor" class="px-3" @click="closeDialog"> Close </v-btn>
+          <v-btn
+            class="px-3"
+            color="secondary"
+            variant="outlined"
+            @click="withdrawTFT(target, amount)"
+            :disabled="!isValidSwap || validatingAddress"
+            :loading="loadingWithdraw"
+            >Send</v-btn
+          >
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { default as StellarSdk, StrKey } from "stellar-sdk";
+import { onMounted, ref } from "vue";
+
+import { useProfileManagerController } from "../components/profile_manager_controller.vue";
+import { useProfileManager } from "../stores";
+import { createCustomToast, ToastType } from "../utils/custom_toast";
+import { getGrid } from "../utils/grid";
+
+const withdrawDialog = ref(false);
+const targetError = ref("");
+const target = ref("");
+const isValidSwap = ref(false);
+const validatingAddress = ref(false);
+const server = new StellarSdk.Server(window.env.STELLAR_HORIZON_URL);
+const loadingWithdraw = ref(false);
+const ProfileManagerController = useProfileManagerController();
+const profileManager = useProfileManager();
+const amount = ref(2);
+const emits = defineEmits(["close"]);
+
+const props = defineProps({
+  selectedName: String,
+  withdrawFee: Number,
+  openWithdrawDialog: Boolean,
+  freeBalance: Number,
+});
+
+onMounted(async () => {
+  if (!props.openWithdrawDialog) return;
+  withdrawDialog.value = true;
+});
+
+function swapAddressCheck() {
+  targetError.value = "";
+  if (!target.value) {
+    isValidSwap.value = false;
+    return true;
+  }
+  const isValid = StrKey.isValidEd25519PublicKey(target.value);
+  const blockedAddresses = [
+    "GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC",
+    "GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4",
+  ];
+  if (blockedAddresses.includes(target.value)) {
+    targetError.value = "Blocked Address";
+    return false;
+  }
+  if (!isValid || target.value.match(/\W/)) {
+    targetError.value = "invalid address";
+    isValidSwap.value = false;
+    return false;
+  }
+  targetError.value = "";
+  validatingAddress.value = true;
+  isValidSwap.value = true;
+  if (props.selectedName == "stellar") validateAddress();
+  return true;
+}
+
+async function validateAddress() {
+  try {
+    // check if the account provided exists on stellar
+    const account = await server.loadAccount(target.value);
+    // check if the account provided has the appropriate trustlines
+    const includes = account.balances.find(
+      (b: { asset_code: string; asset_issuer: string }) =>
+        b.asset_code === "TFT" && b.asset_issuer === window.env.TFT_ASSET_ISSUER,
+    );
+    if (!includes) throw new Error("invalid trustline");
+  } catch (e) {
+    targetError.value =
+      (e as Error).message === "invalid trustline"
+        ? "Address does not have a valid trustline to TFT"
+        : "Address not found";
+    validatingAddress.value = false;
+    isValidSwap.value = false;
+    return;
+  }
+
+  validatingAddress.value = false;
+  isValidSwap.value = true;
+  return;
+}
+
+async function withdrawTFT(targetAddress: string, withdrawAmount: number) {
+  loadingWithdraw.value = true;
+  try {
+    const grid = await getGrid(profileManager.profile!);
+    await grid?.bridge.swapToStellar({ amount: +withdrawAmount, target: targetAddress });
+
+    await ProfileManagerController.reloadBalance();
+    createCustomToast("Transaction Succeeded", ToastType.success);
+    closeDialog();
+  } catch (e) {
+    console.log("Error withdrawing, Error: ", e);
+
+    createCustomToast("Withdraw Failed!", ToastType.danger);
+    closeDialog();
+  }
+}
+
+const closeDialog = () => {
+  withdrawDialog.value = false;
+  emits("close");
+};
+</script>
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "WithdrawDialog",
+});
+</script>
+
+<style>
+.bold-text {
+  font-weight: 500;
+  padding-left: 1rem;
+}
+</style>

--- a/packages/playground/src/dashboard/bridge_view.vue
+++ b/packages/playground/src/dashboard/bridge_view.vue
@@ -39,67 +39,20 @@
   ></deposit-dialog>
 
   <!-- Withdraw Dialog -->
-  <v-container v-if="openWithdrawDialog">
-    <v-dialog transition="dialog-bottom-transition" max-width="1000" v-model="openWithdrawDialog">
-      <v-card>
-        <v-toolbar color="primary" dark class="bold-text justify-center"> Withdraw TFT </v-toolbar>
-        <v-card-text>
-          Interact with the bridge in order to withdraw your TFT to
-          {{ selectedName.charAt(0).toUpperCase() + selectedName.slice(1) }} (withdraw fee is: {{ withdrawFee }} TFT)
-        </v-card-text>
-        <v-card-text>
-          <v-form v-model="isValidSwap">
-            <v-text-field
-              v-model="target"
-              :label="selectedName.charAt(0).toUpperCase() + selectedName.slice(1) + ' Target Wallet Address'"
-              :error-messages="targetError"
-              :disabled="validatingAddress"
-              :loading="validatingAddress"
-              :rules="[() => !!target || 'This field is required', swapAddressCheck]"
-            >
-            </v-text-field>
-            <v-text-field
-              @paste.prevent
-              label="Amount (TFT)"
-              v-model="amount"
-              type="number"
-              onkeydown="javascript: return event.keyCode == 69 || /^\+$/.test(event.key) ? false : true"
-              :rules="[
-                () => !!amount || 'This field is required',
-                () =>
-                  (amount.toString().split('.').length > 1 ? amount.toString().split('.')[1].length <= 3 : true) ||
-                  'Amount must have 3 decimals only',
-                () => amount >= 2 || 'Amount should be at least 2 TFT',
-                () => amount < freeBalance || 'Amount cannot exceed balance',
-              ]"
-            >
-            </v-text-field>
-          </v-form>
-        </v-card-text>
-        <v-card-actions class="justify-end pb-4 px-6">
-          <v-btn variant="outlined" color="anchor" class="px-3" @click="openWithdrawDialog = false"> Close </v-btn>
-          <v-btn
-            class="px-3"
-            color="secondary"
-            variant="outlined"
-            @click="withdrawTFT(target, amount)"
-            :disabled="!isValidSwap || validatingAddress"
-            :loading="loadingWithdraw"
-            >Send</v-btn
-          >
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </v-container>
+  <withdraw-dialog
+    v-if="openWithdrawDialog"
+    :selectedName="selectedName"
+    :withdrawFee="withdrawFee"
+    :openWithdrawDialog="openWithdrawDialog"
+    :freeBalance="freeBalance"
+    @close="openWithdrawDialog = false"
+  ></withdraw-dialog>
 </template>
 
 <script lang="ts" setup>
-import { default as StellarSdk, StrKey } from "stellar-sdk";
-import { onMounted, ref, watch } from "vue";
+import { onMounted, ref } from "vue";
 
-import { useProfileManagerController } from "../components/profile_manager_controller.vue";
 import { useProfileManager } from "../stores";
-import { createCustomToast, ToastType } from "../utils/custom_toast";
 import { getGrid, loadBalance } from "../utils/grid";
 
 const profileManager = useProfileManager();
@@ -109,18 +62,10 @@ const openDepositDialog = ref(false);
 const openWithdrawDialog = ref(false);
 const selectedName = ref("");
 const withdrawFee = ref(0);
-const isValidSwap = ref(false);
-const target = ref("");
-const targetError = ref("");
-const validatingAddress = ref(false);
-const server = new StellarSdk.Server(window.env.STELLAR_HORIZON_URL);
-const amount = ref(2);
 const freeBalance = ref(0);
-const loadingWithdraw = ref(false);
 const depositWallet = ref("");
 const qrCodeText = ref("");
 const depositFee = ref(0);
-const ProfileManagerController = useProfileManagerController();
 
 onMounted(async () => {
   selectedName.value = items.value.filter(item => item.id === selectedItem.value.id)[0].name;
@@ -143,121 +88,23 @@ onMounted(async () => {
   }
 });
 
-watch(openWithdrawDialog, val => {
-  if (!val) {
-    resetForm();
-  }
-});
-
 function navigation() {
   window.open(
     "https://manual.grid.tf/threefold_token/tft_bridges/tfchain_stellar_bridge.html#how-to-use-the-tfchain-stellar-bridge",
     "_blank",
   );
 }
-
-function swapAddressCheck() {
-  targetError.value = "";
-  if (!target.value) {
-    isValidSwap.value = false;
-    return true;
-  }
-  const isValid = StrKey.isValidEd25519PublicKey(target.value);
-  const blockedAddresses = [
-    "GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC",
-    "GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4",
-  ];
-  if (blockedAddresses.includes(target.value)) {
-    targetError.value = "Blocked Address";
-    return false;
-  }
-  if (!isValid || target.value.match(/\W/)) {
-    targetError.value = "invalid address";
-    isValidSwap.value = false;
-    return false;
-  }
-  targetError.value = "";
-  validatingAddress.value = true;
-  isValidSwap.value = true;
-  if (selectedName.value == "stellar") validateAddress();
-  return true;
-}
-
-async function validateAddress() {
-  try {
-    // check if the account provided exists on stellar
-    const account = await server.loadAccount(target.value);
-    // check if the account provided has the appropriate trustlines
-    const includes = account.balances.find(
-      (b: { asset_code: string; asset_issuer: string }) =>
-        b.asset_code === "TFT" && b.asset_issuer === window.env.TFT_ASSET_ISSUER,
-    );
-    if (!includes) throw new Error("invalid trustline");
-  } catch (e) {
-    targetError.value =
-      (e as Error).message === "invalid trustline"
-        ? "Address does not have a valid trustline to TFT"
-        : "Address not found";
-    validatingAddress.value = false;
-    isValidSwap.value = false;
-    return;
-  }
-
-  validatingAddress.value = false;
-  isValidSwap.value = true;
-  return;
-}
-
-async function withdrawTFT(targetAddress: string, withdrawAmount: number) {
-  loadingWithdraw.value = true;
-  try {
-    const grid = await getGrid(profileManager.profile!);
-    await grid?.bridge.swapToStellar({ amount: +withdrawAmount, target: targetAddress });
-
-    openWithdrawDialog.value = false;
-    target.value = "";
-    amount.value = 2;
-    loadingWithdraw.value = false;
-    await ProfileManagerController.reloadBalance();
-    createCustomToast("Transaction Succeeded", ToastType.success);
-  } catch (e) {
-    console.log("Error withdrawing, Error: ", e);
-    openWithdrawDialog.value = false;
-    target.value = "";
-    amount.value = 2;
-    loadingWithdraw.value = false;
-    createCustomToast("Withdraw Failed!", ToastType.danger);
-  }
-}
-
-function resetForm() {
-  openWithdrawDialog.value = false;
-  target.value = "";
-  amount.value = 2;
-  isValidSwap.value = false;
-  validatingAddress.value = false;
-  targetError.value = "";
-}
 </script>
 
 <script lang="ts">
 import DepositDialog from "@/components/deposit_dialog.vue";
+import WithdrawDialog from "@/components/withdraw_dialog.vue";
 
 export default {
   name: "Bridge",
   components: {
     DepositDialog,
+    WithdrawDialog,
   },
 };
 </script>
-
-<style>
-.custom-container {
-  width: 80%;
-}
-
-.bold-text {
-  font-weight: 500;
-  padding-left: 1rem;
-}
-</style>

--- a/packages/playground/src/dashboard/bridge_view.vue
+++ b/packages/playground/src/dashboard/bridge_view.vue
@@ -95,7 +95,7 @@
 
 <script lang="ts" setup>
 import { default as StellarSdk, StrKey } from "stellar-sdk";
-import { onMounted, ref } from "vue";
+import { onMounted, ref, watch } from "vue";
 
 import { useProfileManagerController } from "../components/profile_manager_controller.vue";
 import { useProfileManager } from "../stores";
@@ -140,6 +140,12 @@ onMounted(async () => {
     }
   } catch (e) {
     console.log(e);
+  }
+});
+
+watch(openWithdrawDialog, val => {
+  if (!val) {
+    resetForm();
   }
 });
 
@@ -222,6 +228,15 @@ async function withdrawTFT(targetAddress: string, withdrawAmount: number) {
     loadingWithdraw.value = false;
     createCustomToast("Withdraw Failed!", ToastType.danger);
   }
+}
+
+function resetForm() {
+  openWithdrawDialog.value = false;
+  target.value = "";
+  amount.value = 2;
+  isValidSwap.value = false;
+  validatingAddress.value = false;
+  targetError.value = "";
 }
 </script>
 


### PR DESCRIPTION
### Description

closing the withdraw window at bridge transfer does not clear the field and even clearing the filed the warning will not be cleared when you close and open again

### Changes

-  I separated withdraw dialog in separate component so, it will be destroyed automatic when closing it.
### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2064


[Screencast from 01-24-2024 03:00:12 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/5f137364-6d19-408e-95e2-1d6ef71c80f8)



### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
