### PR TITLE
add created at column for deployments

### DIFF
--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -68,7 +68,7 @@
         { title: 'Planetary Network IP', key: 'planetary', sortable: false },
         { title: 'Workers', key: 'workersLength' },
         { title: 'Billing Rate', key: 'billing' },
-        { title: 'Created At', key: 'createdAt' },
+        { title: 'Created At', key: 'created' },
         { title: 'Health', key: 'status', sortable: false },
         { title: 'Actions', key: 'actions', sortable: false },
       ]"
@@ -80,7 +80,7 @@
       @click:row="$attrs['onClick:row']"
       :sort-by="sortBy"
     >
-      <template #[`item.createdAt`]="{ item }">
+      <template #[`item.created`]="{ item }">
         {{ toHumanDate(item.value.masters[0].created) }}
       </template>
       <template #[`item.status`]="{ item }">
@@ -170,7 +170,7 @@ async function loadDeployments() {
     item.planetary = item.masters[0].planetary || "None";
     item.workersLength = item.workers.length;
     item.billing = item.masters[0].billing;
-    item.createdAt = item.masters[0].created;
+    item.created = item.masters[0].created;
     return item;
   });
   loading.value = false;
@@ -197,7 +197,7 @@ export default {
         { key: "name", order: "asc" },
         { key: "workersLength", order: "asc" },
         { key: "billing", order: "asc" },
-        { key: "createdAt", order: "asc" },
+        { key: "created", order: "asc" },
       ],
     };
   },

--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -68,6 +68,7 @@
         { title: 'Planetary Network IP', key: 'planetary', sortable: false },
         { title: 'Workers', key: 'workersLength' },
         { title: 'Billing Rate', key: 'billing' },
+        { title: 'Created At', key: 'createdAt' },
         { title: 'Health', key: 'status', sortable: false },
         { title: 'Actions', key: 'actions', sortable: false },
       ]"
@@ -79,6 +80,9 @@
       @click:row="$attrs['onClick:row']"
       :sort-by="sortBy"
     >
+      <template #[`item.createdAt`]="{ item }">
+        {{ toHumanDate(item.value.masters[0].created) }}
+      </template>
       <template #[`item.status`]="{ item }">
         <v-chip :color="getNodeHealthColor(item.value.masters[0].status as string).color">
           <v-tooltip v-if="item.value.masters[0].status == NodeHealth.Error" activator="parent" location="top">{{
@@ -175,6 +179,8 @@ defineExpose({ loadDeployments });
 </script>
 
 <script lang="ts">
+import toHumanDate from "@/utils/date";
+
 import AccessDeploymentAlert from "./AccessDeploymentAlert.vue";
 import ListTable from "./list_table.vue";
 
@@ -190,6 +196,7 @@ export default {
         { key: "name", order: "asc" },
         { key: "workersLength", order: "asc" },
         { key: "billing", order: "asc" },
+        { key: "createdAt", order: "asc" },
       ],
     };
   },

--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -170,6 +170,7 @@ async function loadDeployments() {
     item.planetary = item.masters[0].planetary || "None";
     item.workersLength = item.workers.length;
     item.billing = item.masters[0].billing;
+    item.createdAt = item.masters[0].created;
     return item;
   });
   loading.value = false;

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -91,6 +91,10 @@
       <template #[`item.billing`]="{ item }">
         {{ item.value.billing }}
       </template>
+      <template #[`item.createdAt`]="{ item }">
+        {{ toHumanDate(item.value.created) }}
+        {{ console.log(item.value) }}
+      </template>
       <template #[`item.actions`]="{ item }">
         <v-chip color="error" variant="tonal" v-if="deleting && ($props.modelValue || []).includes(item.value)">
           Deleting...
@@ -219,6 +223,7 @@ const filteredHeaders = computed(() => {
     { title: "WireGuard", key: "wireguard", sortable: false },
     { title: "Flist", key: "flist" },
     { title: "Cost", key: "billing" },
+    { title: "Created At", key: "createdAt" },
     { title: "Health", key: "status", sortable: false },
     { title: "Actions", key: "actions", sortable: false },
   ];
@@ -295,6 +300,8 @@ defineExpose({ loadDeployments });
 </script>
 
 <script lang="ts">
+import toHumanDate from "@/utils/date";
+
 import { ProjectName } from "../types";
 import { migrateModule } from "../utils/migration";
 import AccessDeploymentAlert from "./AccessDeploymentAlert.vue";
@@ -312,6 +319,7 @@ export default {
         { key: "name", order: "asc" },
         { key: "flist", order: "asc" },
         { key: "billing", order: "asc" },
+        { key: "createdAt", order: "asc" },
       ],
     };
   },

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -91,7 +91,7 @@
       <template #[`item.billing`]="{ item }">
         {{ item.value.billing }}
       </template>
-      <template #[`item.createdAt`]="{ item }">
+      <template #[`item.created`]="{ item }">
         {{ toHumanDate(item.value.created) }}
       </template>
       <template #[`item.actions`]="{ item }">
@@ -222,7 +222,7 @@ const filteredHeaders = computed(() => {
     { title: "WireGuard", key: "wireguard", sortable: false },
     { title: "Flist", key: "flist" },
     { title: "Cost", key: "billing" },
-    { title: "Created At", key: "createdAt" },
+    { title: "Created At", key: "created" },
     { title: "Health", key: "status", sortable: false },
     { title: "Actions", key: "actions", sortable: false },
   ];
@@ -318,7 +318,7 @@ export default {
         { key: "name", order: "asc" },
         { key: "flist", order: "asc" },
         { key: "billing", order: "asc" },
-        { key: "createdAt", order: "asc" },
+        { key: "created", order: "asc" },
       ],
     };
   },

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -93,7 +93,6 @@
       </template>
       <template #[`item.createdAt`]="{ item }">
         {{ toHumanDate(item.value.created) }}
-        {{ console.log(item.value) }}
       </template>
       <template #[`item.actions`]="{ item }">
         <v-chip color="error" variant="tonal" v-if="deleting && ($props.modelValue || []).includes(item.value)">


### PR DESCRIPTION
### Description

add created at column for deployments

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/d8f9ea4a-2929-499a-b2e1-46d4fd9faa89)

### Changes

- Added a Created At column that displays the date and time for each deployment.
- Added the column for both the vm and k8s deployment tables.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1838

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
