### PR TITLE
Enhance error in playgrounds 

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -15,6 +15,7 @@
     "@threefold/graphql_client": "^2.3.0-alpha9",
     "@threefold/grid_client": "^2.3.0-alpha9",
     "@threefold/gridproxy_client": "^2.3.0-alpha9",
+    "@threefold/types": "^2.3.0-alpha9",
     "bip39": "^3.1.0",
     "chart.js": "^4.4.0",
     "cryptr": "^6.2.0",

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -1,5 +1,6 @@
 import type { FarmFilterOptions, FarmInfo, FilterOptions, NodeInfo } from "@threefold/grid_client";
 import type { NodeStatus } from "@threefold/gridproxy_client";
+import { GridClientErrors } from "@threefold/types";
 import type { DeepPartial } from "utility-types";
 import { z } from "zod";
 
@@ -343,7 +344,7 @@ export async function checkNodeCapacityPool(
       "Something went wrong while checking status of the node. Please check your connection and try again.",
     );
 
-    if (err.toLowerCase().includes("cannot fit the required ssd disk with size")) {
+    if (error instanceof GridClientErrors.Nodes.DiskAllocationError) {
       throw (
         "Although node " +
         node.nodeId +

--- a/packages/types/src/errors/base_error.ts
+++ b/packages/types/src/errors/base_error.ts
@@ -13,62 +13,61 @@ export enum Generic {
   InsufficientBalanceError,
   DeploymentKeyDeletionError,
 }
-export class BaseError extends Error {
-  constructor(public code: number, message: string, public module: ErrorModules) {
-    super(message);
-    this.name = this.constructor.name;
+export abstract class BaseError extends Error {
+  constructor(name: string, public code: number, message: string, public module: ErrorModules) {
+    super(`${name}: ${message}`);
   }
 }
 
 export class ValidationError extends BaseError {
   constructor(message: string) {
-    super(Generic.ValidationError, message, ErrorModules.Generic);
+    super("ValidationError", Generic.ValidationError, message, ErrorModules.Generic);
   }
 }
 export class TimeoutError extends BaseError {
   constructor(message: string) {
-    super(Generic.TimeoutError, message, ErrorModules.Generic);
+    super("TimeoutError", Generic.TimeoutError, message, ErrorModules.Generic);
   }
 }
 
 export class ConnectionError extends BaseError {
   constructor(message: string) {
-    super(Generic.ConnectionError, message, ErrorModules.Generic);
+    super("ConnectionError", Generic.ConnectionError, message, ErrorModules.Generic);
   }
 }
 
 export class RMBError extends BaseError {
   constructor(message: string) {
-    super(Generic.RMBError, message, ErrorModules.Generic);
+    super("RMBError", Generic.RMBError, message, ErrorModules.Generic);
   }
 }
 
 export class InvalidResponse extends BaseError {
   constructor(message: string) {
-    super(Generic.InvalidResponse, message, ErrorModules.Generic);
+    super("InvalidResponse", Generic.InvalidResponse, message, ErrorModules.Generic);
   }
 }
 
 export class RequestError extends BaseError {
   constructor(message: string, public statusCode = -1) {
-    super(Generic.RequestError, message, ErrorModules.Generic);
+    super("RequestError", Generic.RequestError, message, ErrorModules.Generic);
   }
 }
 
 export class TwinNotExistError extends BaseError {
   constructor(message: string) {
-    super(Generic.TwinNotExistError, message, ErrorModules.Generic);
+    super("TwinNotExistError", Generic.TwinNotExistError, message, ErrorModules.Generic);
   }
 }
 
 export class InsufficientBalanceError extends BaseError {
   constructor(message: string) {
-    super(Generic.InsufficientBalanceError, message, ErrorModules.Generic);
+    super("InsufficientBalanceError", Generic.InsufficientBalanceError, message, ErrorModules.Generic);
   }
 }
 
 export class DeploymentKeyDeletionError extends BaseError {
   constructor(message: string) {
-    super(Generic.DeploymentKeyDeletionError, message, ErrorModules.Generic);
+    super("DeploymentKeyDeletionError", Generic.DeploymentKeyDeletionError, message, ErrorModules.Generic);
   }
 }

--- a/packages/types/src/errors/grid_client/farms.ts
+++ b/packages/types/src/errors/grid_client/farms.ts
@@ -7,25 +7,25 @@ export enum Errors {
   NodeSelectionError,
 }
 class TFGridFarmsError extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.Farm);
+  constructor(name = "TFGridFarmsError", code: number, message: string) {
+    super(name, code, message, ErrorModules.Farm);
   }
 }
 
 export class InvalidResourcesError extends TFGridFarmsError {
   constructor(message: string) {
-    super(Errors.InvalidResourcesError, message);
+    super("InvalidResourcesError", Errors.InvalidResourcesError, message);
   }
 }
 
 export class FarmerBotError extends TFGridFarmsError {
   constructor(message: string) {
-    super(Errors.FarmerBotError, message);
+    super("FarmerBotError", Errors.FarmerBotError, message);
   }
 }
 
 export class NodeSelectionError extends TFGridFarmsError {
   constructor(message: string) {
-    super(Errors.NodeSelectionError, message);
+    super("NodeSelectionError", Errors.NodeSelectionError, message);
   }
 }

--- a/packages/types/src/errors/grid_client/grid_client_error.ts
+++ b/packages/types/src/errors/grid_client/grid_client_error.ts
@@ -3,6 +3,6 @@ import { ErrorModules } from "../modules";
 
 export class GridClientError extends BaseError {
   constructor(message: string) {
-    super(Generic.GridClientError, message, ErrorModules.Generic);
+    super("GridClientError", Generic.GridClientError, message, ErrorModules.Generic);
   }
 }

--- a/packages/types/src/errors/grid_client/nodes.ts
+++ b/packages/types/src/errors/grid_client/nodes.ts
@@ -10,43 +10,43 @@ export enum Errors {
   GPULockedError,
 }
 class TFGridNodesError extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.Node);
+  constructor(name = "TFGridNodesError", code: number, message: string) {
+    super(name, code, message, ErrorModules.Node);
   }
 }
 
 export class InvalidResourcesError extends TFGridNodesError {
   constructor(message: string) {
-    super(Errors.InvalidResourcesError, message);
+    super("InvalidResourcesError", Errors.InvalidResourcesError, message);
   }
 }
 
 export class DiskAllocationError extends TFGridNodesError {
   constructor(message: string) {
-    super(Errors.DiskAllocationError, message);
+    super("DiskAllocationError", Errors.DiskAllocationError, message);
   }
 }
 
 export class AccessNodeError extends TFGridNodesError {
   constructor(message: string) {
-    super(Errors.AccessNodeError, message);
+    super("AccessNodeError", Errors.AccessNodeError, message);
   }
 }
 
 export class UnavailableNodeError extends TFGridNodesError {
   constructor(message: string) {
-    super(Errors.UnavailableNodeError, message);
+    super("UnavailableNodeError", Errors.UnavailableNodeError, message);
   }
 }
 
 export class GPUNotFoundError extends TFGridNodesError {
   constructor(message: string) {
-    super(Errors.GPUNotFoundError, message);
+    super("GPUNotFoundError", Errors.GPUNotFoundError, message);
   }
 }
 
 export class GPULockedError extends TFGridNodesError {
   constructor(message: string) {
-    super(Errors.GPULockedError, message);
+    super("GPULockedError", Errors.GPULockedError, message);
   }
 }

--- a/packages/types/src/errors/grid_client/workloads.ts
+++ b/packages/types/src/errors/grid_client/workloads.ts
@@ -8,31 +8,31 @@ export enum Errors {
   WorkloadCreateError,
 }
 class TFGridWorkloadError extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.Workloads);
