### PR TITLE
fixing subsquid port

### DIFF
--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -194,7 +194,7 @@ async function deploy() {
     await deployGatewayName(grid, selectionDetails.value.domain, {
       subdomain,
       ip: vm[0].interfaces[0].ip,
-      port: 80,
+      port: 4444,
       network: vm[0].interfaces[0].network,
     });
     finalize(vm);


### PR DESCRIPTION
### Description
Subsquid port was set to 80 which was the wrong port. The correct one is 4444

![2024-03-03_12-57](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/92c25ae7-f18c-4205-8253-b0be1c0d536c)


![2024-03-03_12-58](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/73dc498b-b225-40ba-abdd-1fe1c181f859)


### Changes
- changed port to 4444

### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2033


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
