### PR TITLE
Fix: Adding and Removing public config take long time to reflect

### DIFF
--- a/packages/playground/src/dashboard/components/public_config.vue
+++ b/packages/playground/src/dashboard/components/public_config.vue
@@ -110,10 +110,6 @@
               Remove Config
             </v-btn>
 
-            <v-btn v-if="runningInDevMode" @click="fillFakeData" color="warning" variant="outlined">
-              Fill fake data
-            </v-btn>
-
             <!-- Close and Save Buttons -->
             <div>
               <v-btn @click="showDialogue = false" variant="outlined" color="anchor">Close</v-btn>
@@ -194,7 +190,6 @@ export default {
     const isConfigChanged = ref(false);
     const formRef = useFormRef();
     const grid = useGrid();
-    const runningInDevMode = import.meta.env.DEV;
 
     const defualtNodeConfig = ref<PublicConfig>(publicConfigInitializer());
     const config = ref<PublicConfig>(publicConfigInitializer());
@@ -263,16 +258,6 @@ export default {
       }
     }
 
-    const fillFakeData = () => {
-      config.value = {
-        ipv4: "123.123.255.52/16",
-        gw4: "123.123.255.55",
-        ipv6: "::52/16",
-        gw6: "::54",
-        domain: "test.com",
-      };
-    };
-
     async function removeConfig() {
       try {
         isRemoving.value = true;
@@ -311,10 +296,8 @@ export default {
       config,
       isConfigChanged,
       formRef,
-      runningInDevMode,
       AddConfig,
       removeConfig,
-      fillFakeData,
       isNodeHasConfig,
     };
   },

--- a/packages/playground/src/dashboard/components/public_config.vue
+++ b/packages/playground/src/dashboard/components/public_config.vue
@@ -110,7 +110,9 @@
               Remove Config
             </v-btn>
 
-            <v-btn @click="fillFakeData" color="warning" variant="outlined"> Fill fake data </v-btn>
+            <v-btn v-if="runningInDevMode" @click="fillFakeData" color="warning" variant="outlined">
+              Fill fake data
+            </v-btn>
 
             <!-- Close and Save Buttons -->
             <div>

--- a/packages/playground/src/dashboard/components/public_config.vue
+++ b/packages/playground/src/dashboard/components/public_config.vue
@@ -23,16 +23,18 @@
           </v-toolbar>
           <div class="pt-6 px-6">
             <form-validator v-model="valid" ref="formRef">
+              <!-- IPv4 -->
               <input-validator
                 :value="config.ipv4"
                 :rules="[validators.required('IPv4 is required.'), validators.isIPRange('IP is not valid.', 4)]"
                 #="{ props }"
               >
-                <input-tooltip tooltip="IPV4 address in CIDR format xx.xx.xx.xx/xx">
+                <input-tooltip tooltip="IPv4 address in CIDR format xx.xx.xx.xx/xx">
                   <v-text-field v-model="config.ipv4" v-bind="props" outlined label="IPv4"></v-text-field>
                 </input-tooltip>
               </input-validator>
 
+              <!-- Gateway IPv4 -->
               <input-validator
                 :value="config.gw4"
                 :rules="[
@@ -47,10 +49,12 @@
                 ]"
                 #="{ props }"
               >
-                <input-tooltip tooltip="Gateway for the IP in ipv4 format">
-                  <v-text-field v-model="config.gw4" v-bind:="props" outlined label="Gateway IPv4"></v-text-field>
+                <input-tooltip tooltip="Gateway for the IP in IPv4 format">
+                  <v-text-field v-model="config.gw4" v-bind="props" outlined label="Gateway IPv4"></v-text-field>
                 </input-tooltip>
               </input-validator>
+
+              <!-- IPv6 -->
               <input-validator
                 :value="config.ipv6"
                 :rules="[
@@ -59,11 +63,12 @@
                 ]"
                 #="{ props }"
               >
-                <input-tooltip tooltip="IPV6 address in format x:x:x:x:x:x:x:x">
-                  <v-text-field v-model="config.ipv6" v-bind:="props" outlined label="IPv6"></v-text-field>
+                <input-tooltip tooltip="IPv6 address in format x:x:x:x:x:x:x:x">
+                  <v-text-field v-model="config.ipv6" v-bind="props" outlined label="IPv6"></v-text-field>
                 </input-tooltip>
               </input-validator>
 
