### PR TITLE
Fix adding public config

### DIFF
--- a/packages/playground/src/dashboard/components/public_config.vue
+++ b/packages/playground/src/dashboard/components/public_config.vue
@@ -269,6 +269,7 @@ export default {
         defualtNodeConfig.value = config.value = publicConfigInitializer();
         context.emit("remove-config", config.value);
         showDialogue.value = false;
+        config.value = publicConfigInitializer();
       } catch (error) {
         console.log(error);
         createCustomToast(`Failed to remove config. ${error}`, ToastType.danger);


### PR DESCRIPTION
### Description

After removing the public config IPs, I can't add them again.

### Changes

- The problem was that config didn't get default values
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1855

[Screencast from 02-26-2024 12:46:34 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/82c6bf89-99ef-45a8-9228-d153307ccc50)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
