### PR TITLE
Check farm has enough public ips before creating the extrinsics 

### DIFF
--- a/packages/grid_client/scripts/config.json
+++ b/packages/grid_client/scripts/config.json
@@ -1,6 +1,6 @@
 {
   "network": "dev",
-  "mnemonic": "",
+  "mnemonic": "oven strong mention shoulder night ghost correct exercise surge lady jungle hundred",
   "storeSecret": "",
-  "ssh_key": ""
+  "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCWEPpx461ry8WlHbkpELC8y1O/xVdVcTKbJmeMqCBj3uSUysVx3KNwZFWK4vs5yZ0N1MU9s2tu7lEZ2Ry9wrXTcBHIvGf17S5cZVasNBg5SQO6GlkYnag2769JIeO5Za/P8J9TZ63ON0G4udUwdsUz+335oA3hbTHjQ7mMDiMgEIvHeJYex5Oq6ClkLjoomunnWDqnWMb5MCB8Cf5JNzIXVuoO3YGI7GWYldIPaw+tnwlqysj/qyN7rpGC6njWa2mntd1QHevPEE4AXAclniJ8XzZUWyXXmexYqeeP3Ld4+U5oiCa1zViN5eN/+z2dNCAq1u71VOWxBQVmkkRWbe+byb8QIEDpIacetpFTch9nuVLG2GfWVCaWSSPszeBcX+7H6pf/hfFpiQDrBu0ai9IB/WbjIKzX6sI/RAWXW8T60+U6SWyO52AE0QVJp+G4S09q8wfOXZOz/ap+AJm0ZujXIu/qXvO3iLUTK4XFFQsGyiHLlTRfPWB+cc2YJ/pCsCk= alaa@alaa-Inspiron-3576"
 }

--- a/packages/grid_client/scripts/config.json
+++ b/packages/grid_client/scripts/config.json
@@ -1,6 +1,6 @@
 {
   "network": "dev",
-  "mnemonic": "oven strong mention shoulder night ghost correct exercise surge lady jungle hundred",
+  "mnemonic": "",
   "storeSecret": "",
-  "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCWEPpx461ry8WlHbkpELC8y1O/xVdVcTKbJmeMqCBj3uSUysVx3KNwZFWK4vs5yZ0N1MU9s2tu7lEZ2Ry9wrXTcBHIvGf17S5cZVasNBg5SQO6GlkYnag2769JIeO5Za/P8J9TZ63ON0G4udUwdsUz+335oA3hbTHjQ7mMDiMgEIvHeJYex5Oq6ClkLjoomunnWDqnWMb5MCB8Cf5JNzIXVuoO3YGI7GWYldIPaw+tnwlqysj/qyN7rpGC6njWa2mntd1QHevPEE4AXAclniJ8XzZUWyXXmexYqeeP3Ld4+U5oiCa1zViN5eN/+z2dNCAq1u71VOWxBQVmkkRWbe+byb8QIEDpIacetpFTch9nuVLG2GfWVCaWSSPszeBcX+7H6pf/hfFpiQDrBu0ai9IB/WbjIKzX6sI/RAWXW8T60+U6SWyO52AE0QVJp+G4S09q8wfOXZOz/ap+AJm0ZujXIu/qXvO3iLUTK4XFFQsGyiHLlTRfPWB+cc2YJ/pCsCk= alaa@alaa-Inspiron-3576"
+  "ssh_key": ""
 }


### PR DESCRIPTION
### Description


Alongside checking the node resources before proceeding with creating the extrinsic, we should check if the deployments require public IPs and validate that against the farm.


### Changes
checking if farm has enough public ip for each vm , while creating deployment.
This won't make huge difference from playground as if there're no public ips, no nodes will appear,  but from scripts it will be checked before creating deployment.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1822 

![Screenshot from 2024-02-21 12-18-45](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/f453d05e-2c15-4a87-ab4b-f260a2057cf8)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
