### PR TITLE
Improve stats requests and error handling

### DIFF
--- a/packages/new_stats/src/components/network_filter.vue
+++ b/packages/new_stats/src/components/network_filter.vue
@@ -40,6 +40,7 @@
             style="min-width: fit-content"
             hide-details
             color="primary"
+            :disabled="loading"
             :model-value="network.value"
             @update:model-value="updateNetworks($event, index)"
             inset

--- a/packages/new_stats/src/utils/stats.ts
+++ b/packages/new_stats/src/utils/stats.ts
@@ -43,12 +43,15 @@ function mergeStatsData(stats: Stats[]): Stats {
   return res;
 }
 
-export async function getStats(network: Network): Promise<Stats> {
+export async function getStats(network: Network): Promise<{ network: Network; stats: Stats }> {
   try {
     const client = new GridProxyClient(network);
     const upStats = await client.stats.get({ status: NodeStatus.Up });
     const standbyStats = await client.stats.get({ status: NodeStatus.Standby });
-    return mergeStatsData([upStats, standbyStats]);
+    return {
+      network,
+      stats: mergeStatsData([upStats, standbyStats]),
+    };
   } catch (error) {
     throw new Error(`Failed to retrieve ${network} network statistics: ${error}`);
   }


### PR DESCRIPTION

### Description

The old scenario was showing the fulfilled results, and whenever any request failed, it showed an error message,
now we are waiting for all requests, store the fulfilled results, and showing an error if any of requests fail 

### Changes

- Update: Modify getStats to return an object containing network and stats.
- Update: Implement Promise.allSettled to manage errors and update fulfilled requests.
- Update: disable toggles during loading phase.


### Related Issues

#2229 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
