### PR TITLE
Filter by Public IPs in `node finder`

### DIFF
--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -218,6 +218,28 @@
           </VTextField>
         </template>
       </TfFilter>
+      <TfFilter
+        query-route="free-public-ips"
+        :rules="[
+          validators.isNumeric('This field accepts numbers only.', { no_symbols: true }),
+          validators.min('The node id should be larger then zero.', 1),
+          validators.startsWith('The node id start with zero.', '0'),
+          validators.validateResourceMaxNumber('This value is out of range.'),
+        ]"
+        v-model="filters.publicIPs"
+      >
+        <template #input="{ props }">
+          <VTextField label="Free Public IPs" variant="outlined" v-model="filters.publicIPs" v-bind="props">
+            <template #append-inner>
+              <VTooltip text="Filter by free Public IPs">
+                <template #activator="{ props }">
+                  <VIcon icon="mdi-information-outline" v-bind="props" />
+                </template>
+              </VTooltip>
+            </template>
+          </VTextField>
+        </template>
+      </TfFilter>
 
       <TfFilter query-route="node-status" v-model="filters.status">
         <v-select
@@ -349,6 +371,7 @@ export default {
       status: "",
       gateway: false,
       gpu: false,
+      publicIPs: "",
     });
 
     const loading = ref<boolean>(true);
@@ -382,6 +405,7 @@ export default {
             totalSru: convertToBytes(filters.value.minSSD),
             hasGpu: filters.value.gpu || undefined,
             domain: filters.value.gateway || undefined,
+            freeIps: +filters.value.publicIPs || undefined,
           },
           { loadFarm: true },
         );


### PR DESCRIPTION
### Description

On the node finder page there is no filter for nodes with free public IP. I think it would save a lot of time instead of using the grid-proxy for that.

### Changes
- added field to filter by free public ips

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2109

![Screenshot from 2024-02-14 13-40-06](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/f37c8122-7004-449f-ad2c-7866dd8d2228)

- Note that there's issue in filtering from gridproxy https://github.com/threefoldtech/tfgrid-sdk-go/issues/808, so the filter is not working right. 
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
