### PR TITLE
Edit SMTP validation

### DIFF
--- a/packages/playground/src/components/smtp_server.vue
+++ b/packages/playground/src/components/smtp_server.vue
@@ -18,13 +18,15 @@
         :value="$props.modelValue.username"
         :rules="[
           validators.required('Email is required.'),
-          validators.isEmail('Please provide a valid email address.'),
+          v => {
+            return isDiscourse ? undefined : validators.isEmail('Please provide a valid email address.')(v);
+          },
         ]"
         #="{ props }"
       >
         <input-tooltip tooltip="SMTP admin email.">
           <v-text-field
-            label="Admin Email"
+            :label="isDiscourse ? 'Admin Email/Username' : 'Admin Email'"
             placeholder="email@example.com"
             v-model="$props.modelValue.username"
             v-bind="props"
@@ -39,7 +41,7 @@
           :rules="[
             validators.required('Password is required.'),
             validators.minLength('Password must be at least 6 characters.', 6),
-            validators.maxLength('Password cannot exceed 15 characters.', 15),
+            validators.maxLength('Password cannot exceed 50 characters.', 50),
             validators.pattern('Password should not contain whitespaces.', {
               pattern: /^[^\s]+$/,
             }),
@@ -132,6 +134,7 @@ defineProps<{
   tls?: boolean;
   email?: boolean;
   persistent?: boolean;
+  isDiscourse?: boolean;
 }>();
 </script>
 

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -88,7 +88,7 @@
       </template>
 
       <template #mail>
-        <SmtpServer v-model="smtp" :persistent="true" :tls="true">
+        <SmtpServer v-model="smtp" :persistent="true" :tls="true" :is-discourse="true">
           Discourse needs SMTP service so please configure these settings properly.
         </SmtpServer>
       </template>


### PR DESCRIPTION
### Description

- Edit discourse SMTP validation

### Changes

- Edit email label in Discourse only
- Loosen email validation in SMTP discourse
- Increase max length for password

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2152

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
