### PR TITLE
fix the manage workers dialog for caprover after adding or deleting a worker

### DIFF
--- a/packages/playground/src/components/manage_caprover_worker_dialog.vue
+++ b/packages/playground/src/components/manage_caprover_worker_dialog.vue
@@ -72,7 +72,7 @@
 
       <v-card-actions>
         <v-spacer />
-        <v-btn color="error" variant="tonal" @click="deployedDialog = false">Close</v-btn>
+        <v-btn color="anchor" variant="outlined" @click="deployedDialog = false">Close</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -147,6 +147,7 @@ async function deploy(layout: any) {
     const [leader, ...workers] = vm;
     leader.workers = workers;
     leader.projectName = props.projectName;
+    leader.deploymentName = leader.name;
     caproverData.value = leader;
     deployedDialog.value = true;
     layout.setStatus("success", `Successfully add a new worker to Caprover('${props.master.name}') Instance.`);
@@ -175,6 +176,7 @@ async function onDelete(cb: (workers: any[]) => void) {
   cb(data.slice(1));
   const [leader, ...workers] = data;
   leader.workers = workers;
+  leader.deploymentName = leader.name;
   leader.projectName = props.projectName;
   emits("update:caprover", leader);
   deleting.value = false;

--- a/packages/playground/src/components/manage_worker_dialog.vue
+++ b/packages/playground/src/components/manage_worker_dialog.vue
@@ -25,7 +25,7 @@
       </form-validator>
 
       <template #footer-actions>
-        <v-btn color="error" variant="tonal" v-if="!deleting" @click="$emit('close')"> Close </v-btn>
+        <v-btn color="anchor" variant="outlined" v-if="!deleting" @click="$emit('close')"> Close </v-btn>
         <v-btn
           color="error"
           variant="outlined"
@@ -37,8 +37,8 @@
           Delete
         </v-btn>
         <v-btn
-          color="primary"
-          variant="tonal"
+          color="secondary"
+          variant="outlined"
           :disabled="!valid"
           @click="$emit('deploy', layout)"
           v-if="showType === 1"


### PR DESCRIPTION
### Description

fix the manage workers dialog for caprover not closing after adding or deleting a worker.

#### Adding a worker

[Screencast from 30-01-24 17:13:51.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/b95a61db-e214-42f3-bce6-e8d74f909a92)

#### Deleting a worker

[Screencast from 30-01-24 17:09:10.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/aead4896-9b71-46b7-91cd-207824ec9c1c)


### Changes

- added deployment name to the leader on deploy and on delete.
- Updated the buttons in the caprover manage workers dialog to be consistent with the the rest of the buttons.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2046

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
