### PR TITLE
Fixing the subsquid port

### DIFF
--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -194,7 +194,7 @@ async function deploy() {
     await deployGatewayName(grid, selectionDetails.value.domain, {
       subdomain,
       ip: vm[0].interfaces[0].ip,
-      port: 80,
+      port: 4444,
       network: vm[0].interfaces[0].network,
     });
     finalize(vm);


### PR DESCRIPTION
### Description

Subsquid port was set to 80 which was the wrong port. The correct one in 4444
### Changes

- changed port to 4444
### Related Issues

#2033
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
