### PR TITLE
increase wireguard range

### DIFF
--- a/packages/grid_client/src/primitives/network.ts
+++ b/packages/grid_client/src/primitives/network.ts
@@ -217,7 +217,9 @@ class Network {
 
     await this.tfClient.connect();
     for (const node of network["nodes"]) {
-      const contract = await this.tfClient.contracts.get({ id: node.contract_id });
+      const contract = await this.tfClient.contracts.get({
+        id: node.contract_id,
+      });
       if (contract === null) continue;
       const node_twin_id = await this.capacity.getNodeTwinId(node.node_id);
       const payload = JSON.stringify({ contract_id: node.contract_id });
@@ -484,7 +486,7 @@ class Network {
 
     let port = 0;
     while (!port || result.includes(port)) {
-      port = getRandomNumber(2000, 8000);
+      port = getRandomNumber(1024, 32767);
     }
     return port;
   }


### PR DESCRIPTION
### Description

Increase wireguard port

### Changes

The range of wireguard ports is increased and becomes a random number from 1024 to 32767

### Related Issues

- [#2090](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2090)

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