+  constructor(name = "TFGridWorkloadError", code: number, message: string) {
+    super(name, code, message, ErrorModules.Workloads);
   }
 }
 
 export class WorkloadDeleteError extends TFGridWorkloadError {
   constructor(message: string) {
-    super(Errors.WorkloadDeleteError, message);
+    super("WorkloadDeleteError", Errors.WorkloadDeleteError, message);
   }
 }
 
 export class WorkloadDeployError extends TFGridWorkloadError {
   constructor(message: string) {
-    super(Errors.WorkloadDeployError, message);
+    super("WorkloadDeployError", Errors.WorkloadDeployError, message);
   }
 }
 
 export class WorkloadUpdateError extends TFGridWorkloadError {
   constructor(message: string) {
-    super(Errors.WorkloadUpdateError, message);
+    super("WorkloadUpdateError", Errors.WorkloadUpdateError, message);
   }
 }
 
 export class WorkloadCreateError extends TFGridWorkloadError {
   constructor(message: string) {
-    super(Errors.WorkloadCreateError, message);
+    super("WorkloadCreateError", Errors.WorkloadCreateError, message);
   }
 }

--- a/packages/types/src/errors/tfchain/dao.ts
+++ b/packages/types/src/errors/tfchain/dao.ts
@@ -22,108 +22,108 @@ export enum Errors {
 }
 
 class DaoError extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.Dao);
+  constructor(name: string, code: number, message: string) {
+    super(name, code, message, ErrorModules.Dao);
   }
 }
 export class NoneValue extends DaoError {
   constructor(message: string) {
-    super(Errors.NoneValue, message);
+    super("NoneValue", Errors.NoneValue, message);
   }
 }
 
 export class StorageOverflow extends DaoError {
   constructor(message: string) {
-    super(Errors.StorageOverflow, message);
+    super("StorageOverflow", Errors.StorageOverflow, message);
   }
 }
 
 export class FarmNotExists extends DaoError {
   constructor(message: string) {
-    super(Errors.FarmNotExists, message);
+    super("FarmNotExists", Errors.FarmNotExists, message);
   }
 }
 
 export class NotCouncilMember extends DaoError {
   constructor(message: string) {
-    super(Errors.NotCouncilMember, message);
+    super("NotCouncilMember", Errors.NotCouncilMember, message);
   }
 }
 
 export class WrongProposalLength extends DaoError {
   constructor(message: string) {
-    super(Errors.WrongProposalLength, message);
+    super("WrongProposalLength", Errors.WrongProposalLength, message);
   }
 }
 
 export class DuplicateProposal extends DaoError {
   constructor(message: string) {
-    super(Errors.DuplicateProposal, message);
+    super("DuplicateProposal", Errors.DuplicateProposal, message);
   }
 }
 
 export class NotAuthorizedToVote extends DaoError {
   constructor(message: string) {
-    super(Errors.NotAuthorizedToVote, message);
+    super("NotAuthorizedToVote", Errors.NotAuthorizedToVote, message);
   }
 }
 
 export class ProposalMissing extends DaoError {
   constructor(message: string) {
-    super(Errors.ProposalMissing, message);
+    super("ProposalMissing", Errors.ProposalMissing, message);
   }
 }
 
 export class WrongIndex extends DaoError {
   constructor(message: string) {
-    super(Errors.WrongIndex, message);
+    super("WrongIndex", Errors.WrongIndex, message);
   }
 }
 
 export class DuplicateVote extends DaoError {
   constructor(message: string) {
-    super(Errors.DuplicateVote, message);
+    super("DuplicateVote", Errors.DuplicateVote, message);
   }
 }
 
 export class DuplicateVeto extends DaoError {
   constructor(message: string) {
-    super(Errors.DuplicateVeto, message);
+    super("DuplicateVeto", Errors.DuplicateVeto, message);
   }
 }
 
 export class WrongProposalWeight extends DaoError {
   constructor(message: string) {
-    super(Errors.WrongProposalWeight, message);
+    super("WrongProposalWeight", Errors.WrongProposalWeight, message);
   }
 }
 
 export class TooEarly extends DaoError {
   constructor(message: string) {
-    super(Errors.TooEarly, message);
+    super("TooEarly", Errors.TooEarly, message);
   }
 }
 
 export class TimeLimitReached extends DaoError {
   constructor(message: string) {
-    super(Errors.TimeLimitReached, message);
+    super("TimeLimitReached", Errors.TimeLimitReached, message);
   }
 }
 
 export class OngoingVoteAndTresholdStillNotMet extends DaoError {
   constructor(message: string) {
-    super(Errors.OngoingVoteAndTresholdStillNotMet, message);
+    super("OngoingVoteAndTresholdStillNotMet", Errors.OngoingVoteAndTresholdStillNotMet, message);
   }
 }
 
 export class FarmHasNoNodes extends DaoError {
   constructor(message: string) {
-    super(Errors.FarmHasNoNodes, message);
+    super("FarmHasNoNodes", Errors.FarmHasNoNodes, message);
   }
 }
 
 export class InvalidProposalDuration extends DaoError {
   constructor(message: string) {
-    super(Errors.InvalidProposalDuration, message);
+    super("InvalidProposalDuration", Errors.InvalidProposalDuration, message);
   }
 }

--- a/packages/types/src/errors/tfchain/kvstore.ts
+++ b/packages/types/src/errors/tfchain/kvstore.ts
@@ -7,24 +7,24 @@ export enum Errors {
 }
 
 class KVStoreError extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.TFKVStore);
+  constructor(name: string, code: number, message: string) {
+    super(name, code, message, ErrorModules.TFKVStore);
   }
 }
 export class NoValueStored extends KVStoreError {
   constructor(message: string) {
-    super(Errors.NoValueStored, message);
+    super("NoValueStored", Errors.NoValueStored, message);
   }
 }
 
 export class KeyIsTooLarge extends KVStoreError {
   constructor(message: string) {
-    super(Errors.NoValueStored, message);
+    super("KeyIsTooLarge", Errors.NoValueStored, message);
   }
 }
 
 export class ValueIsTooLarge extends KVStoreError {
   constructor(message: string) {
-    super(Errors.ValueIsTooLarge, message);
+    super("ValueIsTooLarge", Errors.ValueIsTooLarge, message);
   }
 }

