### PR TITLE
add disk name for disks without mount point

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -259,7 +259,7 @@ function getType(key: string): string {
 
 function getDiskLabel(contract: any, disk: Disk) {
   if (contract.metadata.includes("fullvm") && contract.mounts.indexOf(disk) > 0) {
-    return "Disk(" + disk.name + ") GB";
+    return "Disk( " + disk.name + " ) GB";
   }
   return "Disk( " + disk.mountPoint + " ) GB";
 }

--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -259,7 +259,7 @@ function getType(key: string): string {
 
 function getDiskLabel(contract: any, disk: Disk) {
   if (contract.metadata.includes("fullvm") && contract.mounts.indexOf(disk) > 0) {
-    return "Disk";
+    return "Disk(" + disk.name + ") GB";
   }
   return "Disk( " + disk.mountPoint + " ) GB";
 }


### PR DESCRIPTION
### Description

add disk name for disks without mount point

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/1591badd-76d9-44c3-a3d6-23235193b816)

### Changes

- Added disk name for disks without mount point like the disks that are added for fullvm.
- Added disk capacity unit next to the disk name.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1835

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
