### PR TITLE
remove /64 from public ipv6 in vms table and k8s table

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -44,7 +44,11 @@
                   :data="contract.publicIP.ip.split('/')[0] || contract.publicIP.ip"
                   v-if="contract.publicIP.ip"
                 />
-                <CopyReadonlyInput label="Public IPv6" :data="contract.publicIP.ip6" v-if="contract.publicIP.ip6" />
+                <CopyReadonlyInput
+                  label="Public IPv6"
+                  :data="contract.publicIP.ip6 ? contract.publicIP.ip6.replace(/\/64$/, '') : '-'"
+                  v-if="contract.publicIP.ip6"
+                />
               </template>
 
               <CopyReadonlyInput label="Planetary Network IP" :data="contract.planetary" v-if="contract.planetary" />

--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -166,7 +166,7 @@ async function loadDeployments() {
   items.value = clusters.items.map((item: any) => {
     item.name = item.deploymentName;
     item.ipv4 = item.masters[0].publicIP?.ip?.split("/")?.[0] || item.masters[0].publicIP?.ip || "None";
-    item.ipv6 = item.masters[0].publicIP?.ip6 || "None";
+    item.ipv6 = item.masters[0].publicIP?.ip6.replace(/\/64$/, "") || "None";
     item.planetary = item.masters[0].planetary || "None";
     item.workersLength = item.workers.length;
     item.billing = item.masters[0].billing;

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -67,7 +67,7 @@
       </template>
 
       <template #[`item.ipv6`]="{ item }">
-        {{ item.value.publicIP?.ip6 || "-" }}
+        {{ item.value.publicIP?.ip6.replace(/\/64$/, "") || "-" }}
       </template>
 
       <template #[`item.planetary`]="{ item }">


### PR DESCRIPTION
### Description

When one deploys via the dashboard and asks for a public IPv6, a /64 is added which brings confusion since it's not required to use the IP.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/0658ae4f-7a3c-4eb7-ac9d-36e847e40a8a)

![Screenshot from 2024-02-15 12-20-37](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/878fb6f4-f3ad-4d59-b774-ef480756578f)

![Screenshot from 2024-02-15 12-21-00](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/8f7569f2-50a3-427f-9a62-1a3f493cdea6)



### Changes

- `/64` removed from table and show details dialog.
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2133
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