+              <!-- Gateway IPv6 -->
               <input-validator
                 :value="config.gw6"
                 :rules="[
@@ -77,30 +82,37 @@
                 ]"
                 #="{ props }"
               >
-                <input-tooltip tooltip="Gateway for the IP in ipv6 format">
-                  <v-text-field v-model="config.gw6" v-bind:="props" outlined label="Gateway IPv6"></v-text-field>
+                <input-tooltip tooltip="Gateway for the IP in IPv6 format">
+                  <v-text-field v-model="config.gw6" v-bind="props" outlined label="Gateway IPv6"></v-text-field>
                 </input-tooltip>
               </input-validator>
 
+              <!-- Domain -->
               <input-validator
                 :value="config.domain"
                 :rules="[domain => validators.isURL('Wrong domain format.')(domain)]"
                 #="{ props }"
               >
                 <input-tooltip tooltip="Domain for web gateway">
-                  <v-text-field v-model="config.domain" v-bind:="props" outlined label="Domain"></v-text-field>
+                  <v-text-field v-model="config.domain" v-bind="props" outlined label="Domain"></v-text-field>
                 </input-tooltip>
               </input-validator>
             </form-validator>
           </div>
           <v-card-actions class="justify-space-between px-5 pb-5 pt-0">
+            <!-- Remove and Generate Config Buttons -->
             <v-btn
-              @click="showClearDialogue = true"
+              @click="isNodeHasConfig"
               color="error"
               variant="outlined"
               :disabled="isRemoving || Object.values(config).every(value => value == '')"
-              >Remove Config</v-btn
             >
+              Remove Config
+            </v-btn>
+
+            <v-btn @click="fillFakeData" color="warning" variant="outlined"> Fill fake data </v-btn>
+
+            <!-- Close and Save Buttons -->
             <div>
               <v-btn @click="showDialogue = false" variant="outlined" color="anchor">Close</v-btn>
               <v-btn
@@ -118,6 +130,7 @@
       </v-dialog>
     </template>
 
+    <!-- Remove Config Dialog -->
     <template v-if="showClearDialogue">
       <v-dialog v-model="showClearDialogue" width="650">
         <v-card>
@@ -129,6 +142,7 @@
             <p>This action is reversible!</p>
           </v-alert>
           <v-card-actions class="justify-end px-5 pb-5 pt-0">
+            <!-- Cancel and Remove Buttons -->
             <v-btn text="Cancel" color="anchor" variant="outlined" @click="showClearDialogue = false"></v-btn>
             <v-btn
               text="Remove"
@@ -147,14 +161,13 @@
 
 <script lang="ts">
 import type { PublicConfig } from "@threefold/grid_client";
-import _ from "lodash";
-import { onMounted, type PropType, ref, watch } from "vue";
+import { isEqual } from "lodash";
+import { onMounted, ref, watch } from "vue";
 
 import type { RuleReturn } from "@/components/input_validator.vue";
 import { useFormRef } from "@/hooks/form_validator";