--- a/packages/types/src/errors/tfchain/smart_contract.ts
+++ b/packages/types/src/errors/tfchain/smart_contract.ts
@@ -55,318 +55,318 @@ export enum Errors {
   UnauthorizedToSetExtraFee,
 }
 class SmartContractError extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.SmartContract);
+  constructor(name: string, code: number, message: string) {
+    super(name, code, message, ErrorModules.SmartContract);
   }
 }
 export class TwinNotExists extends SmartContractError {
   constructor(message: string) {
-    super(Errors.TwinNotExists, message);
+    super("TwinNotExists", Errors.TwinNotExists, message);
   }
 }
 
 export class NodeNotExists extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NodeNotExists, message);
+    super("NodeNotExists", Errors.NodeNotExists, message);
   }
 }
 
 export class FarmNotExists extends SmartContractError {
   constructor(message: string) {
-    super(Errors.FarmNotExists, message);
+    super("FarmNotExists", Errors.FarmNotExists, message);
   }
 }
 
 export class FarmHasNotEnoughPublicIPs extends SmartContractError {
   constructor(message: string) {
-    super(Errors.FarmHasNotEnoughPublicIPs, message);
+    super("FarmHasNotEnoughPublicIPs", Errors.FarmHasNotEnoughPublicIPs, message);
   }
 }
 
 export class FarmHasNotEnoughPublicIPsFree extends SmartContractError {
   constructor(message: string) {
-    super(Errors.FarmHasNotEnoughPublicIPsFree, message);
+    super("FarmHasNotEnoughPublicIPsFree", Errors.FarmHasNotEnoughPublicIPsFree, message);
   }
 }
 
 export class FailedToReserveIP extends SmartContractError {
   constructor(message: string) {
-    super(Errors.FailedToReserveIP, message);
+    super("FailedToReserveIP", Errors.FailedToReserveIP, message);
   }
 }
 
 export class FailedToFreeIPs extends SmartContractError {
   constructor(message: string) {
-    super(Errors.FailedToFreeIPs, message);
+    super("FailedToFreeIPs", Errors.FailedToFreeIPs, message);
   }
 }
 
 export class ContractNotExists extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ContractNotExists, message);
+    super("ContractNotExists", Errors.ContractNotExists, message);
   }
 }
 
 export class TwinNotAuthorizedToUpdateContract extends SmartContractError {
   constructor(message: string) {
-    super(Errors.TwinNotAuthorizedToUpdateContract, message);
+    super("TwinNotAuthorizedToUpdateContract", Errors.TwinNotAuthorizedToUpdateContract, message);
   }
 }
 
 export class TwinNotAuthorizedToCancelContract extends SmartContractError {
   constructor(message: string) {
-    super(Errors.TwinNotAuthorizedToCancelContract, message);
+    super("TwinNotAuthorizedToCancelContract", Errors.TwinNotAuthorizedToCancelContract, message);
   }
 }
 
 export class NodeNotAuthorizedToDeployContract extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NodeNotAuthorizedToDeployContract, message);
+    super("NodeNotAuthorizedToDeployContract", Errors.NodeNotAuthorizedToDeployContract, message);
   }
 }
 
 export class NodeNotAuthorizedToComputeReport extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NodeNotAuthorizedToComputeReport, message);
+    super("NodeNotAuthorizedToComputeReport", Errors.NodeNotAuthorizedToComputeReport, message);
   }
 }
 
 export class PricingPolicyNotExists extends SmartContractError {
   constructor(message: string) {
-    super(Errors.PricingPolicyNotExists, message);
+    super("PricingPolicyNotExists", Errors.PricingPolicyNotExists, message);
   }
 }
 
 export class ContractIsNotUnique extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ContractIsNotUnique, message);
+    super("ContractIsNotUnique", Errors.ContractIsNotUnique, message);
   }
 }
 
 export class ContractWrongBillingLoopIndex extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ContractWrongBillingLoopIndex, message);
+    super("ContractWrongBillingLoopIndex", Errors.ContractWrongBillingLoopIndex, message);
   }
 }
 
 export class NameExists extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NameExists, message);
+    super("NameExists", Errors.NameExists, message);
   }
 }
 
 export class NameNotValid extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NameNotValid, message);
+    super("NameNotValid", Errors.NameNotValid, message);
   }
 }
 
 export class InvalidContractType extends SmartContractError {
   constructor(message: string) {
-    super(Errors.InvalidContractType, message);
+    super("InvalidContractType", Errors.InvalidContractType, message);
   }
 }
 
 export class TFTPriceValueError extends SmartContractError {
   constructor(message: string) {
-    super(Errors.TFTPriceValueError, message);
+    super("TFTPriceValueError", Errors.TFTPriceValueError, message);
   }
 }
 
 export class NotEnoughResourcesOnNode extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NotEnoughResourcesOnNode, message);
+    super("NotEnoughResourcesOnNode", Errors.NotEnoughResourcesOnNode, message);
   }
 }
 
 export class NodeNotAuthorizedToReportResources extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NodeNotAuthorizedToReportResources, message);
+    super("NodeNotAuthorizedToReportResources", Errors.NodeNotAuthorizedToReportResources, message);
   }
 }
 
 export class MethodIsDeprecated extends SmartContractError {
   constructor(message: string) {
-    super(Errors.MethodIsDeprecated, message);
+    super("MethodIsDeprecated", Errors.MethodIsDeprecated, message);
   }
 }
 
 export class NodeHasActiveContracts extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NodeHasActiveContracts, message);
+    super("NodeHasActiveContracts", Errors.NodeHasActiveContracts, message);
   }
 }
 
 export class NodeHasRentContract extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NodeHasRentContract, message);
+    super("NodeHasRentContract", Errors.NodeHasRentContract, message);
   }
 }
 
 export class FarmIsNotDedicated extends SmartContractError {
   constructor(message: string) {
-    super(Errors.FarmIsNotDedicated, message);
+    super("FarmIsNotDedicated", Errors.FarmIsNotDedicated, message);
   }
 }
 
 export class NodeNotAvailableToDeploy extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NodeNotAvailableToDeploy, message);
+    super("NodeNotAvailableToDeploy", Errors.NodeNotAvailableToDeploy, message);
   }
 }
 
 export class CannotUpdateContractInGraceState extends SmartContractError {
   constructor(message: string) {
-    super(Errors.CannotUpdateContractInGraceState, message);
+    super("CannotUpdateContractInGraceState", Errors.CannotUpdateContractInGraceState, message);
   }
 }
 
 export class NumOverflow extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NumOverflow, message);
