### PR TITLE
Support filtering by min total num of cpus in `node finder`

### DIFF
--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -154,6 +154,28 @@
       </TfFilter>
 
       <TfFilter
+        query-route="min-cpu"
+        v-model="filters.minCRU"
+        :rules="[
+          validators.isNumeric('This field accepts numbers only.'),
+          validators.min('The total number of CPUs should be larger then zero.', 1),
+          validators.validateResourceMaxNumber('This value is out of range.'),
+        ]"
+      >
+        <template #input="{ props }">
+          <VTextField label="Min CPU " variant="outlined" v-model="filters.minCRU" v-bind="props">
+            <template #append-inner>
+              <VTooltip text="Filter by the minimum total number of CPUs in the node.">
+                <template #activator="{ props }">
+                  <VIcon icon="mdi-information-outline" v-bind="props" />
+                </template>
+              </VTooltip>
+            </template>
+          </VTextField>
+        </template>
+      </TfFilter>
+
+      <TfFilter
         query-route="free-ssd"
         v-model="filters.freeSSD"
         :rules="[
@@ -341,6 +363,7 @@ export default {
       minSSD: "",
       minHDD: "",
       minRAM: "",
+      minCRU: "",
       freeSSD: "",
       freeHDD: "",
       freeRAM: "",
@@ -380,6 +403,7 @@ export default {
             totalHru: convertToBytes(filters.value.minHDD),
             totalMru: convertToBytes(filters.value.minRAM),
             totalSru: convertToBytes(filters.value.minSSD),
+            totalCru: +filters.value.minCRU || undefined,
             hasGpu: filters.value.gpu || undefined,
             domain: filters.value.gateway || undefined,
           },


### PR DESCRIPTION
### Description

- Add cpu filter in nodes page.
### Changes
- filter added to filter with min total number of cpus.



### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1724

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