-
-import { useGrid } from "../../stores";
-import { createCustomToast, ToastType } from "../../utils/custom_toast";
+import { useGrid } from "@/stores";
+import { createCustomToast, ToastType } from "@/utils/custom_toast";
 
 export default {
   name: "AddPublicConfig",
@@ -167,10 +180,6 @@ export default {
       type: Number,
       required: true,
     },
-    modelValue: {
-      type: Object as PropType<PublicConfig>,
-      required: true,
-    },
   },
 
   setup(props, context) {
@@ -180,10 +189,13 @@ export default {
     const showClearDialogue = ref(false);
     const isRemoving = ref(false);
     const isSaving = ref(false);
-    const config = ref<PublicConfig>(publicConfigInitializer());
     const isConfigChanged = ref(false);
     const formRef = useFormRef();
     const grid = useGrid();
+    const runningInDevMode = import.meta.env.DEV;
+
+    const defualtNodeConfig = ref<PublicConfig>(publicConfigInitializer());
+    const config = ref<PublicConfig>(publicConfigInitializer());
 
     function publicConfigInitializer(): PublicConfig {
       return { ipv4: "", ipv6: "", gw4: "", gw6: "", domain: "" };
@@ -196,7 +208,9 @@ export default {
     watch(
       () => ({ ...config.value }),
       (old, newValue) => {
-        isConfigChanged.value = !_.isEqual(old, newValue) && !_.isEqual(props.modelValue, config.value);
+        isConfigChanged.value =
+          !isEqual(defualtNodeConfig.value, config.value) ||
+          (!isEqual(defualtNodeConfig.value, config.value) && !isEqual(old, newValue));
         formRef.value?.validate();
       },
     );
@@ -206,13 +220,14 @@ export default {
         const node = await grid.client.nodes.get({ id: props.nodeId });
 
         if (node.publicConfig) {
-          config.value = {
+          defualtNodeConfig.value = {
             ipv4: node.publicConfig.ip4 ? node.publicConfig.ip4.ip : "",
             gw4: node.publicConfig.ip4 ? node.publicConfig.ip4.gw : "",
             ipv6: node.publicConfig.ip6 ? node.publicConfig.ip6.ip : "",
             gw6: node.publicConfig.ip6 ? node.publicConfig.ip6.gw : "",
             domain: node.publicConfig.domain ? node.publicConfig.domain : "",
           };
+          config.value = { ...defualtNodeConfig.value };
         }
       } catch (error) {
         createCustomToast(`Failed to get node: ${error}.`, ToastType.danger);
@@ -236,6 +251,7 @@ export default {
         });
         createCustomToast("Public config saved successfully.", ToastType.success);
         context.emit("add-config", config.value);
+        getPublicConfig();
         showDialogue.value = false;
       } catch (error) {
         console.log(error);
@@ -245,6 +261,16 @@ export default {
       }
     }
 
+    const fillFakeData = () => {
+      config.value = {
+        ipv4: "123.123.255.52/16",
+        gw4: "123.123.255.55",
+        ipv6: "::52/16",
+        gw6: "::54",
+        domain: "test.com",
+      };
+    };
+
     async function removeConfig() {
       try {
         isRemoving.value = true;
@@ -253,7 +279,7 @@ export default {
           nodeId: props.nodeId,
         });
         createCustomToast("Public config removed successfully.", ToastType.success);
-        config.value = publicConfigInitializer();
+        defualtNodeConfig.value = config.value = publicConfigInitializer();
         context.emit("remove-config", config.value);
         showDialogue.value = false;
       } catch (error) {
@@ -264,6 +290,15 @@ export default {
         showClearDialogue.value = false;
       }
     }
+
+    function isNodeHasConfig() {
+      if (!Object.values(defualtNodeConfig.value).every(value => value == "")) {
+        showClearDialogue.value = true;
+        return;
+      }
+      config.value = defualtNodeConfig.value;
+    }
+
     return {
       showDialogue,
       isAdding,
@@ -274,8 +309,11 @@ export default {
       config,
       isConfigChanged,
       formRef,
+      runningInDevMode,
       AddConfig,
       removeConfig,
+      fillFakeData,
+      isNodeHasConfig,
     };
   },
 };

--- a/packages/playground/src/dashboard/components/user_nodes.vue
+++ b/packages/playground/src/dashboard/components/user_nodes.vue
@@ -104,7 +104,6 @@
           class="me-2"
           :nodeId="item.raw.nodeId"
           :farmId="item.raw.farmId"
-          v-model="item.raw.publicConfig"
           @remove-config="config => toggleConfig(item, config)"
           @add-config="config => toggleConfig(item, config)"
         />


### PR DESCRIPTION
### Description

Refactored and enhanced the AddPublicConfig component to improve readability and maintainability. Extracted configuration fields and used a loop to generate input-validator components for each field. Also, improved variable naming and removed redundant comments.

### Changes

- Created a new variable called `defaultNodeConfig` and copied its values to the config. The form now watches these values instead of `new` and `old` values.
- Extracted configuration fields to improve code readability.
- Improved consistency in variable naming.
- Removed redundant comments and added explanatory comments where needed.
- Created a fake data with `Fill Fake Data` button on development mode.

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1855

### Screenshots/Video

[Screencast from 01-30-2024 05:57:31 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/7750ea8d-6e7b-49c8-be1f-26d1f2e9442d)


### Checklist
- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
