### PR TITLE
add stats summary endpoint

### DIFF
--- a/packages/new_stats/Dockerfile
+++ b/packages/new_stats/Dockerfile
@@ -11,4 +11,3 @@ RUN yarn lerna run build --no-private && yarn workspace @threefold/newstats buil
 FROM nginx:alpine
 COPY --from=build /app/packages/new_stats/dist /usr/share/nginx/html
 COPY --from=build /app/packages/new_stats/nginx /etc/nginx
-COPY --from=build /app/packages/new_stats/tmp /tmp

--- a/packages/new_stats/Dockerfile
+++ b/packages/new_stats/Dockerfile
@@ -11,3 +11,4 @@ RUN yarn lerna run build --no-private && yarn workspace @threefold/newstats buil
 FROM nginx:alpine
 COPY --from=build /app/packages/new_stats/dist /usr/share/nginx/html
 COPY --from=build /app/packages/new_stats/nginx /etc/nginx
+COPY --from=build /app/packages/new_stats/tmp /tmp

--- a/packages/new_stats/Dockerfile
+++ b/packages/new_stats/Dockerfile
@@ -8,6 +8,6 @@ COPY . /app/
 RUN yarn install
 RUN yarn lerna run build --no-private && yarn workspace @threefold/newstats build
 
-FROM nginx:alpine
+FROM nginx:1.25.3-alpine
 COPY --from=build /app/packages/new_stats/dist /usr/share/nginx/html
 COPY --from=build /app/packages/new_stats/nginx /etc/nginx

--- a/packages/new_stats/Dockerfile
+++ b/packages/new_stats/Dockerfile
@@ -8,5 +8,6 @@ COPY . /app/
 RUN yarn install
 RUN yarn lerna run build --no-private && yarn workspace @threefold/newstats build
 
-FROM nginx:1.16.0-alpine
+FROM nginx:alpine
 COPY --from=build /app/packages/new_stats/dist /usr/share/nginx/html
+COPY --from=build /app/nginx /etc/nginx

--- a/packages/new_stats/Dockerfile
+++ b/packages/new_stats/Dockerfile
@@ -10,4 +10,4 @@ RUN yarn lerna run build --no-private && yarn workspace @threefold/newstats buil
 
 FROM nginx:alpine
 COPY --from=build /app/packages/new_stats/dist /usr/share/nginx/html
-COPY --from=build /app/nginx /etc/nginx
+COPY --from=build /app/packages/new_stats/nginx /etc/nginx

--- a/packages/new_stats/nginx/conf.d/default.conf
+++ b/packages/new_stats/nginx/conf.d/default.conf
@@ -9,8 +9,8 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
     }
-    location /api/stats-summary{
-        default_type application/json
+    location /api/stats-summary {
+        default_type application/json;
         js_content main.getStats;
     }
     #error_page  404              /404.html;

--- a/packages/new_stats/nginx/conf.d/default.conf
+++ b/packages/new_stats/nginx/conf.d/default.conf
@@ -9,7 +9,7 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
     }
