### PR TITLE
Wait for the rmb client to finish processing the received envelopes before closing the connection

### DIFF
--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -212,8 +212,8 @@ class GridClient {
   }
 
   async disconnect(): Promise<void> {
-    if (this.tfclient) await this.tfclient.disconnect();
     if (this.rmbClient) await this.rmbClient.disconnect();
+    if (this.tfclient) await this.tfclient.disconnect();
   }
 
   async invoke(message, args) {

--- a/packages/rmb_direct_client/lib/client.ts
+++ b/packages/rmb_direct_client/lib/client.ts
@@ -167,17 +167,21 @@ class Client {
     }
   }
 
-  private async waitForResponses(): Promise<void> {
-    const start = new Date().getTime();
-    while (new Date().getTime() < start + 2 * 60 * 1000) {
-      if (this.responses.size === 0) return;
-      console.debug("Waiting for the rmb responses to be received before closing the connection");
-      for (const id of this.responses.keys()) {
-        const envelope = this.responses.get(id);
-        if (envelope?.request) {
-          console.debug(`- Response for ${envelope?.request.command} from twin ${envelope?.destination}`);
-        }
+  private logPendingResponses() {
+    console.debug("Waiting for the rmb responses to be received before closing the connection");
+    for (const id of this.responses.keys()) {
+      const envelope = this.responses.get(id);
+      if (envelope?.request) {
+        console.debug(`- Response for ${envelope?.request.command} from twin ${envelope?.destination}`);
       }
+    }
+  }
+
+  private async waitForResponses(timeoutInSeconds = 2 * 60): Promise<void> {
+    const start = new Date().getTime();
+    while (new Date().getTime() < start + timeoutInSeconds * 1000) {
+      if (this.responses.size === 0) return;
+      this.logPendingResponses();
       await new Promise(f => setTimeout(f, 1000));
     }
     this.responses.clear();

--- a/packages/rmb_direct_client/lib/client.ts
+++ b/packages/rmb_direct_client/lib/client.ts
@@ -172,6 +172,12 @@ class Client {
     while (new Date().getTime() < start + 2 * 60 * 1000) {
       if (this.responses.size === 0) return;
       console.debug("Waiting for the rmb responses to be received before closing the connection");
+      for (const id of this.responses.keys()) {
+        const envelope = this.responses.get(id);
+        if (envelope?.request) {
+          console.debug(`- Response for ${envelope?.request.command} from twin ${envelope?.destination}`);
+        }
+      }
       await new Promise(f => setTimeout(f, 1000));
     }
     this.responses.clear();

--- a/packages/rmb_direct_client/lib/client.ts
+++ b/packages/rmb_direct_client/lib/client.ts
@@ -167,9 +167,21 @@ class Client {
     }
   }
 
-  disconnect() {
+  private async waitForResponses(): Promise<void> {
+    const start = new Date().getTime();
+    while (new Date().getTime() < start + 2 * 60 * 1000) {
+      if (this.responses.size === 0) return;
+      console.debug("Waiting for the rmb responses to be received before closing the connection");
+      await new Promise(f => setTimeout(f, 1000));
+    }
+    this.responses.clear();
+  }
+
+  async disconnect() {
     if (this.__pingPongTimeout) clearTimeout(this.__pingPongTimeout);
-    this.tfclient.disconnect();
+    this.con.removeAllListeners();
+    await this.waitForResponses();
+    await this.tfclient.disconnect();
     if (this.con?.readyState !== this.con?.CLOSED) this.con.close();
   }
 


### PR DESCRIPTION
### Description

- Wait for the rmb client to finish processing the received envelopes before closing the connection.
- Disconnect rmb client before disconnecting the chain client.

### Changes

this is the best effort to wait before closing the connection of the rmb client for the remaining envelopes. also, it will give a better vision of where this problem is coming from and why these envelopes are delayed that much.

### Related Issues

- #2073

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
