### PR TITLE
Add Dialog to show contract lock details for contracts on grace period

### DIFF
--- a/packages/playground/src/components/contracts_list/contracts_table.vue
+++ b/packages/playground/src/components/contracts_list/contracts_table.vue
@@ -195,7 +195,7 @@ const getAmountLocked = (): number => {
 };
 
 const isNodeInRentContracts = computed(() => {
-  if (props.contractsType == "rent") {
+  if (props.contractsType == ContractType.RENT) {
     const nodeIds = contracts.value.map(contract => contract.nodeId).filter(nodeId => nodeId !== undefined) as number[];
     if (contractLocked.value && contractLocked.value.amountLocked === 0) {
       return nodeIds.includes(selectedItem.value.nodeId);


### PR DESCRIPTION
### Description

When clicking on the grace period contract, it doesn't show me the locked TFT like before; it's just stuck doing nothing.

### Changes
- Dialog added to show locked tfts.

### Related Issues

#2053 

[Screencast from 01-29-2024 11:18:56 AM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/fb0cc253-ba77-4f2c-bd91-71b86f614fa5)




### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
