### PR TITLE
Cache twin data on connect

### DIFF
--- a/packages/rmb_direct_client/lib/types/lib/types.ts
+++ b/packages/rmb_direct_client/lib/types/lib/types.ts
@@ -933,3 +933,11 @@ export class Envelope extends pb_1.Message {
     return Envelope.deserialize(bytes);
   }
 }
+
+export interface Twin {
+  id: number;
+  accountId: string;
+  relay: string;
+  entities: string[];
+  pk: string;
+}


### PR DESCRIPTION
### Description

Describe the changes introduced by this PR and what does it affect

### Changes

- Cache twin data on connect, use cached twin when send envelope

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2137

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
