### PR TITLE
support mycelium with yggdrasil

### DIFF
--- a/packages/grid_client/scripts/single_vm.ts
+++ b/packages/grid_client/scripts/single_vm.ts
@@ -27,14 +27,14 @@ async function main() {
   const grid3 = await getClient();
 
   const vms: MachinesModel = {
-    name: "newVMS220",
+    name: "newVMS",
     network: {
-      name: "wedtest220",
+      name: "wedtest",
       ip_range: "10.249.0.0/16",
     },
     machines: [
       {
-        name: "testvm220",
+        name: "testvm",
         node_id: 11,
         disks: [
           {
@@ -62,7 +62,7 @@ async function main() {
   };
 
   //Deploy VMs
-  // await deploy(grid3, vms);
+  await deploy(grid3, vms);
 
   //Get the deployment
   await getDeployment(grid3, vms.name);

--- a/packages/grid_client/scripts/single_vm.ts
+++ b/packages/grid_client/scripts/single_vm.ts
@@ -27,14 +27,14 @@ async function main() {
   const grid3 = await getClient();
 
   const vms: MachinesModel = {
-    name: "newVMS",
+    name: "newVMS220",
     network: {
-      name: "wedtest",
+      name: "wedtest220",
       ip_range: "10.249.0.0/16",
     },
     machines: [
       {
-        name: "testvm",
+        name: "testvm220",
         node_id: 11,
         disks: [
           {
@@ -46,7 +46,7 @@ async function main() {
         public_ip: false,
         public_ip6: false,
         planetary: true,
-        mycelium: false,
+        mycelium: true,
         cpu: 1,
         memory: 1024 * 2,
         rootfs_size: 0,
@@ -62,7 +62,7 @@ async function main() {
   };
 
   //Deploy VMs
-  await deploy(grid3, vms);
+  // await deploy(grid3, vms);
 
   //Get the deployment
   await getDeployment(grid3, vms.name);

--- a/packages/grid_client/scripts/single_vm.ts
+++ b/packages/grid_client/scripts/single_vm.ts
@@ -46,7 +46,7 @@ async function main() {
         public_ip: false,
         public_ip6: false,
         planetary: true,
-        mycelium: true,
+        mycelium: false,
         cpu: 1,
         memory: 1024 * 2,
         rootfs_size: 0,

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -220,6 +220,7 @@ class BaseModule {
 
   async _getZmachineData(deploymentName: string, deployments, workload: Workload): Promise<Record<string, unknown>> {
     const data = workload.data as Zmachine;
+    const resultData = workload.result.data as ZmachineResult;
     return {
       version: workload.version,
       contractId: workload["contractId"],
@@ -230,10 +231,8 @@ class BaseModule {
       message: workload.result.message,
       flist: data.flist,
       publicIP: await this._getMachinePubIP(deploymentName, deployments, data.network.public_ip),
-      planetary: data.network.planetary
-        ? (workload.result.data as ZmachineResult).planetary_ip
-        : (workload.result.data as ZmachineResult).ygg_ip,
-      myceliumIP: data.network.mycelium.hex_seed ? (workload.result.data as ZmachineResult).mycelium_ip : "",
+      planetary: data.network.planetary ? resultData.planetary_ip : resultData.ygg_ip,
+      myceliumIP: data.network.mycelium?.hex_seed ? resultData.mycelium_ip : "",
       interfaces: data.network.interfaces.map(n => ({
         network: n.network,
         ip: n.ip,

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -231,8 +231,9 @@ class BaseModule {
       flist: data.flist,
       publicIP: await this._getMachinePubIP(deploymentName, deployments, data.network.public_ip),
       planetary: data.network.planetary
-        ? (workload.result.data as ZmachineResult).ygg_ip || (workload.result.data as ZmachineResult).planetary_ip
-        : "",
+        ? (workload.result.data as ZmachineResult).planetary_ip
+        : (workload.result.data as ZmachineResult).ygg_ip,
+      myceliumIP: data.network.mycelium.hex_seed ? (workload.result.data as ZmachineResult).mycelium_ip : "",
       interfaces: data.network.interfaces.map(n => ({
         network: n.network,
         ip: n.ip,

--- a/packages/grid_client/src/zos/zmachine.ts
+++ b/packages/grid_client/src/zos/zmachine.ts
@@ -97,6 +97,7 @@ class ZmachineResult extends WorkloadDataResult {
   @Expose() ip: string;
   @Expose() ygg_ip: string;
   @Expose() planetary_ip: string;
+  @Expose() mycelium_ip: string;
 }
 
 export { Zmachine, ZmachineNetwork, ZNetworkInterface, Mount, ZmachineResult, MyceliumIP };

--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -48,6 +48,7 @@
               </template>
 
               <CopyReadonlyInput label="Planetary Network IP" :data="contract.planetary" v-if="contract.planetary" />
+              <CopyReadonlyInput label="Mycelium Network IP" :data="contract.myceliumIP" v-if="contract.myceliumIP" />
 
               <CopyReadonlyInput label="Network Name" :data="contract.interfaces[0].network" />
               <CopyReadonlyInput label="CPU (vCores)" :data="contract.capacity.cpu" />

--- a/packages/playground/src/components/k8s_deployment_table.vue
+++ b/packages/playground/src/components/k8s_deployment_table.vue
@@ -66,6 +66,7 @@
         { title: 'Public IPv4', key: 'ipv4', sortable: false },
         { title: 'Public IPv6', key: 'ipv6', sortable: false },
         { title: 'Planetary Network IP', key: 'planetary', sortable: false },
+        { title: 'Mycelium Network IP', key: 'mycelium', sortable: false },
         { title: 'Workers', key: 'workersLength' },
         { title: 'Billing Rate', key: 'billing' },
         { title: 'Created At', key: 'created' },
@@ -83,6 +84,11 @@
       <template #[`item.created`]="{ item }">
         {{ toHumanDate(item.value.masters[0].created) }}
       </template>
+
+      <template #[`item.mycelium`]="{ item }">
+        {{ item.value.myceliumIP || "-" }}
+      </template>
+
       <template #[`item.status`]="{ item }">
         <v-chip :color="getNodeHealthColor(item.value.masters[0].status as string).color">
           <v-tooltip v-if="item.value.masters[0].status == NodeHealth.Error" activator="parent" location="top">{{

--- a/packages/playground/src/components/manage_k8s_worker_dialog.vue
+++ b/packages/playground/src/components/manage_k8s_worker_dialog.vue
@@ -16,6 +16,7 @@
           { title: 'Contract ID', key: 'contractId' },
           { title: 'Name', key: 'name' },
           { title: 'Planetary Network IP', key: 'planetary' },
+          { title: 'Mycelium Network IP', key: 'mycelium' },
           { title: 'CPU(vCores)', key: 'capacity.cpu' },
           { title: 'Memory(MB)', key: 'capacity.memory' },
           { title: 'Disk(GB)', key: 'disk' },
@@ -31,6 +32,9 @@
 
         <template #[`item.disk`]="{ item }">
           {{ calcDiskSize(item.value.mounts) }}
+        </template>
+        <template #[`item.mycelium`]="{ item }">
+          {{ item.value.myceliumIP || "-" }}
         </template>
       </ListTable>
     </template>

--- a/packages/playground/src/components/networks.vue
+++ b/packages/playground/src/components/networks.vue
@@ -141,22 +141,6 @@ export default {
     ) {
       throw new Error("You must provide at least one network  option");
     }
-    watch(
-      () => props.mycelium,
-      newValue => {
-        if (newValue) {
-          emit("update:planetary", true);
-        }
-      },
-    );
-    watch(
-      () => props.planetary,
-      val => {
-        if (!val && props.mycelium) {
-          emit("update:mycelium", false);
-        }
-      },
-    );
     const error = computed(
       () => !(props.ipv4 || props.ipv6 || props.planetary || props.wireguard || props.mycelium) && props.required,
     );

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -74,6 +74,10 @@
         {{ item.value.planetary || "-" }}
       </template>
 
+      <template #[`item.mycelium`]="{ item }">
+        {{ item.value.myceliumIP || "-" }}
+      </template>
+
       <template #[`item.wireguard`]="{ item }">
         {{ item.value.interfaces[0].ip || "-" }}
       </template>
@@ -219,6 +223,7 @@ const filteredHeaders = computed(() => {
     { title: "Public IPv4", key: "ipv4", sortable: false },
     { title: "Public IPv6", key: "ipv6", sortable: false },
     { title: "Planetary Network IP", key: "planetary", sortable: false },
+    { title: "Mycelium Network IP", key: "mycelium", sortable: false },
     { title: "WireGuard", key: "wireguard", sortable: false },
     { title: "Flist", key: "flist" },
     { title: "Cost", key: "billing" },


### PR DESCRIPTION
### Description

- Support mycelium beside yggdrasil
### Changes
- support mycelium in zmachine from grid_client.
- myceliumIP will be in indpendent field not in planetary.
- handle the same from playground. 
- add `Mycelium Network IP` new field in deployment tables.

![Screenshot from 2024-02-26 15-39-19](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/d19084b6-3367-4bb1-acf8-6b76a4e60975)

![Screenshot from 2024-02-26 15-29-38](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/62b12b95-3413-403f-aa3e-629c56847a41)

[Screencast from 02-26-2024 03:26:50 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/508ac47b-33e9-4a11-9b5f-1f27ddb635f3)

![Screenshot from 2024-02-26 15-26-30](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/496567ef-a4e5-4527-9d1c-9c66492b3161)

![Screenshot from 2024-02-26 15-24-32](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/5d72423a-ead1-4921-9ae7-f293f9dc680a)
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2251



### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2251

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