+    super("NumOverflow", Errors.NumOverflow, message);
   }
 }
 
 export class OffchainSignedTxCannotSign extends SmartContractError {
   constructor(message: string) {
-    super(Errors.OffchainSignedTxCannotSign, message);
+    super("OffchainSignedTxCannotSign", Errors.OffchainSignedTxCannotSign, message);
   }
 }
 
 export class OffchainSignedTxAlreadySent extends SmartContractError {
   constructor(message: string) {
-    super(Errors.OffchainSignedTxAlreadySent, message);
+    super("OffchainSignedTxAlreadySent", Errors.OffchainSignedTxAlreadySent, message);
   }
 }
 
 export class OffchainSignedTxNoLocalAccountAvailable extends SmartContractError {
   constructor(message: string) {
-    super(Errors.OffchainSignedTxNoLocalAccountAvailable, message);
+    super("OffchainSignedTxNoLocalAccountAvailable", Errors.OffchainSignedTxNoLocalAccountAvailable, message);
   }
 }
 
 export class NameContractNameTooShort extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NameContractNameTooShort, message);
+    super("NameContractNameTooShort", Errors.NameContractNameTooShort, message);
   }
 }
 
 export class NameContractNameTooLong extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NameContractNameTooLong, message);
+    super("NameContractNameTooLong", Errors.NameContractNameTooLong, message);
   }
 }
 
 export class InvalidProviderConfiguration extends SmartContractError {
   constructor(message: string) {
-    super(Errors.InvalidProviderConfiguration, message);
+    super("InvalidProviderConfiguration", Errors.InvalidProviderConfiguration, message);
   }
 }
 
 export class NoSuchSolutionProvider extends SmartContractError {
   constructor(message: string) {
-    super(Errors.NoSuchSolutionProvider, message);
+    super("NoSuchSolutionProvider", Errors.NoSuchSolutionProvider, message);
   }
 }
 
 export class SolutionProviderNotApproved extends SmartContractError {
   constructor(message: string) {
-    super(Errors.SolutionProviderNotApproved, message);
+    super("SolutionProviderNotApproved", Errors.SolutionProviderNotApproved, message);
   }
 }
 
 export class TwinNotAuthorized extends SmartContractError {
   constructor(message: string) {
-    super(Errors.TwinNotAuthorized, message);
+    super("TwinNotAuthorized", Errors.TwinNotAuthorized, message);
   }
 }
 
 export class ServiceContractNotExists extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractNotExists, message);
+    super("ServiceContractNotExists", Errors.ServiceContractNotExists, message);
   }
 }
 
 export class ServiceContractCreationNotAllowed extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractCreationNotAllowed, message);
+    super("ServiceContractCreationNotAllowed", Errors.ServiceContractCreationNotAllowed, message);
   }
 }
 
 export class ServiceContractModificationNotAllowed extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractModificationNotAllowed, message);
+    super("ServiceContractModificationNotAllowed", Errors.ServiceContractModificationNotAllowed, message);
   }
 }
 
 export class ServiceContractApprovalNotAllowed extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractApprovalNotAllowed, message);
+    super("ServiceContractApprovalNotAllowed", Errors.ServiceContractApprovalNotAllowed, message);
   }
 }
 
 export class ServiceContractRejectionNotAllowed extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractRejectionNotAllowed, message);
+    super("ServiceContractRejectionNotAllowed", Errors.ServiceContractRejectionNotAllowed, message);
   }
 }
 
 export class ServiceContractBillingNotApprovedByBoth extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractBillingNotApprovedByBoth, message);
+    super("ServiceContractBillingNotApprovedByBoth", Errors.ServiceContractBillingNotApprovedByBoth, message);
   }
 }
 
 export class ServiceContractBillingVariableAmountTooHigh extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractBillingVariableAmountTooHigh, message);
+    super("ServiceContractBillingVariableAmountTooHigh", Errors.ServiceContractBillingVariableAmountTooHigh, message);
   }
 }
 
 export class ServiceContractBillMetadataTooLong extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractBillMetadataTooLong, message);
+    super("ServiceContractBillMetadataTooLong", Errors.ServiceContractBillMetadataTooLong, message);
   }
 }
 
 export class ServiceContractMetadataTooLong extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractMetadataTooLong, message);
+    super("ServiceContractMetadataTooLong", Errors.ServiceContractMetadataTooLong, message);
   }
 }
 
 export class ServiceContractNotEnoughFundsToPayBill extends SmartContractError {
   constructor(message: string) {
-    super(Errors.ServiceContractNotEnoughFundsToPayBill, message);
+    super("ServiceContractNotEnoughFundsToPayBill", Errors.ServiceContractNotEnoughFundsToPayBill, message);
   }
 }
 
 export class CanOnlyIncreaseFrequency extends SmartContractError {
   constructor(message: string) {
-    super(Errors.CanOnlyIncreaseFrequency, message);
+    super("CanOnlyIncreaseFrequency", Errors.CanOnlyIncreaseFrequency, message);
   }
 }
 
 export class IsNotAnAuthority extends SmartContractError {
   constructor(message: string) {
-    super(Errors.IsNotAnAuthority, message);
+    super("IsNotAnAuthority", Errors.IsNotAnAuthority, message);
   }
 }
 
 export class WrongAuthority extends SmartContractError {
   constructor(message: string) {
-    super(Errors.WrongAuthority, message);
+    super("WrongAuthority", Errors.WrongAuthority, message);
   }
 }
 
 export class UnauthorizedToChangeSolutionProviderId extends SmartContractError {
   constructor(message: string) {
-    super(Errors.UnauthorizedToChangeSolutionProviderId, message);
+    super("UnauthorizedToChangeSolutionProviderId", Errors.UnauthorizedToChangeSolutionProviderId, message);
   }
 }
 
 export class UnauthorizedToSetExtraFee extends SmartContractError {
   constructor(message: string) {
-    super(Errors.UnauthorizedToSetExtraFee, message);
+    super("UnauthorizedToSetExtraFee", Errors.UnauthorizedToSetExtraFee, message);
   }
 }

--- a/packages/types/src/errors/tfchain/tfchain_error.ts
+++ b/packages/types/src/errors/tfchain/tfchain_error.ts
@@ -3,6 +3,6 @@ import { ErrorModules } from "../modules";
 
 export class TFChainError extends BaseError {
   constructor(message: string) {
-    super(Generic.TFChainError, message, ErrorModules.Generic);
+    super("TFChainError", Generic.TFChainError, message, ErrorModules.Generic);
   }
 }

--- a/packages/types/src/errors/tfchain/tfgrid.ts
+++ b/packages/types/src/errors/tfchain/tfgrid.ts
@@ -134,690 +134,690 @@ export enum Errors {
 }
 
 class TFGridErrors extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.TFGrid);
+  constructor(name: string, code: number, message: string) {
+    super(name, code, message, ErrorModules.TFGrid);
   }
 }
 export class NoneValue extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.NoneValue, message);
+    super("NoneValue", Errors.NoneValue, message);
   }
 }
 
 export class StorageOverflow extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.StorageOverflow, message);
