### PR TITLE
Make cpu & mem values optional in rootFs

### DIFF
--- a/packages/playground/src/utils/root_fs.ts
+++ b/packages/playground/src/utils/root_fs.ts
@@ -2,11 +2,15 @@ import { Decimal } from "decimal.js";
 
 const GB = 1024;
 
-export default function rootFs(cpu_in_cores: number, mem_in_mb: number): number {
-  const cu = new Decimal(cpu_in_cores)
-    .mul(mem_in_mb)
-    .divToInt(8 * GB)
-    .toNumber();
+export default function rootFs(cpu_in_cores?: number, mem_in_mb?: number): number {
+  let cu = 0;
+
+  if (cpu_in_cores && mem_in_mb) {
+    cu = new Decimal(cpu_in_cores)
+      .mul(mem_in_mb)
+      .divToInt(8 * GB)
+      .toNumber();
+  }
 
   return cu === 0 ? 500 / GB : 2;
 }


### PR DESCRIPTION
### Description

The issue happened because undefined case was not handled in case of CPU & memory. Fixed by making them optional and assigning default cu to 0.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2154

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
