### PR TITLE
Disable creating 2 farms with same name

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -227,6 +227,7 @@
 </template>
 
 <script lang="ts">
+import { FailedToFreeIPs } from "@threefold/types/dist/errors/tfchain/smart_contract";
 import { onMounted, type PropType, ref } from "vue";
 
 import { useProfileManager } from "../stores";
@@ -303,6 +304,7 @@ export default {
           name: networkName,
           ipRange: `${x}.${y}.0.0/16`,
           nodeId: selectionDetails.value!.domain!.selectedDomain!.nodeId,
+          mycelium: false,
         };
 
         const hasNode = await grid!.networks.hasNode(data);

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -227,7 +227,6 @@
 </template>
 
 <script lang="ts">
-import { FailedToFreeIPs } from "@threefold/types/dist/errors/tfchain/smart_contract";
 import { onMounted, type PropType, ref } from "vue";
 
 import { useProfileManager } from "../stores";
@@ -304,7 +303,6 @@ export default {
           name: networkName,
           ipRange: `${x}.${y}.0.0/16`,
           nodeId: selectionDetails.value!.domain!.selectedDomain!.nodeId,
-          mycelium: false,
         };
 
         const hasNode = await grid!.networks.hasNode(data);

--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -93,13 +93,6 @@ export default {
     async function createFarm() {
       try {
         isCreating.value = true;
-        const names = props.userFarms.getFarmsNames();
-        if (names.includes(props.name.toLocaleLowerCase())) {
-          createCustomToast("Failed to create farm, name already exists.", ToastType.danger);
-          isCreating.value = false;
-          return;
-        }
-
         await gridStore.grid.farms.create({ name: props.name });
         createCustomToast("Farm created successfully.", ToastType.success);
         notifyDelaying();
@@ -115,6 +108,10 @@ export default {
     function validateFarmName(name: string) {
       if (!name.split("").every((c: string) => /[a-zA-Z0-9\-_]/.test(c))) {
         return { message: "Farm name can only contain alphabetic letters, numbers, '-' or '_'" };
+      }
+      const names = props.userFarms.getFarmsNames();
+      if (names.includes(props.name.toLocaleLowerCase())) {
+        return { message: "Farm name already exists!" };
       }
     }
     return {

--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -93,6 +93,13 @@ export default {
     async function createFarm() {
       try {
         isCreating.value = true;
+        const names = props.userFarms.getFarmsNames();
+        if (names.includes(props.name.toLocaleLowerCase())) {
+          createCustomToast("Failed to create farm, name already exists.", ToastType.danger);
+          isCreating.value = false;
+          return;
+        }
+
         await gridStore.grid.farms.create({ name: props.name });
         createCustomToast("Farm created successfully.", ToastType.success);
         notifyDelaying();

--- a/packages/playground/src/dashboard/components/user_farms.vue
+++ b/packages/playground/src/dashboard/components/user_farms.vue
@@ -205,7 +205,6 @@ export default {
     const refreshPublicIPs = ref(false);
 
     const reloadFarms = debounce(getUserFarms, 20000);
-    // context.expose({ reloadFarms });
     function filter(items: Farm[]) {
       const start = (page.value - 1) * pageSize.value;
       const end = start + pageSize.value;

--- a/packages/playground/src/dashboard/components/user_farms.vue
+++ b/packages/playground/src/dashboard/components/user_farms.vue
@@ -205,7 +205,7 @@ export default {
     const refreshPublicIPs = ref(false);
 
     const reloadFarms = debounce(getUserFarms, 20000);
-    context.expose({ reloadFarms });
+    // context.expose({ reloadFarms });
     function filter(items: Farm[]) {
       const start = (page.value - 1) * pageSize.value;
       const end = start + pageSize.value;
@@ -332,6 +332,11 @@ export default {
       refreshPublicIPs.value = !refreshPublicIPs.value;
     }
 
+    function getFarmsNames() {
+      return farms.value?.map(farm => farm.name.toLocaleLowerCase());
+    }
+
+    context.expose({ getFarmsNames, reloadFarms });
     return {
       gridStore,
       headers,
@@ -355,6 +360,7 @@ export default {
       downloadFarmReceipts,
       handleIpAdded,
       refreshPublicIPs,
+      getFarmsNames,
     };
   },
 };


### PR DESCRIPTION
### Description

Create farm in your farms tab is case senestive;
which means the one user can crerate mutltiple farms with the same name !
and when come to search by name (its not case sensitive)

### Changes

- added function returns all farms names', then check the entered name in lower case doesn't exist.
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1790

[Screencast from 02-13-2024 11:28:35 AM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/43d4701f-b80b-4bcc-8c01-62de2478b282)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