+    super("StorageOverflow", Errors.StorageOverflow, message);
   }
 }
 
 export class CannotCreateNode extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotCreateNode, message);
+    super("CannotCreateNode", Errors.CannotCreateNode, message);
   }
 }
 
 export class NodeNotExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.NodeNotExists, message);
+    super("NodeNotExists", Errors.NodeNotExists, message);
   }
 }
 
 export class NodeWithTwinIdExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.NodeWithTwinIdExists, message);
+    super("NodeWithTwinIdExists", Errors.NodeWithTwinIdExists, message);
   }
 }
 
 export class CannotDeleteNode extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotDeleteNode, message);
+    super("CannotDeleteNode", Errors.CannotDeleteNode, message);
   }
 }
 
 export class NodeDeleteNotAuthorized extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.NodeDeleteNotAuthorized, message);
+    super("NodeDeleteNotAuthorized", Errors.NodeDeleteNotAuthorized, message);
   }
 }
 
 export class NodeUpdateNotAuthorized extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.NodeUpdateNotAuthorized, message);
+    super("NodeUpdateNotAuthorized", Errors.NodeUpdateNotAuthorized, message);
   }
 }
 
 export class FarmExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmExists, message);
+    super("FarmExists", Errors.FarmExists, message);
   }
 }
 
 export class FarmNotExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmNotExists, message);
+    super("FarmNotExists", Errors.FarmNotExists, message);
   }
 }
 
 export class CannotCreateFarmWrongTwin extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotCreateFarmWrongTwin, message);
+    super("CannotCreateFarmWrongTwin", Errors.CannotCreateFarmWrongTwin, message);
   }
 }
 
 export class CannotUpdateFarmWrongTwin extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotUpdateFarmWrongTwin, message);
+    super("CannotUpdateFarmWrongTwin", Errors.CannotUpdateFarmWrongTwin, message);
   }
 }
 
 export class CannotDeleteFarm extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotDeleteFarm, message);
+    super("CannotDeleteFarm", Errors.CannotDeleteFarm, message);
   }
 }
 
 export class CannotDeleteFarmWithPublicIPs extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotDeleteFarmWithPublicIPs, message);
+    super("CannotDeleteFarmWithPublicIPs", Errors.CannotDeleteFarmWithPublicIPs, message);
   }
 }
 
 export class CannotDeleteFarmWithNodesAssigned extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotDeleteFarmWithNodesAssigned, message);
+    super("CannotDeleteFarmWithNodesAssigned", Errors.CannotDeleteFarmWithNodesAssigned, message);
   }
 }
 
 export class CannotDeleteFarmWrongTwin extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotDeleteFarmWrongTwin, message);
+    super("CannotDeleteFarmWrongTwin", Errors.CannotDeleteFarmWrongTwin, message);
   }
 }
 
 export class IpExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.IpExists, message);
+    super("IpExists", Errors.IpExists, message);
   }
 }
 
 export class IpNotExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.IpNotExists, message);
+    super("IpNotExists", Errors.IpNotExists, message);
   }
 }
 
 export class EntityWithNameExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.EntityWithNameExists, message);
+    super("EntityWithNameExists", Errors.EntityWithNameExists, message);
   }
 }
 
 export class EntityWithPubkeyExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.EntityWithPubkeyExists, message);
+    super("EntityWithPubkeyExists", Errors.EntityWithPubkeyExists, message);
   }
 }
 
 export class EntityNotExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.EntityNotExists, message);
+    super("EntityNotExists", Errors.EntityNotExists, message);
   }
 }
 
 export class EntitySignatureDoesNotMatch extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.EntitySignatureDoesNotMatch, message);
+    super("EntitySignatureDoesNotMatch", Errors.EntitySignatureDoesNotMatch, message);
   }
 }
 
 export class EntityWithSignatureAlreadyExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.EntityWithSignatureAlreadyExists, message);
+    super("EntityWithSignatureAlreadyExists", Errors.EntityWithSignatureAlreadyExists, message);
   }
 }
 
 export class CannotUpdateEntity extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotUpdateEntity, message);
+    super("CannotUpdateEntity", Errors.CannotUpdateEntity, message);
   }
 }
 
 export class CannotDeleteEntity extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotDeleteEntity, message);
+    super("CannotDeleteEntity", Errors.CannotDeleteEntity, message);
   }
 }
 
 export class SignatureLengthIsIncorrect extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.SignatureLengthIsIncorrect, message);
+    super("SignatureLengthIsIncorrect", Errors.SignatureLengthIsIncorrect, message);
   }
 }
 
 export class TwinExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.TwinExists, message);
+    super("TwinExists", Errors.TwinExists, message);
   }
 }
 
 export class TwinNotExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.TwinNotExists, message);
+    super("TwinNotExists", Errors.TwinNotExists, message);
   }
 }
 
 export class TwinWithPubkeyExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.TwinWithPubkeyExists, message);
+    super("TwinWithPubkeyExists", Errors.TwinWithPubkeyExists, message);
   }
 }
 
 export class CannotCreateTwin extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CannotCreateTwin, message);
+    super("CannotCreateTwin", Errors.CannotCreateTwin, message);
   }
 }
 
 export class UnauthorizedToUpdateTwin extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.UnauthorizedToUpdateTwin, message);
+    super("UnauthorizedToUpdateTwin", Errors.UnauthorizedToUpdateTwin, message);
   }
 }
 
 export class TwinCannotBoundToItself extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.TwinCannotBoundToItself, message);
+    super("TwinCannotBoundToItself", Errors.TwinCannotBoundToItself, message);
   }
 }
 
 export class PricingPolicyExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.PricingPolicyExists, message);
+    super("PricingPolicyExists", Errors.PricingPolicyExists, message);
   }
 }
 
 export class PricingPolicyNotExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.PricingPolicyNotExists, message);
+    super("PricingPolicyNotExists", Errors.PricingPolicyNotExists, message);
   }
 }
 
 export class PricingPolicyWithDifferentIdExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.PricingPolicyWithDifferentIdExists, message);
+    super("PricingPolicyWithDifferentIdExists", Errors.PricingPolicyWithDifferentIdExists, message);
   }
 }
 
 export class CertificationCodeExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CertificationCodeExists, message);
+    super("CertificationCodeExists", Errors.CertificationCodeExists, message);
   }
 }
 
 export class FarmingPolicyAlreadyExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmingPolicyAlreadyExists, message);
+    super("FarmingPolicyAlreadyExists", Errors.FarmingPolicyAlreadyExists, message);
   }
 }
 
 export class FarmPayoutAdressAlreadyRegistered extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmPayoutAdressAlreadyRegistered, message);
+    super("FarmPayoutAdressAlreadyRegistered", Errors.FarmPayoutAdressAlreadyRegistered, message);
   }
 }
 
 export class FarmerDoesNotHaveEnoughFunds extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmerDoesNotHaveEnoughFunds, message);
