### PR TITLE
Use stats summary on grid capacity cards

### DIFF
--- a/packages/new_stats/nginx/conf.d/default.conf
+++ b/packages/new_stats/nginx/conf.d/default.conf
@@ -10,6 +10,7 @@ server {
         index  index.html index.htm;
     }
     location /api/stats-summary {
+        add_header 'Access-Control-Allow-Origin' '*';
         default_type application/json;
         js_content main.getStats;
     }

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -32,7 +32,7 @@ async function getStats(r) {
   }
 }
 
-function initTargeRequests(urls, r) {
+function initTargeRequests(urls) {
   return urls.map(url =>
     //   eslint-disable-next-line no-undef
     ngx.fetch(url, { verify: false }).then(res => res.json()),
@@ -42,7 +42,7 @@ async function fetchStats(r) {
   let retries = 0;
   const stats = [];
   while (URLS.length !== 0 && retries < RETRIES) {
-    const responses = await Promise.allSettled(initTargeRequests(URLS, r));
+    const responses = await Promise.allSettled(initTargeRequests(URLS));
     const failedURls = [];
     responses.forEach((item, index) => {
       if (item.status === "fulfilled") {

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -35,9 +35,7 @@ async function getStats(r) {
 function initTargeRequests(urls, r) {
   return urls.map(url =>
     //   eslint-disable-next-line no-undef
-    ngx
-      .fetch(url, { verify: r.headersIn["Host"].split(":")[0] !== "localhost" }) // disable ssl on localhost
-      .then(res => res.json()),
+    ngx.fetch(url, { verify: false }).then(res => res.json()),
   );
 }
 async function fetchStats(r) {

--- a/packages/playground/public/config.js
+++ b/packages/playground/public/config.js
@@ -9,6 +9,7 @@ window.env = {
   STELLAR_NETWORK: "test",
   STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
   TFT_ASSET_ISSUER: "GA47YZA3PKFUZMPLQ3B5F2E3CJIB57TGGU7SPCQT2WAEYKN766PWIMB3",
+  STATS_URL: "https://stats.dev.grid.tf",
   MINTING_URL: "",
   TIMEOUT: +"10000",
   PAGE_SIZE: +"20",

--- a/packages/playground/scripts/build-env.sh
+++ b/packages/playground/scripts/build-env.sh
@@ -6,6 +6,7 @@ STELLAR_NETWORK="${STELLAR_NETWORK:=test}"
 TIMEOUT="${TIMEOUT:=10000}"
 PAGE_SIZE="${PAGE_SIZE:=20}"
 MINTING_URL="https://alpha.minting.tfchain.grid.tf"
+STATS_URL="https://stats.grid.tf"
 
 # Env vars must provide in `custom` mode
 REQUIRED_ENV_VARS=(
@@ -31,6 +32,7 @@ case $MODE in
     ACTIVATION_SERVICE_URL='https://activation.dev.grid.tf/activation/activate'
     RELAY_DOMAIN='wss://relay.dev.grid.tf'
     BRIDGE_TFT_ADDRESS=GDHJP6TF3UXYXTNEZ2P36J5FH7W4BJJQ4AYYAXC66I2Q2AH5B6O6BCFG
+    STATS_URL='https://stats.dev.grid.tf'
     STELLAR_NETWORK=test
   ;;
 
@@ -41,6 +43,7 @@ case $MODE in
     ACTIVATION_SERVICE_URL='https://activation.qa.grid.tf/activation/activate'
     RELAY_DOMAIN='wss://relay.qa.grid.tf'
     BRIDGE_TFT_ADDRESS=GAQH7XXFBRWXT2SBK6AHPOLXDCLXVFAKFSOJIRMRNCDINWKHGI6UYVKM
+    STATS_URL='https://stats.qa.grid.tf'
     STELLAR_NETWORK=test
   ;;
 
@@ -51,6 +54,7 @@ case $MODE in
     ACTIVATION_SERVICE_URL='https://activation.test.grid.tf/activation/activate'
     RELAY_DOMAIN='wss://relay.test.grid.tf'
     BRIDGE_TFT_ADDRESS=GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4
+    STATS_URL='https://stats.test.grid.tf'
     STELLAR_NETWORK=main
   ;;
 
@@ -110,6 +114,7 @@ window.env = {
   STELLAR_HORIZON_URL: '$STELLAR_HORIZON_URL',
   TFT_ASSET_ISSUER: '$TFT_ASSET_ISSUER',
   MINTING_URL: '$MINTING_URL',
+  STATS_URL: '$STATS_URL',
   TIMEOUT: +'$TIMEOUT',
   PAGE_SIZE: +'$PAGE_SIZE'
 };

--- a/packages/playground/src/components/connect_wallet_landing.vue
+++ b/packages/playground/src/components/connect_wallet_landing.vue
@@ -89,7 +89,7 @@ import { useRoute } from "vue-router";
 import { useTheme } from "vuetify";
 
 import { DashboardRoutes } from "@/router/routes";
-import { useRequestStore } from "@/stores/stats";
+import { useStatsStore } from "@/stores/stats";
 export default {
   name: "ConnectWalletLanding",
   setup() {
@@ -97,34 +97,12 @@ export default {
     const baseUrl = import.meta.env.BASE_URL;
     const route = useRoute();
     const pageTitle = computed(() => route.meta.title);
-    const statsStore = useRequestStore();
-    const stats = computed(() => [
-      {
-        label: "Capacity",
-        value: statsStore.data?.capacity,
-        image: "capacity.png",
-      },
-      {
-        label: "Nodes",
-        value: statsStore.data?.nodes,
-        image: "nodes.png",
-      },
-      {
-        label: "Countries",
-        value: statsStore.data?.countries,
-        image: "countries.png",
-      },
-      {
-        label: "Cores",
-        value: statsStore.data?.cores,
-        image: "cores.png",
-      },
-    ]);
+    const statsStore = useStatsStore();
     return {
       theme,
       pageTitle,
       DashboardRoutes,
-      stats,
+      stats: computed(() => statsStore.stats),
       statsUrl: window.env.STATS_URL || "https://stats.grid.tf",
       baseUrl,
     };

--- a/packages/playground/src/components/connect_wallet_landing.vue
+++ b/packages/playground/src/components/connect_wallet_landing.vue
@@ -56,9 +56,7 @@
         </div>
 
         <div class="d-flex justify-center mt-5">
-          <v-btn color="primary" target="_blank" @click="$router.push(DashboardRoutes.TFGrid.NodeStatistics)">
-            Explore ThreeFold Grid Capacity
-          </v-btn>
+          <v-btn color="primary" target="_blank" :href="statsUrl"> Explore ThreeFold Grid Capacity </v-btn>
         </div>
       </div>
       <div class="text-center">
@@ -87,47 +85,48 @@
 
 <script lang="ts">
 import { computed } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import { useTheme } from "vuetify";
 
 import { DashboardRoutes } from "@/router/routes";
-
+import { useRequestStore } from "@/stores/stats";
 export default {
   name: "ConnectWalletLanding",
   setup() {
     const theme = useTheme();
     const baseUrl = import.meta.env.BASE_URL;
     const route = useRoute();
-    const $router = useRouter();
     const pageTitle = computed(() => route.meta.title);
+    const statsStore = useRequestStore();
+    const stats = computed(() => [
+      {
+        label: "Capacity",
+        value: statsStore.data?.capacity,
+        image: "capacity.png",
+      },
+      {
+        label: "Nodes",
+        value: statsStore.data?.nodes,
+        image: "nodes.png",
+      },
+      {
+        label: "Countries",
+        value: statsStore.data?.countries,
+        image: "countries.png",
+      },
+      {
+        label: "Cores",
+        value: statsStore.data?.cores,
+        image: "cores.png",
+      },
+    ]);
     return {
       theme,
       pageTitle,
       DashboardRoutes,
-      stats: [
-        {
-          label: "Capacity",
-          value: "33.46PB",
-          image: "capacity.png",
-        },
-        {
-          label: "Nodes",
-          value: "2420",
-          image: "nodes.png",
-        },
-        {
-          label: "Countries",
-          value: "60",
-          image: "countries.png",
-        },
-        {
-          label: "Cores",
-          value: "56,530",
-          image: "cores.png",
-        },
-      ],
+      stats,
+      statsUrl: window.env.STATS_URL || "https://stats.grid.tf",
       baseUrl,
-      $router,
     };
   },
 };

--- a/packages/playground/src/components/logged_in_landing.vue
+++ b/packages/playground/src/components/logged_in_landing.vue
@@ -99,7 +99,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useTheme } from "vuetify";
 
 import { DashboardRoutes } from "@/router/routes";
-import { useRequestStore } from "@/stores/stats";
+import { useStatsStore } from "@/stores/stats";
 
 import { useProfileManager } from "../stores";
 export default {
@@ -111,29 +111,8 @@ export default {
     const $router = useRouter();
     const pageTitle = computed(() => route.meta.title);
     const profileManager = useProfileManager();
-    const statsStore = useRequestStore();
-    const stats = computed(() => [
-      {
-        label: "Capacity",
-        value: statsStore.data?.capacity,
-        image: "capacity.png",
-      },
-      {
-        label: "Nodes",
-        value: statsStore.data?.nodes,
-        image: "nodes.png",
-      },
-      {
-        label: "Countries",
-        value: statsStore.data?.countries,
-        image: "countries.png",
-      },
-      {
-        label: "Cores",
-        value: statsStore.data?.cores,
-        image: "cores.png",
-      },
-    ]);
+    const statsStore = useStatsStore();
+
     const cards = [
       {
         title: "Your Profile",
@@ -177,7 +156,7 @@ export default {
       pageTitle,
       cards,
       profileManager,
-      stats,
+      stats: computed(() => statsStore.stats),
       baseUrl,
       $router,
     };

--- a/packages/playground/src/components/logged_in_landing.vue
+++ b/packages/playground/src/components/logged_in_landing.vue
@@ -99,6 +99,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useTheme } from "vuetify";
 
 import { DashboardRoutes } from "@/router/routes";
+import { useRequestStore } from "@/stores/stats";
 
 import { useProfileManager } from "../stores";
 export default {
@@ -110,7 +111,29 @@ export default {
     const $router = useRouter();
     const pageTitle = computed(() => route.meta.title);
     const profileManager = useProfileManager();
-
+    const statsStore = useRequestStore();
+    const stats = computed(() => [
+      {
+        label: "Capacity",
+        value: statsStore.data?.capacity,
+        image: "capacity.png",
+      },
+      {
+        label: "Nodes",
+        value: statsStore.data?.nodes,
+        image: "nodes.png",
+      },
+      {
+        label: "Countries",
+        value: statsStore.data?.countries,
+        image: "countries.png",
+      },
+      {
+        label: "Cores",
+        value: statsStore.data?.cores,
+        image: "cores.png",
+      },
+    ]);
     const cards = [
       {
         title: "Your Profile",
@@ -154,29 +177,7 @@ export default {
       pageTitle,
       cards,
       profileManager,
-
-      stats: [
-        {
-          label: "Capacity",
-          value: "33.46PB",
-          image: "capacity.png",
-        },
-        {
-          label: "Nodes",
-          value: "2420",
-          image: "nodes.png",
-        },
-        {
-          label: "Countries",
-          value: "60",
-          image: "countries.png",
-        },
-        {
-          label: "Cores",
-          value: "56,530",
-          image: "cores.png",
-        },
-      ],
+      stats,
       baseUrl,
       $router,
     };

--- a/packages/playground/src/global-components.d.ts
+++ b/packages/playground/src/global-components.d.ts
@@ -50,6 +50,7 @@ declare global {
       STELLAR_HORIZON_URL: string;
       TFT_ASSET_ISSUER: string;
       MINTING_URL: string;
+      STATS_URL: string;
       TIMEOUT: number;
       PAGE_SIZE: number;
     };

--- a/packages/playground/src/stores/stats.ts
+++ b/packages/playground/src/stores/stats.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { computed } from "vue";
 
 import { useAsync } from "@/hooks";
-const url = window.env.STATS_URL || "https://stats.grid.tf/";
+const url = window.env.STATS_URL || "https://stats.grid.tf";
 
 export const useRequestStore = defineStore("request-store", () => {
   const res = useAsync(() => fetch(url + "/api/stats-summary").then(resp => resp.json()), {

--- a/packages/playground/src/stores/stats.ts
+++ b/packages/playground/src/stores/stats.ts
@@ -4,10 +4,35 @@ import { computed } from "vue";
 import { useAsync } from "@/hooks";
 const url = window.env.STATS_URL || "https://stats.grid.tf";
 
-export const useRequestStore = defineStore("request-store", () => {
+export const useStatsStore = defineStore("stats-store", () => {
   const res = useAsync(() => fetch(url + "/api/stats-summary").then(resp => resp.json()), {
     init: true,
   });
   const data = computed(() => res.value.data);
-  return { data };
+  const stats = computed(() => [
+    {
+      label: "Capacity",
+      value: data.value?.capacity,
+      image: "capacity.png",
+    },
+    {
+      label: "Nodes",
+      value: data.value?.nodes,
+      image: "nodes.png",
+    },
+    {
+      label: "Countries",
+      value: data.value?.countries,
+      image: "countries.png",
+    },
+    {
+      label: "Cores",
+      value: data.value?.cores,
+      image: "cores.png",
+    },
+  ]);
+  return {
+    data,
+    stats,
+  };
 });

--- a/packages/playground/src/stores/stats.ts
+++ b/packages/playground/src/stores/stats.ts
@@ -1,0 +1,13 @@
+import { defineStore } from "pinia";
+import { computed } from "vue";
+
+import { useAsync } from "@/hooks";
+const url = window.env.STATS_URL || "https://stats.grid.tf/";
+
+export const useRequestStore = defineStore("request-store", () => {
+  const res = useAsync(() => fetch(url + "/summary").then(resp => resp.json()), {
+    init: true,
+  });
+  const data = computed(() => res.value.data);
+  return { data };
+});

--- a/packages/playground/src/stores/stats.ts
+++ b/packages/playground/src/stores/stats.ts
@@ -5,7 +5,7 @@ import { useAsync } from "@/hooks";
 const url = window.env.STATS_URL || "https://stats.grid.tf/";
 
 export const useRequestStore = defineStore("request-store", () => {
-  const res = useAsync(() => fetch(url + "/summary").then(resp => resp.json()), {
+  const res = useAsync(() => fetch(url + "/api/stats-summary").then(resp => resp.json()), {
     init: true,
   });
   const data = computed(() => res.value.data);


### PR DESCRIPTION
### Description

use stats summary endpoint to fetch the landing page cards data, those data will be stored in stats store to access them from different pages 

### Changes

  - use stats-summary endpoint to fetch grid stats data
  - add stats store to store stats summary
  - make explore grid redirect to stats website
  - add stats url to build-env script and configs, also added to
  - enable CORS from all origins on stats summary endpoint

### Related Issues
- #1981 
- #2179 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
