### PR TITLE
Fix K8s master tooltip

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -286,7 +286,7 @@ function getTooltipText(contract: any, index: number) {
     return "Leader";
   }
 
-  if (index === 0 && getMetadata(contract).projectName === "kubernetes") {
+  if (index === 0 && getMetadata(contract).type === "kubernetes") {
     return "Master";
   }
 


### PR DESCRIPTION
### Description

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/7ad799d0-2d42-411d-82f0-9dfa5fc045a5)

### Changes

- K8s project name was changed to the deployment name, hence the tooltip info was broken. Fixed by using the type instead.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2151

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
