### PR TITLE
Update discount msg in dedicated nodes

### DIFF
--- a/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
+++ b/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
@@ -40,7 +40,7 @@
               Discounts: <v-spacer />
               <ul class="pl-2">
                 <li>
-                  You receive 50% discount if you reserve an entire
+                  You'll receive 50% discount if you reserve an entire
                   <a
                     target="_blank"
                     href="https://manual.grid.tf/dashboard/portal/dashboard_portal_dedicated_nodes.html#billing--pricing"

--- a/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
+++ b/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
@@ -40,7 +40,8 @@
               Discounts: <v-spacer />
               <ul class="pl-2">
                 <li>
-                  {{ activeTab == 1 ? "You receive " : "You'll be receiving " }} 50% discount if you reserve an entire
+                  {{ activeTab == 1 ? "You receive " : "You'll receive " }} 50% discount
+                  {{ activeTab == 1 ? " as you reserve the " : " if you reserve an " }} entire
                   <a
                     target="_blank"
                     href="https://manual.grid.tf/dashboard/portal/dashboard_portal_dedicated_nodes.html#billing--pricing"

--- a/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
+++ b/packages/playground/src/dashboard/components/dedicated_nodes_table.vue
@@ -40,7 +40,7 @@
               Discounts: <v-spacer />
               <ul class="pl-2">
                 <li>
-                  You'll receive 50% discount if you reserve an entire
+                  {{ activeTab == 1 ? "You receive " : "You'll be receiving " }} 50% discount if you reserve an entire
                   <a
                     target="_blank"
                     href="https://manual.grid.tf/dashboard/portal/dashboard_portal_dedicated_nodes.html#billing--pricing"
@@ -49,7 +49,8 @@
                   </a>
                 </li>
                 <li>
-                  You're receiving {{ item.raw.discount }}% discount as per the
+                  {{ activeTab == 1 ? "You're receiving " : "You'll be receiving " }} {{ item.raw.discount }}% discount
+                  as per the
                   <a
                     target="_blank"
                     href="https://manual.grid.tf/wiki/cloudunits/pricing/staking_discount_levels.html#staking-discount-levels"


### PR DESCRIPTION
### Description

- In the dedicated node discounts info; there is inconsistency between the two messages.

### Changes

- I user in `mine` tab, messages will stay the same.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/e3094ec4-b52d-4cbe-b249-bd9171668d3a)

- If user in `rentable` tab, 

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/dca053db-2497-4c96-93ff-5b570d111402)



### Related Issues

#2069 
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
