### PR TITLE
Make failed deployments icon more clear

### DIFF
--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -9,7 +9,13 @@
           >or the deployment{{ count - items.length > 1 ? "s are" : " is" }} encrypted by another key</span
         >.
       </span>
-      <v-icon class="custom-icon" @click="showDialog = true">mdi-file-document-outline </v-icon>
+      <v-tooltip location="top" text="Show failed deployments">
+        <template #activator="{ props }">
+          <v-icon v-bind="props" class="custom-icon" @click="showDialog = true"
+            >mdi-file-document-refresh-outline
+          </v-icon>
+        </template>
+      </v-tooltip>
 
       <v-dialog transition="dialog-bottom-transition" v-model="showDialog" max-width="500px">
         <v-card>

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -9,7 +9,13 @@
           >or the deployment{{ count - items.length > 1 ? "s are" : " is" }} encrypted by another key</span
         >.
       </span>
-      <v-icon class="custom-icon" @click="showDialog = true">mdi-file-document-outline </v-icon>
+      <v-tooltip location="top" text="Show failed deployments">
+        <template #activator="{ props }">
+          <v-icon v-bind="props" class="custom-icon" @click="showDialog = true"
+            >mdi-file-document-refresh-outline
+          </v-icon>
+        </template>
+      </v-tooltip>
 
       <v-dialog transition="dialog-bottom-transition" v-model="showDialog" max-width="500px" scrollable>
         <v-card>


### PR DESCRIPTION
### Description

failed to load icon is still not clear to the user that it is a clickable button to show the failed to load contracts.
### Changes
- Icon updated to be `mdi-file-document-refresh-outline`, also added tooltip on it.

![Screenshot from 2024-01-30 14-05-03](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/a17d2a08-3875-4123-b5dc-68e6890a841e)


### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1907
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