+    super("FarmerDoesNotHaveEnoughFunds", Errors.FarmerDoesNotHaveEnoughFunds, message);
   }
 }
 
 export class UserDidNotSignTermsAndConditions extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.UserDidNotSignTermsAndConditions, message);
+    super("UserDidNotSignTermsAndConditions", Errors.UserDidNotSignTermsAndConditions, message);
   }
 }
 
 export class FarmerDidNotSignTermsAndConditions extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmerDidNotSignTermsAndConditions, message);
+    super("FarmerDidNotSignTermsAndConditions", Errors.FarmerDidNotSignTermsAndConditions, message);
   }
 }
 
 export class FarmerNotAuthorized extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmerNotAuthorized, message);
+    super("FarmerNotAuthorized", Errors.FarmerNotAuthorized, message);
   }
 }
 
 export class InvalidFarmName extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidFarmName, message);
+    super("InvalidFarmName", Errors.InvalidFarmName, message);
   }
 }
 
 export class AlreadyCertifier extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.AlreadyCertifier, message);
+    super("AlreadyCertifier", Errors.AlreadyCertifier, message);
   }
 }
 
 export class NotCertifier extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.NotCertifier, message);
+    super("NotCertifier", Errors.NotCertifier, message);
   }
 }
 
 export class NotAllowedToCertifyNode extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.NotAllowedToCertifyNode, message);
+    super("NotAllowedToCertifyNode", Errors.NotAllowedToCertifyNode, message);
   }
 }
 
 export class FarmingPolicyNotExists extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmingPolicyNotExists, message);
+    super("FarmingPolicyNotExists", Errors.FarmingPolicyNotExists, message);
   }
 }
 
 export class RelayTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.RelayTooShort, message);
+    super("RelayTooShort", Errors.RelayTooShort, message);
   }
 }
 
 export class RelayTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.RelayTooLong, message);
+    super("RelayTooLong", Errors.RelayTooLong, message);
   }
 }
 
 export class InvalidRelay extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidRelay, message);
+    super("InvalidRelay", Errors.InvalidRelay, message);
   }
 }
 
 export class FarmNameTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmNameTooShort, message);
+    super("FarmNameTooShort", Errors.FarmNameTooShort, message);
   }
 }
 
 export class FarmNameTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmNameTooLong, message);
+    super("FarmNameTooLong", Errors.FarmNameTooLong, message);
   }
 }
 
 export class InvalidPublicIP extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidPublicIP, message);
+    super("InvalidPublicIP", Errors.InvalidPublicIP, message);
   }
 }
 
 export class PublicIPTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.PublicIPTooShort, message);
+    super("PublicIPTooShort", Errors.PublicIPTooShort, message);
   }
 }
 
 export class PublicIPTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.PublicIPTooLong, message);
+    super("PublicIPTooLong", Errors.PublicIPTooLong, message);
   }
 }
 
 export class GatewayIPTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.GatewayIPTooShort, message);
+    super("GatewayIPTooShort", Errors.GatewayIPTooShort, message);
   }
 }
 
 export class GatewayIPTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.GatewayIPTooLong, message);
+    super("GatewayIPTooLong", Errors.GatewayIPTooLong, message);
   }
 }
 
 export class IP4TooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.IP4TooShort, message);
+    super("IP4TooShort", Errors.IP4TooShort, message);
   }
 }
 
 export class IP4TooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.IP4TooLong, message);
+    super("IP4TooLong", Errors.IP4TooLong, message);
   }
 }
 
 export class InvalidIP4 extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidIP4, message);
+    super("InvalidIP4", Errors.InvalidIP4, message);
   }
 }
 
 export class GW4TooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.GW4TooShort, message);
+    super("GW4TooShort", Errors.GW4TooShort, message);
   }
 }
 
 export class GW4TooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.GW4TooLong, message);
+    super("GW4TooLong", Errors.GW4TooLong, message);
   }
 }
 
 export class InvalidGW4 extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidGW4, message);
+    super("InvalidGW4", Errors.InvalidGW4, message);
   }
 }
 
 export class IP6TooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.IP6TooShort, message);
+    super("IP6TooShort", Errors.IP6TooShort, message);
   }
 }
 
 export class IP6TooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.IP6TooLong, message);
+    super("IP6TooLong", Errors.IP6TooLong, message);
   }
 }
 
 export class InvalidIP6 extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidIP6, message);
+    super("InvalidIP6", Errors.InvalidIP6, message);
   }
 }
 
 export class GW6TooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.GW6TooShort, message);
+    super("GW6TooShort", Errors.GW6TooShort, message);
   }
 }
 
 export class GW6TooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.GW6TooLong, message);
+    super("GW6TooLong", Errors.GW6TooLong, message);
   }
 }
 
 export class InvalidGW6 extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidGW6, message);
+    super("InvalidGW6", Errors.InvalidGW6, message);
   }
 }
 
 export class DomainTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.DomainTooShort, message);
+    super("DomainTooShort", Errors.DomainTooShort, message);
   }
 }
 
 export class DomainTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.DomainTooLong, message);
+    super("DomainTooLong", Errors.DomainTooLong, message);
   }
 }
 
 export class InvalidDomain extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidDomain, message);
+    super("InvalidDomain", Errors.InvalidDomain, message);
   }
 }
 
 export class MethodIsDeprecated extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.MethodIsDeprecated, message);
+    super("MethodIsDeprecated", Errors.MethodIsDeprecated, message);
   }
 }
 
 export class InterfaceNameTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InterfaceNameTooShort, message);
+    super("InterfaceNameTooShort", Errors.InterfaceNameTooShort, message);
   }
 }
 
 export class InterfaceNameTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InterfaceNameTooLong, message);
+    super("InterfaceNameTooLong", Errors.InterfaceNameTooLong, message);
   }
 }
 
 export class InvalidInterfaceName extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidInterfaceName, message);
+    super("InvalidInterfaceName", Errors.InvalidInterfaceName, message);
   }
 }
 
 export class InterfaceMacTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InterfaceMacTooShort, message);
+    super("InterfaceMacTooShort", Errors.InterfaceMacTooShort, message);
   }
 }
 
 export class InterfaceMacTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InterfaceMacTooLong, message);
+    super("InterfaceMacTooLong", Errors.InterfaceMacTooLong, message);
   }
 }
 
 export class InvalidMacAddress extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidMacAddress, message);
+    super("InvalidMacAddress", Errors.InvalidMacAddress, message);
   }
 }
 
 export class InterfaceIpTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InterfaceIpTooShort, message);
+    super("InterfaceIpTooShort", Errors.InterfaceIpTooShort, message);
   }
 }
 
 export class InterfaceIpTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InterfaceIpTooLong, message);
+    super("InterfaceIpTooLong", Errors.InterfaceIpTooLong, message);
   }
 }
 
 export class InvalidInterfaceIP extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidInterfaceIP, message);
