### PR TITLE
Adding margin to card details items

### DIFF
--- a/packages/playground/src/components/node_details_cards/card_details.vue
+++ b/packages/playground/src/components/node_details_cards/card_details.vue
@@ -14,7 +14,7 @@
       <div :class="`items`" v-else>
         <slot name="gpu-hint-message" />
 
-        <v-row class="bb-gray mt-2" v-for="item in items" :key="item.name">
+        <v-row class="bb-gray" v-for="item in items" :key="item.name">
           <v-col class="d-flex justify-start align-center ml-3">
             <p class="font-14">{{ item.name }}</p>
             <v-chip class="ml-4" v-if="item.nameHint" :color="item.nameHintColor">{{ item.nameHint }}</v-chip>

--- a/packages/playground/src/components/node_details_cards/card_details.vue
+++ b/packages/playground/src/components/node_details_cards/card_details.vue
@@ -14,7 +14,7 @@
       <div :class="`items`" v-else>
         <slot name="gpu-hint-message" />
 
-        <v-row class="bb-gray" v-for="item in items" :key="item.name">
+        <v-row class="bb-gray mt-2" v-for="item in items" :key="item.name">
           <v-col class="d-flex justify-start align-center ml-3">
             <p class="font-14">{{ item.name }}</p>
             <v-chip class="ml-4" v-if="item.nameHint" :color="item.nameHintColor">{{ item.nameHint }}</v-chip>

--- a/packages/playground/src/components/node_details_cards/gpu_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/gpu_details_card.vue
@@ -7,7 +7,7 @@
     icon="mdi-credit-card-settings-outline"
   >
     <template #gpu-hint-message>
-      <div v-if="node.cards?.length">
+      <div v-if="node.cards?.length" class="mb-3">
         <v-chip class="d-flex justify-center ma-4 mt-1" color="info">
           Select a GPU card ID from the below selection to load its data.
         </v-chip>
@@ -19,7 +19,15 @@
             </v-chip>
           </v-col>
           <v-col class="mr-3 d-flex justify-end align-center">
-            <v-select chips clearable hide-details="auto" v-model="cardId" :items="cardsIds" variant="outlined" />
+            <v-select
+              chips
+              density="compact"
+              clearable
+              hide-details="auto"
+              v-model="cardId"
+              :items="cardsIds"
+              variant="outlined"
+            />
             <v-icon class="ml-1" :icon="'mdi-content-copy'" @click="copy(cardId)" />
           </v-col>
         </v-row>


### PR DESCRIPTION
### Description
Adding margins to the cars details items

![Screenshot from 2024-02-04 13-43-44](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/0de8ac7d-e5c9-4ad1-8312-2a1555d97205)

### Changes

List of changes this PR includes

### Related Issues

#2078
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
