### PR TITLE
support reserving standby Nodes from dedicated machines

### DIFF
--- a/packages/playground/src/dashboard/dedicated_nodes_view.vue
+++ b/packages/playground/src/dashboard/dedicated_nodes_view.vue
@@ -162,7 +162,7 @@
 </template>
 
 <script lang="ts" setup>
-import { NodeStatus } from "@threefold/gridproxy_client";
+import { type GridNode, NodeStatus, type Pagination } from "@threefold/gridproxy_client";
 import { CertificationType } from "@threefold/gridproxy_client";
 import { ref } from "vue";
 
@@ -190,6 +190,11 @@ const tabParams = {
     rentedBy: profileManager.profile?.twinId,
     retCount: true,
   },
+  2: {
+    rentable: true,
+    status: NodeStatus.Standby,
+    retCount: true,
+  },
 };
 
 const size = ref(window.env.PAGE_SIZE);
@@ -209,8 +214,24 @@ const updateActiveTabValue = (newValue: number) => {
   loadNodes();
 };
 
+async function listNodes(params: any) {
+  const response = await gridProxyClient.nodes.list({
+    ...params,
+    size: size.value,
+    page: page.value,
+    totalSru: convert(filters.value.minSSD),
+    totalMru: convert(filters.value.minRAM),
+    totalHru: convert(filters.value.minHDD),
+    totalCru: +filters.value.minCPU || undefined,
+    gpuVendorName: filters.value.gpuVendorName || undefined,
+    gpuDeviceName: filters.value.gpuDeviceName || undefined,
+    hasGpu: filters.value.gpu || undefined,
+  });
+  return response || [];
+}
+
 async function loadNodes() {
-  const params = tabParams[activeTab.value as keyof typeof tabParams];
+  let params = tabParams[activeTab.value as keyof typeof tabParams];
 
   if (!params) {
     return;
@@ -223,20 +244,20 @@ async function loadNodes() {
   }
 
   loading.value = true;
-
+  let data: Pagination<GridNode[]>;
   try {
-    const data = await gridProxyClient.nodes.list({
-      ...params,
-      size: size.value,
-      page: page.value,
-      totalSru: convert(filters.value.minSSD),
-      totalMru: convert(filters.value.minRAM),
-      totalHru: convert(filters.value.minHDD),
-      totalCru: +filters.value.minCPU || undefined,
-      gpuVendorName: filters.value.gpuVendorName || undefined,
-      gpuDeviceName: filters.value.gpuDeviceName || undefined,
-      hasGpu: filters.value.gpu || undefined,
-    });
+    if (activeTab.value === 0) {
+      const onlineNodes = await listNodes(params);
+      params = tabParams[2];
+      const standbyNodes = await listNodes(params);
+      const allNodes = onlineNodes.data.concat(standbyNodes.data);
+      data = {
+        count: (onlineNodes.count ?? 0) + (standbyNodes.count ?? 0),
+        data: allNodes,
+      };
+    } else {
+      data = await listNodes(params);
+    }
 
     if (data.count === 0) {
       loading.value = false;

--- a/packages/playground/src/dashboard/dedicated_nodes_view.vue
+++ b/packages/playground/src/dashboard/dedicated_nodes_view.vue
@@ -231,7 +231,7 @@ async function listNodes(params: any) {
 }
 
 async function loadNodes() {
-  let params = tabParams[activeTab.value as keyof typeof tabParams];
+  const params = tabParams[activeTab.value as keyof typeof tabParams];
 
   if (!params) {
     return;
@@ -248,8 +248,7 @@ async function loadNodes() {
   try {
     if (activeTab.value === 0) {
       const onlineNodes = await listNodes(params);
-      params = tabParams[2];
-      const standbyNodes = await listNodes(params);
+      const standbyNodes = await listNodes(tabParams[2]);
       const allNodes = onlineNodes.data.concat(standbyNodes.data);
       data = {
         count: (onlineNodes.count ?? 0) + (standbyNodes.count ?? 0),


### PR DESCRIPTION
### Description

currently, the dashboard allows renting only the online nodes, but now https://github.com/threefoldtech/tfchain/issues/923 and the famerbot can wake the rented node up if the farm has an up-and-running farmerbot (can ping the farmerbot before renting to make sure it's running). So besides showing the online nodes, the dashboard should also show the standby nodes.
### Changes

- from rentable tab, all nodes will be online and standby nodes.
### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2143

- Note that there'so screenshots as for now no standby nodes available for renting.
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