+    super("InvalidInterfaceIP", Errors.InvalidInterfaceIP, message);
   }
 }
 
 export class InvalidZosVersion extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidZosVersion, message);
+    super("InvalidZosVersion", Errors.InvalidZosVersion, message);
   }
 }
 
 export class FarmingPolicyExpired extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.FarmingPolicyExpired, message);
+    super("FarmingPolicyExpired", Errors.FarmingPolicyExpired, message);
   }
 }
 
 export class InvalidHRUInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidHRUInput, message);
+    super("InvalidHRUInput", Errors.InvalidHRUInput, message);
   }
 }
 
 export class InvalidSRUInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidSRUInput, message);
+    super("InvalidSRUInput", Errors.InvalidSRUInput, message);
   }
 }
 
 export class InvalidCRUInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidCRUInput, message);
+    super("InvalidCRUInput", Errors.InvalidCRUInput, message);
   }
 }
 
 export class InvalidMRUInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidMRUInput, message);
+    super("InvalidMRUInput", Errors.InvalidMRUInput, message);
   }
 }
 
 export class LatitudeInputTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.LatitudeInputTooShort, message);
+    super("LatitudeInputTooShort", Errors.LatitudeInputTooShort, message);
   }
 }
 
 export class LatitudeInputTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.LatitudeInputTooLong, message);
+    super("LatitudeInputTooLong", Errors.LatitudeInputTooLong, message);
   }
 }
 
 export class InvalidLatitudeInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidLatitudeInput, message);
+    super("InvalidLatitudeInput", Errors.InvalidLatitudeInput, message);
   }
 }
 
 export class LongitudeInputTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.LongitudeInputTooShort, message);
+    super("LongitudeInputTooShort", Errors.LongitudeInputTooShort, message);
   }
 }
 
 export class LongitudeInputTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.LongitudeInputTooLong, message);
+    super("LongitudeInputTooLong", Errors.LongitudeInputTooLong, message);
   }
 }
 
 export class InvalidLongitudeInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidLongitudeInput, message);
+    super("InvalidLongitudeInput", Errors.InvalidLongitudeInput, message);
   }
 }
 
 export class CountryNameTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CountryNameTooShort, message);
+    super("CountryNameTooShort", Errors.CountryNameTooShort, message);
   }
 }
 
 export class CountryNameTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CountryNameTooLong, message);
+    super("CountryNameTooLong", Errors.CountryNameTooLong, message);
   }
 }
 
 export class InvalidCountryName extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidCountryName, message);
+    super("InvalidCountryName", Errors.InvalidCountryName, message);
   }
 }
 
 export class CityNameTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CityNameTooShort, message);
+    super("CityNameTooShort", Errors.CityNameTooShort, message);
   }
 }
 
 export class CityNameTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.CityNameTooLong, message);
+    super("CityNameTooLong", Errors.CityNameTooLong, message);
   }
 }
 
 export class InvalidCityName extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidCityName, message);
+    super("InvalidCityName", Errors.InvalidCityName, message);
   }
 }
 
 export class InvalidCountryCityPair extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidCountryCityPair, message);
+    super("InvalidCountryCityPair", Errors.InvalidCountryCityPair, message);
   }
 }
 
 export class SerialNumberTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.SerialNumberTooShort, message);
+    super("SerialNumberTooShort", Errors.SerialNumberTooShort, message);
   }
 }
 
 export class SerialNumberTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.SerialNumberTooLong, message);
+    super("SerialNumberTooLong", Errors.SerialNumberTooLong, message);
   }
 }
 
 export class InvalidSerialNumber extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidSerialNumber, message);
+    super("InvalidSerialNumber", Errors.InvalidSerialNumber, message);
   }
 }
 
 export class DocumentLinkInputTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.DocumentLinkInputTooShort, message);
+    super("DocumentLinkInputTooShort", Errors.DocumentLinkInputTooShort, message);
   }
 }
 
 export class DocumentLinkInputTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.DocumentLinkInputTooLong, message);
+    super("DocumentLinkInputTooLong", Errors.DocumentLinkInputTooLong, message);
   }
 }
 
 export class InvalidDocumentLinkInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidDocumentLinkInput, message);
+    super("InvalidDocumentLinkInput", Errors.InvalidDocumentLinkInput, message);
   }
 }
 
 export class DocumentHashInputTooShort extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.DocumentHashInputTooShort, message);
+    super("DocumentHashInputTooShort", Errors.DocumentHashInputTooShort, message);
   }
 }
 
 export class DocumentHashInputTooLong extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.DocumentHashInputTooLong, message);
+    super("DocumentHashInputTooLong", Errors.DocumentHashInputTooLong, message);
   }
 }
 
 export class InvalidDocumentHashInput extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidDocumentHashInput, message);
+    super("InvalidDocumentHashInput", Errors.InvalidDocumentHashInput, message);
   }
 }
 
 export class InvalidPublicConfig extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidPublicConfig, message);
+    super("InvalidPublicConfig", Errors.InvalidPublicConfig, message);
   }
 }
 
 export class UnauthorizedToChangePowerTarget extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.UnauthorizedToChangePowerTarget, message);
+    super("UnauthorizedToChangePowerTarget", Errors.UnauthorizedToChangePowerTarget, message);
   }
 }
 
 export class InvalidRelayAddress extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidRelayAddress, message);
+    super("InvalidRelayAddress", Errors.InvalidRelayAddress, message);
   }
 }
 
 export class InvalidTimestampHint extends TFGridErrors {
   constructor(message: string) {
-    super(Errors.InvalidTimestampHint, message);
+    super("InvalidTimestampHint", Errors.InvalidTimestampHint, message);
   }
 }

--- a/packages/types/src/errors/tfchain/tft_bridge.ts
+++ b/packages/types/src/errors/tfchain/tft_bridge.ts
@@ -26,133 +26,133 @@ export enum Errors {
 }
 
 class TFTBridge extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.TFTBridge);
+  constructor(name: string, code: number, message: string) {
+    super(name, code, message, ErrorModules.TFTBridge);
   }
 }
 
 export class ValidatorExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.ValidatorExists, message);
+    super("ValidatorExists", Errors.ValidatorExists, message);
   }
 }
 
 export class ValidatorNotExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.ValidatorNotExists, message);
+    super("ValidatorNotExists", Errors.ValidatorNotExists, message);
   }
 }
 
 export class TransactionValidatorExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.TransactionValidatorExists, message);
+    super("TransactionValidatorExists", Errors.TransactionValidatorExists, message);
   }
 }
 
 export class TransactionValidatorNotExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.TransactionValidatorNotExists, message);
+    super("TransactionValidatorNotExists", Errors.TransactionValidatorNotExists, message);
   }
 }
 
 export class MintTransactionExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.MintTransactionExists, message);
