### PR TITLE
handle to show - when field is empty in my nodes

### DIFF
--- a/packages/playground/src/dashboard/components/user_nodes.vue
+++ b/packages/playground/src/dashboard/components/user_nodes.vue
@@ -110,6 +110,14 @@
         />
         <SetExtraFee class="me-2" :nodeId="item.raw.nodeId" />
       </template>
+
+      <template v-slot:[`item.country`]="{ item }">
+        {{ item.raw.country || "-" }}
+      </template>
+
+      <template v-slot:[`item.serialNumber`]="{ item }">
+        {{ item.raw.serialNumber || "-" }}
+      </template>
     </v-data-table-server>
   </div>
 </template>
@@ -255,6 +263,10 @@ export default {
       return (capacity / 1024 / 1024 / 1024).toFixed(2);
     }
 
+    const country = "";
+    const city = "";
+    const serialNumber = "";
+
     function getNodeDetails(item: any): NodeDetailsCard[] {
       return [
         { name: "Node ID", value: item.nodeId },
@@ -263,9 +275,9 @@ export default {
         { name: "Certification", value: item.certificationType },
         { name: "First Boot at", value: moment(item.created * 1000).format("MM-DD-YY, HH:mm A") },
         { name: "Updated at", value: moment(item.updatedAt * 1000).format("MM-DD-YY, HH:mm A") },
-        { name: "Country", value: item.country },
-        { name: "City", value: item.city },
-        { name: "Serial Number", value: item.serialNumber },
+        { name: "Country", value: country || "-" },
+        { name: "City", value: city || "-" },
+        { name: "Serial Number", value: serialNumber || "-" },
         { name: "Pricing Policy", value: item.farmingPolicyId },
         { name: "Uptime", value: item.uptime + "%" },
       ];

--- a/packages/playground/src/dashboard/components/user_nodes.vue
+++ b/packages/playground/src/dashboard/components/user_nodes.vue
@@ -263,10 +263,6 @@ export default {
       return (capacity / 1024 / 1024 / 1024).toFixed(2);
     }
 
-    const country = "";
-    const city = "";
-    const serialNumber = "";
-
     function getNodeDetails(item: any): NodeDetailsCard[] {
       return [
         { name: "Node ID", value: item.nodeId },
@@ -275,9 +271,9 @@ export default {
         { name: "Certification", value: item.certificationType },
         { name: "First Boot at", value: moment(item.created * 1000).format("MM-DD-YY, HH:mm A") },
         { name: "Updated at", value: moment(item.updatedAt * 1000).format("MM-DD-YY, HH:mm A") },
-        { name: "Country", value: country || "-" },
-        { name: "City", value: city || "-" },
-        { name: "Serial Number", value: serialNumber || "-" },
+        { name: "Country", value: item.country || "-" },
+        { name: "City", value: item.city || "-" },
+        { name: "Serial Number", value: item.serialNumber || "-" },
         { name: "Pricing Policy", value: item.farmingPolicyId },
         { name: "Uptime", value: item.uptime + "%" },
       ];


### PR DESCRIPTION
### Description

- Add a dash or some default label for the non-existing value instead of the empty label in your nodes table in farms page.

### Changes

- dash added when any field in empty
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2083

![Screenshot from 2024-02-04 11-20-46](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/ed0b1c71-8476-44a6-a296-c5e161137b77)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
