### PR TITLE
Using default urls if env vars are'nt avaliable

### DIFF
--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -67,11 +67,21 @@ class GridClient {
       backendStorageType: clientOptions.backendStorageType ? clientOptions.backendStorageType : BackendStorageType.auto,
       deploymentTimeoutMinutes: clientOptions.deploymentTimeoutMinutes ? clientOptions.deploymentTimeoutMinutes : 10,
     };
-    this.clientOptions.substrateURL = clientOptions.substrateURL;
-    this.clientOptions.proxyURL = clientOptions.proxyURL;
-    this.clientOptions.graphqlURL = clientOptions.graphqlURL;
-    this.clientOptions.activationURL = clientOptions.activationURL;
-    this.clientOptions.relayURL = clientOptions.relayURL;
+
+    if (
+      this.clientOptions.network === NetworkEnv.dev ||
+      this.clientOptions.network === NetworkEnv.qa ||
+      this.clientOptions.network === NetworkEnv.test ||
+      this.clientOptions.network === NetworkEnv.main
+    ) {
+      this.clientOptions.substrateURL = clientOptions.substrateURL;
+      this.clientOptions.proxyURL = clientOptions.proxyURL;
+      this.clientOptions.graphqlURL = clientOptions.graphqlURL;
+      this.clientOptions.activationURL = clientOptions.activationURL;
+      this.clientOptions.relayURL = clientOptions.relayURL;
+    } else {
+      throw new Error("Unknown NETWORK selected! Acceptable networks are [dev | qa | test | main ]");
+    }
   }
   async connect(): Promise<void> {
     const urls = this.getDefaultUrls(this.clientOptions.network);
@@ -158,44 +168,51 @@ class GridClient {
 
   getDefaultUrls(network: NetworkEnv): Record<string, string> {
     const urls = { rmbProxy: "", substrate: "", graphql: "", activation: "", relay: "" };
-    if (
-      !this.clientOptions.proxyURL ||
-      !this.clientOptions.relayURL ||
-      !this.clientOptions.substrateURL ||
-      !this.clientOptions.graphqlURL ||
-      !this.clientOptions.activationURL
-    ) {
-      if (network === NetworkEnv.dev) {
-        urls.rmbProxy = "https://gridproxy.dev.grid.tf";
-        urls.relay = "wss://relay.dev.grid.tf";
-        urls.substrate = "wss://tfchain.dev.grid.tf/ws";
-        urls.graphql = "https://graphql.dev.grid.tf/graphql";
-        urls.activation = "https://activation.dev.grid.tf/activation/activate";
-      } else if (network === NetworkEnv.test) {
-        urls.rmbProxy = "https://gridproxy.test.grid.tf";
-        urls.relay = "wss://relay.test.grid.tf";
-        urls.substrate = "wss://tfchain.test.grid.tf/ws";
-        urls.graphql = "https://graphql.test.grid.tf/graphql";
-        urls.activation = "https://activation.test.grid.tf/activation/activate";
-      } else if (network === NetworkEnv.qa) {
-        urls.rmbProxy = "https://gridproxy.qa.grid.tf";
-        urls.relay = "wss://relay.qa.grid.tf";
-        urls.substrate = "wss://tfchain.qa.grid.tf/ws";
-        urls.graphql = "https://graphql.qa.grid.tf/graphql";
-        urls.activation = "https://activation.qa.grid.tf/activation/activate";
-      } else if (network === NetworkEnv.main) {
-        urls.rmbProxy = "https://gridproxy.grid.tf";
-        urls.relay = "wss://relay.grid.tf";
-        urls.substrate = "wss://tfchain.grid.tf/ws";
-        urls.graphql = "https://graph.grid.tf/graphql";
-        urls.activation = "https://activation.grid.tf/activation/activate";
-      }
-    } else {
-      urls.rmbProxy = this.clientOptions.proxyURL!;
-      urls.relay = this.clientOptions.relayURL!;
-      urls.substrate = this.clientOptions.substrateURL!;
-      urls.graphql = this.clientOptions.graphqlURL!;
-      urls.activation = this.clientOptions.activationURL!;
+
+    if (network === NetworkEnv.dev) {
+      urls.rmbProxy = this.clientOptions.proxyURL ? this.clientOptions.proxyURL : "https://gridproxy.dev.grid.tf";
+      urls.relay = this.clientOptions.relayURL ? this.clientOptions.relayURL : "wss://relay.dev.grid.tf";
+      urls.substrate = this.clientOptions.substrateURL
+        ? this.clientOptions.substrateURL
+        : "wss://tfchain.dev.grid.tf/ws";
+      urls.graphql = this.clientOptions.graphqlURL
+        ? this.clientOptions.graphqlURL
+        : "https://graphql.dev.grid.tf/graphql";
+      urls.activation = this.clientOptions.activationURL
+        ? this.clientOptions.activationURL
+        : "https://activation.dev.grid.tf/activation/activate";
+    } else if (network === NetworkEnv.test) {
+      urls.rmbProxy = this.clientOptions.proxyURL ? this.clientOptions.proxyURL : "https://gridproxy.test.grid.tf";
+      urls.relay = this.clientOptions.relayURL ? this.clientOptions.relayURL : "wss://relay.test.grid.tf";
+      urls.substrate = this.clientOptions.substrateURL
+        ? this.clientOptions.substrateURL
+        : "wss://tfchain.test.grid.tf/ws";
+      urls.graphql = this.clientOptions.graphqlURL
+        ? this.clientOptions.graphqlURL
+        : "https://graphql.test.grid.tf/graphql";
+      urls.activation = this.clientOptions.activationURL
+        ? this.clientOptions.activationURL
+        : "https://activation.test.grid.tf/activation/activate";
+    } else if (network === NetworkEnv.qa) {
+      urls.rmbProxy = this.clientOptions.proxyURL ? this.clientOptions.proxyURL : "https://gridproxy.qa.grid.tf";
+      urls.relay = this.clientOptions.relayURL ? this.clientOptions.relayURL : "wss://relay.qa.grid.tf";
+      urls.substrate = this.clientOptions.substrateURL
+        ? this.clientOptions.substrateURL
+        : "wss://tfchain.qa.grid.tf/ws";
+      urls.graphql = this.clientOptions.graphqlURL
+        ? this.clientOptions.graphqlURL
+        : "https://graphql.qa.grid.tf/graphql";
+      urls.activation = this.clientOptions.activationURL
+        ? this.clientOptions.activationURL
+        : "https://activation.qa.grid.tf/activation/activate";
+    } else if (network === NetworkEnv.main) {
+      urls.rmbProxy = this.clientOptions.proxyURL ? this.clientOptions.proxyURL : "https://gridproxy.grid.tf";
+      urls.relay = this.clientOptions.relayURL ? this.clientOptions.relayURL : "wss://relay.grid.tf";
+      urls.substrate = this.clientOptions.substrateURL ? this.clientOptions.substrateURL : "wss://tfchain.grid.tf/ws";
+      urls.graphql = this.clientOptions.graphqlURL ? this.clientOptions.graphqlURL : "https://graph.grid.tf/graphql";
+      urls.activation = this.clientOptions.activationURL
+        ? this.clientOptions.activationURL
+        : "https://activation.grid.tf/activation/activate";
     }
     return urls;
   }

--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -67,30 +67,11 @@ class GridClient {
       backendStorageType: clientOptions.backendStorageType ? clientOptions.backendStorageType : BackendStorageType.auto,
       deploymentTimeoutMinutes: clientOptions.deploymentTimeoutMinutes ? clientOptions.deploymentTimeoutMinutes : 10,
     };
-    if (
-      !(
-        this.clientOptions.network === NetworkEnv.dev ||
-        this.clientOptions.network === NetworkEnv.qa ||
-        this.clientOptions.network === NetworkEnv.test ||
-        this.clientOptions.network === NetworkEnv.main
-      )
-    ) {
-      if (
-        !clientOptions.substrateURL ||
-        !clientOptions.proxyURL ||
-        !clientOptions.graphqlURL ||
-        !clientOptions.activationURL ||
-        !clientOptions.relayURL
-      )
-        //TODO throw a grid client error when its pr got merged
-        throw new Error("In Case of using a custom network, Must provide urls in GridClientOptions");
-      this.clientOptions.network = NetworkEnv.custom;
-      this.clientOptions.substrateURL = clientOptions.substrateURL;
-      this.clientOptions.proxyURL = clientOptions.proxyURL;
-      this.clientOptions.graphqlURL = clientOptions.graphqlURL;
-      this.clientOptions.activationURL = clientOptions.activationURL;
-      this.clientOptions.relayURL = clientOptions.relayURL;
-    }
+    this.clientOptions.substrateURL = clientOptions.substrateURL;
+    this.clientOptions.proxyURL = clientOptions.proxyURL;
+    this.clientOptions.graphqlURL = clientOptions.graphqlURL;
+    this.clientOptions.activationURL = clientOptions.activationURL;
+    this.clientOptions.relayURL = clientOptions.relayURL;
   }
   async connect(): Promise<void> {
     const urls = this.getDefaultUrls(this.clientOptions.network);
@@ -177,30 +158,38 @@ class GridClient {
 
   getDefaultUrls(network: NetworkEnv): Record<string, string> {
     const urls = { rmbProxy: "", substrate: "", graphql: "", activation: "", relay: "" };
-    if (network === NetworkEnv.dev) {
-      urls.rmbProxy = "https://gridproxy.dev.grid.tf";
-      urls.relay = "wss://relay.dev.grid.tf";
-      urls.substrate = "wss://tfchain.dev.grid.tf/ws";
-      urls.graphql = "https://graphql.dev.grid.tf/graphql";
-      urls.activation = "https://activation.dev.grid.tf/activation/activate";
-    } else if (network === NetworkEnv.test) {
-      urls.rmbProxy = "https://gridproxy.test.grid.tf";
-      urls.relay = "wss://relay.test.grid.tf";
-      urls.substrate = "wss://tfchain.test.grid.tf/ws";
-      urls.graphql = "https://graphql.test.grid.tf/graphql";
-      urls.activation = "https://activation.test.grid.tf/activation/activate";
-    } else if (network === NetworkEnv.qa) {
-      urls.rmbProxy = "https://gridproxy.qa.grid.tf";
-      urls.relay = "wss://relay.qa.grid.tf";
-      urls.substrate = "wss://tfchain.qa.grid.tf/ws";
-      urls.graphql = "https://graphql.qa.grid.tf/graphql";
-      urls.activation = "https://activation.qa.grid.tf/activation/activate";
-    } else if (network === NetworkEnv.main) {
-      urls.rmbProxy = "https://gridproxy.grid.tf";
-      urls.relay = "wss://relay.grid.tf";
-      urls.substrate = "wss://tfchain.grid.tf/ws";
-      urls.graphql = "https://graph.grid.tf/graphql";
-      urls.activation = "https://activation.grid.tf/activation/activate";
+    if (
+      !this.clientOptions.proxyURL ||
+      !this.clientOptions.relayURL ||
+      !this.clientOptions.substrateURL ||
+      !this.clientOptions.graphqlURL ||
+      !this.clientOptions.activationURL
+    ) {
+      if (network === NetworkEnv.dev) {
+        urls.rmbProxy = "https://gridproxy.dev.grid.tf";
+        urls.relay = "wss://relay.dev.grid.tf";
+        urls.substrate = "wss://tfchain.dev.grid.tf/ws";
+        urls.graphql = "https://graphql.dev.grid.tf/graphql";
+        urls.activation = "https://activation.dev.grid.tf/activation/activate";
+      } else if (network === NetworkEnv.test) {
+        urls.rmbProxy = "https://gridproxy.test.grid.tf";
+        urls.relay = "wss://relay.test.grid.tf";
+        urls.substrate = "wss://tfchain.test.grid.tf/ws";
+        urls.graphql = "https://graphql.test.grid.tf/graphql";
+        urls.activation = "https://activation.test.grid.tf/activation/activate";
+      } else if (network === NetworkEnv.qa) {
+        urls.rmbProxy = "https://gridproxy.qa.grid.tf";
+        urls.relay = "wss://relay.qa.grid.tf";
+        urls.substrate = "wss://tfchain.qa.grid.tf/ws";
+        urls.graphql = "https://graphql.qa.grid.tf/graphql";
+        urls.activation = "https://activation.qa.grid.tf/activation/activate";
+      } else if (network === NetworkEnv.main) {
+        urls.rmbProxy = "https://gridproxy.grid.tf";
+        urls.relay = "wss://relay.grid.tf";
+        urls.substrate = "wss://tfchain.grid.tf/ws";
+        urls.graphql = "https://graph.grid.tf/graphql";
+        urls.activation = "https://activation.grid.tf/activation/activate";
+      }
     } else {
       urls.rmbProxy = this.clientOptions.proxyURL!;
       urls.relay = this.clientOptions.relayURL!;

--- a/packages/grid_client/src/client.ts
+++ b/packages/grid_client/src/client.ts
@@ -80,7 +80,7 @@ class GridClient {
       this.clientOptions.activationURL = clientOptions.activationURL;
       this.clientOptions.relayURL = clientOptions.relayURL;
     } else {
-      throw new Error("Unknown NETWORK selected! Acceptable networks are [dev | qa | test | main ]");
+      throw new GridClientError(`Unknown NETWORK selected! Acceptable networks are [dev | qa | test | main ]`);
     }
   }
   async connect(): Promise<void> {

--- a/packages/grid_client/src/config.ts
+++ b/packages/grid_client/src/config.ts
@@ -10,7 +10,6 @@ enum NetworkEnv {
   test = "test",
   main = "main",
   qa = "qa",
-  custom = "custom",
 }
 
 class GridClientConfig {

--- a/packages/playground/docs/build.md
+++ b/packages/playground/docs/build.md
@@ -14,10 +14,10 @@ bash ../scripts/build-env.sh
 - By default, it runs on dev mode. the values already sat on the config file. if you want to change the mode
 
   ```bash
-  export MODE=dev | qa | test | main | custom
+  export MODE=dev | qa | test | main
   ```
 
-- In case you chose `custom` you will need to provide all the needed values which is
+- In case the user wants to use different urls, he can chose change any of the following urls, In case a url wasn't provided by the user, the default network's url will be used
 
   - GRAPHQL_URL
   - GRIDPROXY_URL

--- a/packages/playground/docs/build.md
+++ b/packages/playground/docs/build.md
@@ -17,7 +17,7 @@ bash ../scripts/build-env.sh
   export MODE=dev | qa | test | main
   ```
 
-- In case the user wants to use different urls, he can chose change any of the following urls, In case a url wasn't provided by the user, the default network's url will be used
+- In case the user wants to use different urls, he can change any of the following urls, In case a url wasn't provided by the user, the default network's url will be used
 
   - GRAPHQL_URL
   - GRIDPROXY_URL

--- a/packages/playground/scripts/build-env.sh
+++ b/packages/playground/scripts/build-env.sh
@@ -8,83 +8,60 @@ PAGE_SIZE="${PAGE_SIZE:=20}"
 MINTING_URL="https://alpha.minting.tfchain.grid.tf"
 STATS_URL="https://stats.grid.tf"
 
-# Env vars must provide in `custom` mode
-REQUIRED_ENV_VARS=(
-    GRAPHQL_URL
-    GRIDPROXY_URL
-    SUBSTRATE_URL
-    ACTIVATION_SERVICE_URL
-    RELAY_DOMAIN
-    BRIDGE_TFT_ADDRESS
-    MINTING_URL
-)
 
 STELLAR_ENV_Vars=(
     STELLAR_HORIZON_URL
     TFT_ASSET_ISSUER
 )
 
-case $MODE in
-  "dev")
-    GRAPHQL_URL='https://graphql.dev.grid.tf/graphql'
-    GRIDPROXY_URL='https://gridproxy.dev.grid.tf'
-    SUBSTRATE_URL='wss://tfchain.dev.grid.tf/ws'
-    ACTIVATION_SERVICE_URL='https://activation.dev.grid.tf/activation/activate'
-    RELAY_DOMAIN='wss://relay.dev.grid.tf'
-    BRIDGE_TFT_ADDRESS=GDHJP6TF3UXYXTNEZ2P36J5FH7W4BJJQ4AYYAXC66I2Q2AH5B6O6BCFG
-    STATS_URL='https://stats.dev.grid.tf'
-    STELLAR_NETWORK=test
-  ;;
 
-  "qa")
-    GRAPHQL_URL='https://graphql.qa.grid.tf/graphql'
-    GRIDPROXY_URL='https://gridproxy.qa.grid.tf'
-    SUBSTRATE_URL='wss://tfchain.qa.grid.tf/ws'
-    ACTIVATION_SERVICE_URL='https://activation.qa.grid.tf/activation/activate'
-    RELAY_DOMAIN='wss://relay.qa.grid.tf'
-    BRIDGE_TFT_ADDRESS=GAQH7XXFBRWXT2SBK6AHPOLXDCLXVFAKFSOJIRMRNCDINWKHGI6UYVKM
-    STATS_URL='https://stats.qa.grid.tf'
-    STELLAR_NETWORK=test
-  ;;
-
-  "test")
-    GRAPHQL_URL='https://graphql.test.grid.tf/graphql'
-    GRIDPROXY_URL='https://gridproxy.test.grid.tf'
-    SUBSTRATE_URL='wss://tfchain.test.grid.tf/ws'
-    ACTIVATION_SERVICE_URL='https://activation.test.grid.tf/activation/activate'
-    RELAY_DOMAIN='wss://relay.test.grid.tf'
-    BRIDGE_TFT_ADDRESS=GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4
-    STATS_URL='https://stats.test.grid.tf'
-    STELLAR_NETWORK=main
-  ;;
-
-  "main")
-    GRAPHQL_URL='https://graphql.grid.tf/graphql'
-    GRIDPROXY_URL='https://gridproxy.grid.tf'
-    SUBSTRATE_URL='wss://tfchain.grid.tf/ws'
-    ACTIVATION_SERVICE_URL='https://activation.grid.tf/activation/activate'
-    RELAY_DOMAIN='wss://relay.grid.tf'
-    BRIDGE_TFT_ADDRESS=GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC
-    STELLAR_NETWORK=main
-  ;;
-
-  "custom")
-    for i in "${REQUIRED_ENV_VARS[@]}"
-    do
-      if ! [[ -v $i ]]; then
-        echo -e "\n\e[1;50m \e[1;31m$i is required!\e[0m\n \e[1;3mPlease set it by executing the following command."
-        echo -e "\e[1;31m export\e[0m \e[1;32m$i\e[0m=\e[1;38m'Your Value Here'\n"
-        return
-      fi
-    done
-    echo -e "\e[1;33mEnvironment variables were exported before, if you want to change any of them maybe you have to re-export them or close the terminal window and start from scratch."
-  ;;
-
-  *)
-    echo "Unknown 'MODE' selected!, Acceptable modes are [dev | qa | test | main | custom]\n"
-    return
-  ;;
-esac
+if [ -z "$MODE" ] || [ -z "$GRAPHQL_URL" ] || [ -z "$GRIDPROXY_URL" ] || [ -z "$SUBSTRATE_URL" ] || [ -z "$ACTIVATION_SERVICE_URL" ] || [ -z "$RELAY_DOMAIN" ] || [ -z "$BRIDGE_TFT_ADDRESS" ] || [ -z "$MINTING_URL" ]; then
+  case $MODE in
+    "dev")
+      GRAPHQL_URL='https://graphql.dev.grid.tf/graphql'
+      GRIDPROXY_URL='https://gridproxy.dev.grid.tf'
+      SUBSTRATE_URL='wss://tfchain.dev.grid.tf/ws'
+      ACTIVATION_SERVICE_URL='https://activation.dev.grid.tf/activation/activate'
+      RELAY_DOMAIN='wss://relay.dev.grid.tf'
+      BRIDGE_TFT_ADDRESS='GDHJP6TF3UXYXTNEZ2P36J5FH7W4BJJQ4AYYAXC66I2Q2AH5B6O6BCFG'
+      STATS_URL='https://stats.dev.grid.tf'
+      STELLAR_NETWORK='test'
+    ;;
+    "qa")
+      GRAPHQL_URL='https://graphql.qa.grid.tf/graphql'
+      GRIDPROXY_URL='https://gridproxy.qa.grid.tf'
+      SUBSTRATE_URL='wss://tfchain.qa.grid.tf/ws'
+      ACTIVATION_SERVICE_URL='https://activation.qa.grid.tf/activation/activate'
+      RELAY_DOMAIN='wss://relay.qa.grid.tf'
+      BRIDGE_TFT_ADDRESS='GAQH7XXFBRWXT2SBK6AHPOLXDCLXVFAKFSOJIRMRNCDINWKHGI6UYVKM'
+      STATS_URL='https://stats.qa.grid.tf'
+      STELLAR_NETWORK='test'
+    ;;
+    "test")
+      GRAPHQL_URL='https://graphql.test.grid.tf/graphql'
+      GRIDPROXY_URL='https://gridproxy.test.grid.tf'
+      SUBSTRATE_URL='wss://tfchain.test.grid.tf/ws'
+      ACTIVATION_SERVICE_URL='https://activation.test.grid.tf/activation/activate'
+      RELAY_DOMAIN='wss://relay.test.grid.tf'
+      BRIDGE_TFT_ADDRESS='GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4'
+      STATS_URL='https://stats.test.grid.tf'
+      STELLAR_NETWORK='main'
+    ;;
+    "main")
+      GRAPHQL_URL='https://graphql.grid.tf/graphql'
+      GRIDPROXY_URL='https://gridproxy.grid.tf'
+      SUBSTRATE_URL='wss://tfchain.grid.tf/ws'
+      ACTIVATION_SERVICE_URL='https://activation.grid.tf/activation/activate'
+      RELAY_DOMAIN='wss://relay.grid.tf'
+      BRIDGE_TFT_ADDRESS='GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC'
+      STELLAR_NETWORK='main'
+    ;;
+    *)
+      echo "Unknown 'MODE' selected! Acceptable modes are [dev | qa | test | main ]"
+      return
+    ;;
+  esac
+fi
 
 case $STELLAR_NETWORK in
   "test")

--- a/packages/playground/scripts/build-env.sh
+++ b/packages/playground/scripts/build-env.sh
@@ -14,54 +14,54 @@ STELLAR_ENV_Vars=(
     TFT_ASSET_ISSUER
 )
 
-
-if [ -z "$MODE" ] || [ -z "$GRAPHQL_URL" ] || [ -z "$GRIDPROXY_URL" ] || [ -z "$SUBSTRATE_URL" ] || [ -z "$ACTIVATION_SERVICE_URL" ] || [ -z "$RELAY_DOMAIN" ] || [ -z "$BRIDGE_TFT_ADDRESS" ] || [ -z "$MINTING_URL" ]; then
-  case $MODE in
+case $MODE in
     "dev")
-      GRAPHQL_URL='https://graphql.dev.grid.tf/graphql'
-      GRIDPROXY_URL='https://gridproxy.dev.grid.tf'
-      SUBSTRATE_URL='wss://tfchain.dev.grid.tf/ws'
-      ACTIVATION_SERVICE_URL='https://activation.dev.grid.tf/activation/activate'
-      RELAY_DOMAIN='wss://relay.dev.grid.tf'
-      BRIDGE_TFT_ADDRESS='GDHJP6TF3UXYXTNEZ2P36J5FH7W4BJJQ4AYYAXC66I2Q2AH5B6O6BCFG'
-      STATS_URL='https://stats.dev.grid.tf'
-      STELLAR_NETWORK='test'
+        GRAPHQL_URL="${GRAPHQL_URL:-https://graphql.dev.grid.tf/graphql}"
+        GRIDPROXY_URL="${GRIDPROXY_URL:-https://gridproxy.dev.grid.tf}"
+        SUBSTRATE_URL="${SUBSTRATE_URL:-wss://tfchain.dev.grid.tf/ws}"
+        ACTIVATION_SERVICE_URL="${ACTIVATION_SERVICE_URL:-https://activation.dev.grid.tf/activation/activate}"
+        RELAY_DOMAIN="${RELAY_DOMAIN:-wss://relay.dev.grid.tf}"
+        BRIDGE_TFT_ADDRESS="${BRIDGE_TFT_ADDRESS:-GDHJP6TF3UXYXTNEZ2P36J5FH7W4BJJQ4AYYAXC66I2Q2AH5B6O6BCFG}"
+        STATS_URL="${STATS_URL:-https://stats.dev.grid.tf}"
+        STELLAR_NETWORK="${STELLAR_NETWORK:-test}"
     ;;
     "qa")
-      GRAPHQL_URL='https://graphql.qa.grid.tf/graphql'
-      GRIDPROXY_URL='https://gridproxy.qa.grid.tf'
-      SUBSTRATE_URL='wss://tfchain.qa.grid.tf/ws'
-      ACTIVATION_SERVICE_URL='https://activation.qa.grid.tf/activation/activate'
-      RELAY_DOMAIN='wss://relay.qa.grid.tf'
-      BRIDGE_TFT_ADDRESS='GAQH7XXFBRWXT2SBK6AHPOLXDCLXVFAKFSOJIRMRNCDINWKHGI6UYVKM'
-      STATS_URL='https://stats.qa.grid.tf'
-      STELLAR_NETWORK='test'
+        GRAPHQL_URL="${GRAPHQL_URL:-https://graphql.qa.grid.tf/graphql}"
+        GRIDPROXY_URL="${GRIDPROXY_URL:-https://gridproxy.qa.grid.tf}"
+        SUBSTRATE_URL="${SUBSTRATE_URL:-wss://tfchain.qa.grid.tf/ws}"
+        ACTIVATION_SERVICE_URL="${ACTIVATION_SERVICE_URL:-https://activation.qa.grid.tf/activation/activate}"
+        RELAY_DOMAIN="${RELAY_DOMAIN:-wss://relay.qa.grid.tf}"
+        BRIDGE_TFT_ADDRESS="${BRIDGE_TFT_ADDRESS:-GAQH7XXFBRWXT2SBK6AHPOLXDCLXVFAKFSOJIRMRNCDINWKHGI6UYVKM}"
+        STATS_URL="${STATS_URL:-https://stats.qa.grid.tf}"
+        STELLAR_NETWORK="${STELLAR_NETWORK:-test}"
     ;;
     "test")
-      GRAPHQL_URL='https://graphql.test.grid.tf/graphql'
-      GRIDPROXY_URL='https://gridproxy.test.grid.tf'
-      SUBSTRATE_URL='wss://tfchain.test.grid.tf/ws'
-      ACTIVATION_SERVICE_URL='https://activation.test.grid.tf/activation/activate'
-      RELAY_DOMAIN='wss://relay.test.grid.tf'
-      BRIDGE_TFT_ADDRESS='GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4'
-      STATS_URL='https://stats.test.grid.tf'
-      STELLAR_NETWORK='main'
+        GRAPHQL_URL="${GRAPHQL_URL:-https://graphql.test.grid.tf/graphql}"
+        GRIDPROXY_URL="${GRIDPROXY_URL:-https://gridproxy.test.grid.tf}"
+        SUBSTRATE_URL="${SUBSTRATE_URL:-wss://tfchain.test.grid.tf/ws}"
+        ACTIVATION_SERVICE_URL="${ACTIVATION_SERVICE_URL:-https://activation.test.grid.tf/activation/activate}"
+        RELAY_DOMAIN="${RELAY_DOMAIN:-wss://relay.test.grid.tf}"
+        BRIDGE_TFT_ADDRESS="${BRIDGE_TFT_ADDRESS:-GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4}"
+        STATS_URL="${STATS_URL:-https://stats.test.grid.tf}"
+        STELLAR_NETWORK="${STELLAR_NETWORK:-main}"
     ;;
     "main")
-      GRAPHQL_URL='https://graphql.grid.tf/graphql'
-      GRIDPROXY_URL='https://gridproxy.grid.tf'
-      SUBSTRATE_URL='wss://tfchain.grid.tf/ws'
-      ACTIVATION_SERVICE_URL='https://activation.grid.tf/activation/activate'
-      RELAY_DOMAIN='wss://relay.grid.tf'
-      BRIDGE_TFT_ADDRESS='GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC'
-      STELLAR_NETWORK='main'
+        GRAPHQL_URL="${GRAPHQL_URL:-https://graphql.grid.tf/graphql}"
+        GRIDPROXY_URL="${GRIDPROXY_URL:-https://gridproxy.grid.tf}"
+        SUBSTRATE_URL="${SUBSTRATE_URL:-wss://tfchain.grid.tf/ws}"
+        ACTIVATION_SERVICE_URL="${ACTIVATION_SERVICE_URL:-https://activation.grid.tf/activation/activate}"
+        RELAY_DOMAIN="${RELAY_DOMAIN:-wss://relay.grid.tf}"
+        BRIDGE_TFT_ADDRESS="${BRIDGE_TFT_ADDRESS:-GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC}"
+        STATS_URL="${STATS_URL:-https://stats.grid.tf}"
+        STELLAR_NETWORK="${STELLAR_NETWORK:-main}"
     ;;
     *)
-      echo "Unknown 'MODE' selected! Acceptable modes are [dev | qa | test | main ]"
-      return
+        echo "Unknown 'MODE' selected! Acceptable modes are [dev | qa | test | main ]"
+        return
     ;;
-  esac
-fi
+esac
+
+
 
 case $STELLAR_NETWORK in
   "test")

--- a/packages/playground/src/utils/grid.ts
+++ b/packages/playground/src/utils/grid.ts
@@ -42,15 +42,11 @@ export function createAccount() {
     network,
     mnemonic: "",
     storeSecret: "test",
-    ...(import.meta.env.DEV && network !== NetworkEnv.custom
-      ? {}
-      : {
-          substrateURL: window.env.SUBSTRATE_URL,
-          proxyURL: window.env.GRIDPROXY_URL,
-          graphqlURL: window.env.GRAPHQL_URL,
-          activationURL: window.env.ACTIVATION_SERVICE_URL,
-          relayURL: window.env.RELAY_DOMAIN,
-        }),
+    substrateURL: window.env.SUBSTRATE_URL,
+    proxyURL: window.env.GRIDPROXY_URL,
+    graphqlURL: window.env.GRAPHQL_URL,
+    activationURL: window.env.ACTIVATION_SERVICE_URL,
+    relayURL: window.env.RELAY_DOMAIN,
   });
   grid._connect();
   const relay = grid.getDefaultUrls(network).relay.slice(6);
@@ -62,15 +58,11 @@ export function activateAccountAndCreateTwin(mnemonic: string) {
     network,
     mnemonic,
     storeSecret: mnemonic,
-    ...(import.meta.env.DEV && network !== NetworkEnv.custom
-      ? {}
-      : {
-          substrateURL: window.env.SUBSTRATE_URL,
-          proxyURL: window.env.GRIDPROXY_URL,
-          graphqlURL: window.env.GRAPHQL_URL,
-          activationURL: window.env.ACTIVATION_SERVICE_URL,
-          relayURL: window.env.RELAY_DOMAIN,
-        }),
+    substrateURL: window.env.SUBSTRATE_URL,
+    proxyURL: window.env.GRIDPROXY_URL,
+    graphqlURL: window.env.GRAPHQL_URL,
+    activationURL: window.env.ACTIVATION_SERVICE_URL,
+    relayURL: window.env.RELAY_DOMAIN,
   });
   grid._connect();
   const relay = grid.getDefaultUrls(network).relay.slice(6);

--- a/packages/playground/src/utils/grid.ts
+++ b/packages/playground/src/utils/grid.ts
@@ -14,16 +14,11 @@ export async function getGrid(
     backendStorageType: BackendStorageType.tfkvstore,
     keypairType: profile.keypairType || KeypairType.sr25519,
     projectName,
-
-    ...(import.meta.env.DEV && network !== NetworkEnv.custom
-      ? {}
-      : {
-          substrateURL: window.env.SUBSTRATE_URL,
-          proxyURL: window.env.GRIDPROXY_URL,
-          graphqlURL: window.env.GRAPHQL_URL,
-          activationURL: window.env.ACTIVATION_SERVICE_URL,
-          relayURL: window.env.RELAY_DOMAIN,
-        }),
+    substrateURL: window.env.SUBSTRATE_URL,
+    proxyURL: window.env.GRIDPROXY_URL,
+    graphqlURL: window.env.GRAPHQL_URL,
+    activationURL: window.env.ACTIVATION_SERVICE_URL,
+    relayURL: window.env.RELAY_DOMAIN,
   });
   try {
     await grid.connect();


### PR DESCRIPTION
### Description

If all required env vars are missing, we'll use default urls
### Changes

- Adding condition to check if env vars are empty, if so the use default urls in build-env bash in playground and in client in grid_client
- When connecting to the grid always send the env vars regardless of network

### Related Issues

#2267
### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