-    location /summary{
+    location /api/stats-summary{
         default_type application/json
         js_content main.getStats;
     }

--- a/packages/new_stats/nginx/conf.d/default.conf
+++ b/packages/new_stats/nginx/conf.d/default.conf
@@ -10,6 +10,7 @@ server {
         index  index.html index.htm;
     }
     location /summary{
+        default_type application/json
         js_content main.getStats;
     }
     #error_page  404              /404.html;

--- a/packages/new_stats/nginx/conf.d/default.conf
+++ b/packages/new_stats/nginx/conf.d/default.conf
@@ -1,0 +1,46 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+    location /summary{
+        js_content main.getStats;
+    }
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/packages/new_stats/nginx/nginx.conf
+++ b/packages/new_stats/nginx/nginx.conf
@@ -1,0 +1,37 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+load_module modules/ngx_http_js_module.so;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    js_path "/etc/nginx/njs/";
+
+    resolver 8.8.8.8;
+    js_import main from stats.js;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/packages/new_stats/nginx/njs/cache.js
+++ b/packages/new_stats/nginx/njs/cache.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+function updateCache(summary, path) {
+  const data = {
+    summary,
+    updatedAt: Date.now(),
+  };
+  fs.writeFileSync(path, JSON.stringify(data));
+}
+
+function isLessThan24Hours(timestamp) {
+  const now = Date.now();
+  const difference = now - timestamp;
+  const hours = 24;
+  return difference < hours * 60 * 60 * 1000;
+}
+
+async function readCache(path) {
+  const cache = JSON.parse(fs.readFileSync(path));
+  if (cache.summary) {
+    const validCache = isLessThan24Hours(cache.timestamp || undefined);
+    return {
+      cache,
+      validCache,
+    };
+  }
+}
+
+export default {
+  updateCache,
+  readCache,
+};

--- a/packages/new_stats/nginx/njs/cache.js
+++ b/packages/new_stats/nginx/njs/cache.js
@@ -24,7 +24,7 @@ function readCache(path) {
   try {
     const cache = JSON.parse(fs.readFileSync(path));
     if (cache.summary) {
-      const validCache = isLessThan24Hours(cache.timestamp || undefined);
+      const validCache = isLessThan24Hours(cache.updatedAt);
       return {
         summary: cache.summary,
         valid: validCache,

--- a/packages/new_stats/nginx/njs/cache.js
+++ b/packages/new_stats/nginx/njs/cache.js
@@ -14,13 +14,27 @@ function isLessThan24Hours(timestamp) {
   return difference < hours * 60 * 60 * 1000;
 }
 
-async function readCache(path) {
-  const cache = JSON.parse(fs.readFileSync(path));
-  if (cache.summary) {
-    const validCache = isLessThan24Hours(cache.timestamp || undefined);
+const DUMMY_DATA = {
+  capacity: "32.74 PB",
+  nodes: 2569,
+  countries: 61,
+  cores: 63968,
+};
+function readCache(path) {
+  try {
+    const cache = JSON.parse(fs.readFileSync(path));
+    if (cache.summary) {
+      const validCache = isLessThan24Hours(cache.timestamp || undefined);
+      return {
+        summary: cache.summary,
+        valid: validCache,
+      };
+    } else throw "Invalid cache";
+  } catch (error) {
     return {
-      cache,
-      validCache,
+      summary: DUMMY_DATA,
+      valid: false,
+      error,
     };
   }
 }

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -57,7 +57,7 @@ async function fetchStats(r) {
     if (URLS.length !== 0) retries++;
   }
   let result;
-  if (retries >= 3 || URLS.length > 0) throw `Failed to get response form ${URLS} after ${retries} ret`;
+  if (retries >= 3 || URLS.length > 0) throw `Failed to get response form ${URLS} after ${retries} retries`;
   else result = mergeStatsData(stats);
   try {
     cache.updateCache(result, cache_path);

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -57,7 +57,7 @@ async function fetchStats(r) {
     if (URLS.length !== 0) retries++;
   }
   let result;
-  if (retries >= 3 || URLS.length > 0) throw `Failed to get response form ${URLS} after ${retries} retries`;
+  if (retries >= 3 && URLS.length > 0) throw `Failed to get response form ${URLS} after ${retries} retries`;
   else result = mergeStatsData(stats);
   try {
     cache.updateCache(result, cache_path);

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -9,7 +9,7 @@ const urls = [
 
 async function getStats(r) {
   //   eslint-disable-next-line no-undef
-  const fetchPromises = urls.map(url => ngx.fetch(url, { verify: false }));
+  const fetchPromises = urls.map(url => ngx.fetch(url, { verify: r.headersIn["Host"] !== "localhost" })); // disable ssl on localhost
 
   try {
     const responses = await Promise.all(fetchPromises);

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -1,0 +1,110 @@
+const urls = [
+  "https://gridproxy.grid.tf/stats?status=up",
+  "https://gridproxy.grid.tf/stats?status=standby",
+  "https://gridproxy.test.grid.tf/stats?status=up",
+  "https://gridproxy.test.grid.tf/stats?status=standby",
+  "https://gridproxy.dev.grid.tf/stats?status=up",
+  "https://gridproxy.dev.grid.tf/stats?status=standby",
+];
+
+async function getStats(r) {
+  const fetchPromises = [];
+
+  for (let i = 0; i < urls.length; i++) {
+    // eslint-disable-next-line no-undef
+    fetchPromises.push(ngx.fetch(urls[i], { method: "GET", verify: false }));
+  }
+
+  try {
+    const responses = await Promise.all(fetchPromises);
+
+    const stats = await Promise.all(
+      responses.map(async res => {
+        if (res.status === 200) {
+          const js = await res.json();
+          return js;
+        }
+        return null;
+      }),
+    );
+
+    r.headersOut["Content-Type"] = "application/json";
+    r.headersOut["Content-Disposition"] = "inline";
+    r.return(200, JSON.stringify(mergeStatsData(stats)), "application/json");
+  } catch (error) {
+    r.error(error);
+    r.return(500);
+  }
+}
+
+function mergeStatsData(stats) {
+  const res = Object.assign({}, stats[0]);
+
+  for (let i = 1; i < stats.length; i++) {
+    if (stats[i]) {
+      res.nodes += stats[i].nodes;
+      res.totalCru += stats[i].totalCru;
+      res.totalHru += stats[i].totalHru;
+      res.totalSru += stats[i].totalSru;
+      res.nodesDistribution = mergeNodeDistribution([res.nodesDistribution, stats[i].nodesDistribution]);
+      res.countries = Object.keys(res.nodesDistribution).length;
+    }
+  }
+
+  const result = {};
+  result.capacity = toTeraOrGiga(res.totalHru + res.totalSru);
+  result.nodes = res.nodes;
+  result.countries = res.countries;
+  result.cores = res.totalCru;
+
+  return result;
+}
+
+function mergeNodeDistribution(stats) {
+  const keys = [];
+  for (let i = 0; i < stats.length; i++) {
+    const obj = stats[i];
+    if (obj) {
+      const objKeys = Object.keys(obj);
+      for (let j = 0; j < objKeys.length; j++) {
+        if (!keys.includes(objKeys[j])) keys.push(objKeys[j]);
+      }
+    }
+  }
+
+  const result = {};
+  keys.forEach(function (key) {
+    result[key] = 0;
+    for (let i = 0; i < stats.length; i++) {
+      const country = stats[i];
+      result[key] += country ? country[key] || 0 : 0;
+    }
+  });
+
+  return result;
+}
+
+function toTeraOrGiga(value) {
+  const giga = 1024 ** 3;
+
+  if (!value) return "0";
+
+  const val = +value;
+  if (val === 0 || isNaN(val)) return "0";
+
+  if (val < giga) return val.toString();
+
+  let gb = val / giga;
+
+  if (gb < 1024) return gb.toFixed(2) + " GB";
+
+  gb = gb / 1024;
+
+  if (gb < 1024) return gb.toFixed(2) + " TB";
+
+  gb = gb / 1024;
+  return gb.toFixed(2) + " PB";
+}
+
+// Exporting the main function for Nginx
+export default { getStats };

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -8,12 +8,8 @@ const urls = [
 ];
 
 async function getStats(r) {
-  const fetchPromises = [];
-
-  for (let i = 0; i < urls.length; i++) {
-    // eslint-disable-next-line no-undef
-    fetchPromises.push(ngx.fetch(urls[i], { method: "GET", verify: false }));
-  }
+  //   eslint-disable-next-line no-undef
+  const fetchPromises = urls.map(url => ngx.fetch(url, { verify: false }));
 
   try {
     const responses = await Promise.all(fetchPromises);
@@ -30,10 +26,19 @@ async function getStats(r) {
 
     r.headersOut["Content-Type"] = "application/json";
     r.headersOut["Content-Disposition"] = "inline";
-    r.return(200, JSON.stringify(mergeStatsData(stats)), "application/json");
+    r.return(200, JSON.stringify(mergeStatsData(stats)));
   } catch (error) {
     r.error(error);
-    r.return(500);
+    const DUMMY_DATA = {
+      capacity: "32.74 PB",
+      nodes: 2569,
+      countries: 61,
+      cores: 63968,
+      notUpdated: true,
+    };
+    r.headersOut["Content-Type"] = "application/json";
+    r.headersOut["Content-Disposition"] = "inline";
+    r.return(200, JSON.stringify(DUMMY_DATA));
   }
 }
 

--- a/packages/new_stats/tmp/statsSummary.json
+++ b/packages/new_stats/tmp/statsSummary.json
@@ -1,0 +1,1 @@
+{"summary":{"capacity":"32.82 PB","nodes":2577,"countries":62,"cores":64109},"updatedAt":1707297824596}

--- a/packages/new_stats/tmp/statsSummary.json
+++ b/packages/new_stats/tmp/statsSummary.json
@@ -1,1 +1,0 @@
-{"summary":{"capacity":"32.82 PB","nodes":2577,"countries":62,"cores":64109},"updatedAt":1707297824596}


### PR DESCRIPTION
### Description

Using nginx javascript we can run a script whenever the user hit the target endpoint, the mentioned endpoint is `/api/stats-summary`, this will reduce code replication and make data consistent over different websites; threefold.io, dashboard 
also we are caching the data for one day, if any errors happen while updating it, we are returning the outdated data with flag `outdated` if there is no cached data too or if any error happen while reading it, we return a dummy data,
### Changes

- DockerFile: 
   - update the nginx version: njs require the latest nginx image
   - copy nginx files to the image
- Nginx : 
   - in nginx.conf I just loaded the needed js module and  set the resolver:
     the actual changes on the default nginx.conf is :
      ```
     load_module modules/ngx_http_js_module.so;
      js_path "/etc/nginx/njs/";
  
      resolver 8.8.8.8;
      js_import main from stats.js;
     ```
   - add `/summary` endpoint to server in `default.conf
   - add njs script

### Related Issues

 - #1981 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
