### PR TITLE
include in tooltip there's no activation of ed25519 keys also

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -101,7 +101,8 @@
 
               <v-alert variant="tonal" type="info" class="mb-6" v-if="keypairType === KeypairType.ed25519">
                 <p>
-                  Please note that generation of ed25519 Keys isn't supported, you can only import pre existing ones.
+                  Please note that generation or activation of ed25519 Keys isn't supported, you can only import pre
+                  existing ones.
                 </p>
               </v-alert>
 


### PR DESCRIPTION
### Description

- It wasn't clear that user can't also activate key of type ed25519
### Changes
- Included that node also in the alert.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/bda89290-ccb8-4223-b905-491e197c6a30)


### Related Issues
#2067 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
