### PR TITLE
Trigger Minting hash validation before clicking view 

### DIFF
--- a/packages/playground/src/views/minting_view.vue
+++ b/packages/playground/src/views/minting_view.vue
@@ -23,6 +23,7 @@
             v-model="receiptHash"
             v-bind="{ ...validationProps }"
             :loading="loading"
+            @update:modelValue="reset"
         /></InputValidator>
       </FormValidator>
     </v-form>
@@ -176,7 +177,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from "vue";
+import { ref } from "vue";
 
 import type { AsyncRule, RuleReturn } from "@/components/input_validator.vue";
 import { useInputRef } from "@/hooks/input_validator";
@@ -214,13 +215,6 @@ function mintingHash(): AsyncRule {
 
   return asyncValidator;
 }
-
-watch(
-  () => receiptHash.value,
-  () => {
-    reset();
-  },
-);
 </script>
 
 <style scoped>

--- a/packages/playground/src/views/minting_view.vue
+++ b/packages/playground/src/views/minting_view.vue
@@ -172,10 +172,6 @@
         </v-list>
       </v-card>
     </v-container>
-
-    <v-alert type="error" variant="tonal" class="mt-2 mb-4" v-if="noData">
-      {{ noData }}
-    </v-alert>
   </view-layout>
 </template>
 
@@ -185,14 +181,12 @@ import { ref, watch } from "vue";
 import type { AsyncRule, RuleReturn } from "@/components/input_validator.vue";
 import { useInputRef } from "@/hooks/input_validator";
 
-import { normalizeError } from "../utils/helpers";
 import { getMintingData } from "../utils/mintings";
 
 const receiptHash = ref();
 const isValidForm = ref(false);
 const hashInput = useInputRef();
 const loading = ref(false);
-const noData = ref<string | null>(null);
 const item = ref();
 const mintNodeInfoHeaders = ["ID", "Farm", "Measured Uptime"];
 const fixupNodeInfoHeaders = ["ID", "Farm"];
@@ -203,7 +197,6 @@ const fixupPayoutHeaders = ["TFT Received", "TFT Owed", "Additional TFT Minted",
 
 function reset() {
   item.value = null;
-  noData.value = null;
 }
 function mintingHash(): AsyncRule {
   const asyncValidator: AsyncRule = async (): Promise<RuleReturn> => {
@@ -213,8 +206,7 @@ function mintingHash(): AsyncRule {
       item.value = await getMintingData(receiptHash.value);
       return { message: "" };
     } catch (e) {
-      noData.value = normalizeError(e, "Something went wrong while fetching data.");
-      return { message: "Failed to fetch minting data" };
+      return { message: "Receipt not found." };
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
### Description

The validation for minting should be initiated before clicking the view button.

Not only should the validation check the hash's length, but also if the hash is valid or not.
### Changes

- Make all validations done before clicking view.
- Found that if hash valid will appear automatically, then there's no need for view button.
### Related Issues

#1848 

[Screencast from 02-19-2024 02:01:36 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/2c401fe4-d4a0-4cc0-8bb0-944bed67d2bd)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
