### PR TITLE
fix condition of tooltip to not appear in login card

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -99,7 +99,12 @@
                 </p>
               </v-alert>
 
-              <v-alert variant="tonal" type="info" class="mb-6" v-if="keypairType === KeypairType.ed25519">
+              <v-alert
+                variant="tonal"
+                type="info"
+                class="mb-6"
+                v-if="keypairType === KeypairType.ed25519 && activeTab == 1"
+              >
                 <p>
                   Please note that generation or activation of ed25519 Keys isn't supported, you can only import pre
                   existing ones.


### PR DESCRIPTION
### Description

- The note of `keypair type ed25519` appears in login tab.
### Changes

- added condition to appear only in connect tab.
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2067

[Screencast from 01-31-2024 04:17:58 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/b6bd198b-c8ee-472f-9289-136c6b089a46)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