+    super("MintTransactionExists", Errors.MintTransactionExists, message);
   }
 }
 
 export class MintTransactionAlreadyExecuted extends TFTBridge {
   constructor(message: string) {
-    super(Errors.MintTransactionAlreadyExecuted, message);
+    super("MintTransactionAlreadyExecuted", Errors.MintTransactionAlreadyExecuted, message);
   }
 }
 
 export class MintTransactionNotExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.MintTransactionNotExists, message);
+    super("MintTransactionNotExists", Errors.MintTransactionNotExists, message);
   }
 }
 
 export class BurnTransactionExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.BurnTransactionExists, message);
+    super("BurnTransactionExists", Errors.BurnTransactionExists, message);
   }
 }
 
 export class BurnTransactionNotExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.BurnTransactionNotExists, message);
+    super("BurnTransactionNotExists", Errors.BurnTransactionNotExists, message);
   }
 }
 
 export class BurnSignatureExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.BurnSignatureExists, message);
+    super("BurnSignatureExists", Errors.BurnSignatureExists, message);
   }
 }
 
 export class EnoughBurnSignaturesPresent extends TFTBridge {
   constructor(message: string) {
-    super(Errors.EnoughBurnSignaturesPresent, message);
+    super("EnoughBurnSignaturesPresent", Errors.EnoughBurnSignaturesPresent, message);
   }
 }
 
 export class RefundSignatureExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.RefundSignatureExists, message);
+    super("RefundSignatureExists", Errors.RefundSignatureExists, message);
   }
 }
 
 export class BurnTransactionAlreadyExecuted extends TFTBridge {
   constructor(message: string) {
-    super(Errors.BurnTransactionAlreadyExecuted, message);
+    super("BurnTransactionAlreadyExecuted", Errors.BurnTransactionAlreadyExecuted, message);
   }
 }
 
 export class RefundTransactionNotExists extends TFTBridge {
   constructor(message: string) {
-    super(Errors.RefundTransactionNotExists, message);
+    super("RefundTransactionNotExists", Errors.RefundTransactionNotExists, message);
   }
 }
 
 export class RefundTransactionAlreadyExecuted extends TFTBridge {
   constructor(message: string) {
-    super(Errors.RefundTransactionAlreadyExecuted, message);
+    super("RefundTransactionAlreadyExecuted", Errors.RefundTransactionAlreadyExecuted, message);
   }
 }
 
 export class EnoughRefundSignaturesPresent extends TFTBridge {
   constructor(message: string) {
-    super(Errors.EnoughRefundSignaturesPresent, message);
+    super("EnoughRefundSignaturesPresent", Errors.EnoughRefundSignaturesPresent, message);
   }
 }
 
 export class NotEnoughBalanceToSwap extends TFTBridge {
   constructor(message: string) {
-    super(Errors.NotEnoughBalanceToSwap, message);
+    super("NotEnoughBalanceToSwap", Errors.NotEnoughBalanceToSwap, message);
   }
 }
 
 export class AmountIsLessThanWithdrawFee extends TFTBridge {
   constructor(message: string) {
-    super(Errors.AmountIsLessThanWithdrawFee, message);
+    super("AmountIsLessThanWithdrawFee", Errors.AmountIsLessThanWithdrawFee, message);
   }
 }
 
 export class AmountIsLessThanDepositFee extends TFTBridge {
   constructor(message: string) {
-    super(Errors.AmountIsLessThanDepositFee, message);
+    super("AmountIsLessThanDepositFee", Errors.AmountIsLessThanDepositFee, message);
   }
 }
 
 export class WrongParametersProvided extends TFTBridge {
   constructor(message: string) {
-    super(Errors.WrongParametersProvided, message);
+    super("WrongParametersProvided", Errors.WrongParametersProvided, message);
   }
 }
 
 export class InvalidStellarPublicKey extends TFTBridge {
   constructor(message: string) {
-    super(Errors.InvalidStellarPublicKey, message);
+    super("InvalidStellarPublicKey", Errors.InvalidStellarPublicKey, message);
   }
 }

--- a/packages/types/src/errors/tfchain/tft_price.ts
+++ b/packages/types/src/errors/tfchain/tft_price.ts
@@ -13,54 +13,54 @@ export enum Errors {
 }
 
 class TFTPrice extends BaseError {
-  constructor(code: number, message: string) {
-    super(code, message, ErrorModules.TFTPrice);
+  constructor(name: string, code: number, message: string) {
+    super(name, code, message, ErrorModules.TFTPrice);
   }
 }
 export class ErrFetchingPrice extends TFTPrice {
   constructor(message: string) {
-    super(Errors.ErrFetchingPrice, message);
+    super("ErrFetchingPrice", Errors.ErrFetchingPrice, message);
   }
 }
 
 export class OffchainSignedTxError extends TFTPrice {
   constructor(message: string) {
-    super(Errors.OffchainSignedTxError, message);
+    super("OffchainSignedTxError", Errors.OffchainSignedTxError, message);
   }
 }
 
 export class NoLocalAcctForSigning extends TFTPrice {
   constructor(message: string) {
-    super(Errors.NoLocalAcctForSigning, message);
+    super("NoLocalAcctForSigning", Errors.NoLocalAcctForSigning, message);
   }
 }
 
 export class AccountUnauthorizedToSetPrice extends TFTPrice {
   constructor(message: string) {
-    super(Errors.AccountUnauthorizedToSetPrice, message);
+    super("AccountUnauthorizedToSetPrice", Errors.AccountUnauthorizedToSetPrice, message);
   }
 }
 
 export class MaxPriceBelowMinPriceError extends TFTPrice {
   constructor(message: string) {
-    super(Errors.MaxPriceBelowMinPriceError, message);
+    super("MaxPriceBelowMinPriceError", Errors.MaxPriceBelowMinPriceError, message);
   }
 }
 
 export class MinPriceAboveMaxPriceError extends TFTPrice {
   constructor(message: string) {
-    super(Errors.MinPriceAboveMaxPriceError, message);
+    super("MinPriceAboveMaxPriceError", Errors.MinPriceAboveMaxPriceError, message);
   }
 }
 
 export class IsNotAnAuthority extends TFTPrice {
   constructor(message: string) {
-    super(Errors.IsNotAnAuthority, message);
+    super("IsNotAnAuthority", Errors.IsNotAnAuthority, message);
   }
 }
 
 export class WrongAuthority extends TFTPrice {
   constructor(message: string) {
-    super(Errors.WrongAuthority, message);
+    super("WrongAuthority", Errors.WrongAuthority, message);
   }
 }


### PR DESCRIPTION
### Description

`@threefold/types` introduce error classes so we could replace literal message check with instance check; this  is already done in profile manager and now in node selector.
also we added error name to the message, to make the error more clear and meaningful 

### Changes

- add `DiskAllocationError` to node selector
- add  name to `BaseError` class and prepend it to the message
- add names to error classes 

![Screenshot from 2024-02-12 13-54-51](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/3d1b1329-ad86-40e5-af06-87ce2df16c3a)

### Related Issues

- #1462

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
