### PR TITLE
remove the leading pipe character from the contracts list

### DIFF
--- a/packages/playground/src/components/list_table.vue
+++ b/packages/playground/src/components/list_table.vue
@@ -16,7 +16,6 @@
       <div class="d-flex align-center justify-space-between">
         <span>#</span>
         <div class="d-flex">
-          <v-divider vertical class="ml-3 mr-1" />
           <v-checkbox-btn
             :model-value="selectedItems.length > 0 && selectedItems.length === items.length"
             :indeterminate="selectedItems.length > 0 && items.length !== selectedItems.length"
@@ -31,7 +30,6 @@
       <div class="d-flex align-center justify-space-between">
         <span>{{ index + 1 }}</span>
         <div class="d-flex" @click.stop>
-          <v-divider vertical class="ml-3 mr-1" />
           <v-progress-circular
             v-if="deleting && selectedItems.includes(item?.value)"
             class="ml-3"


### PR DESCRIPTION
### Description

remove the leading pipe character from the contracts list.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/101194226/697771ce-2533-4328-a5f5-112b20a8a38d)

### Changes

- Removed the `v-divider` element from the list table.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1495

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
