### PR TITLE
fix tft to USD conversion should be multiplied not divided

### DIFF
--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -126,7 +126,7 @@ async function onMount() {
         nodeStatus.value = await getNodeStatus(nodeIDs.value);
         totalCost.value = getTotalCost(contracts.value);
         const TFTInUSD = await queryClient.tftPrice.get();
-        totalCostUSD.value = totalCost.value / TFTInUSD;
+        totalCostUSD.value = totalCost.value * TFTInUSD;
       } catch (error: any) {
         // Handle errors and display toast messages
         loadingErrorMessage.value = error.message;


### PR DESCRIPTION
### Description

The conversion was wrong
### Changes

- Instead of dividing by the value of tft in usd, it should be multiplied
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2234
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
