### PR TITLE
Fix issue in loading the node flag image.

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -30,7 +30,12 @@
       <VTooltip :text="node?.location.country" :disabled="!node">
         <template #activator="{ props }">
           <VAvatar size="40">
-            <img :src="flag" class="h-100" :alt="(node?.location.country ?? 'node') + '-flag'" v-bind="props" />
+            <img
+              :src="getCountryFlagSrc()"
+              class="h-100"
+              :alt="(node?.location.country ?? 'node') + '-flag'"
+              v-bind="props"
+            />
           </VAvatar>
         </template>
       </VTooltip>
@@ -42,6 +47,13 @@
         <template #activator="{ props }">
           <VChip size="x-small" v-bind="props">
             <span class="font-weight-bold" v-text="checkSerialNumber(node?.serialNumber)" />
+          </VChip>
+        </template>
+      </VTooltip>
+      <VTooltip text="Node Country" v-if="node && node.location.country" location="left">
+        <template #activator="{ props }">
+          <VChip class="ml-2" size="x-small" v-bind="props">
+            <span class="font-weight-bold" v-text="node?.location.country" />
           </VChip>
         </template>
       </VTooltip>
@@ -108,8 +120,10 @@
 
 <script lang="ts">
 import type { NodeInfo } from "@threefold/grid_client";
-import { byCountry } from "country-code-lookup";
+import { GridNode } from "@threefold/gridproxy_client";
 import { computed, type PropType } from "vue";
+
+import { getCountryCode } from "@/utils/get_nodes";
 
 import formatResourceSize from "../../utils/format_resource_size";
 import ResourceDetails from "./node_details_internals/ResourceDetails.vue";
@@ -127,14 +141,12 @@ export default {
     "node:select": (node: NodeInfo) => true || node,
   },
   setup(props) {
-    const flag = computed(() => {
-      const country = props.node?.location.country ?? "";
-      const code =
-        country === "Czechia" ? "CZ" : byCountry(country)?.internet || byCountry(country.toLowerCase())?.internet;
-      return code
-        ? `https://www.worldatlas.com/r/w425/img/flag/${code.toLowerCase()}-flag.jpg`
-        : `https://placehold.co/30x20?text=TF`;
-    });
+    const getCountryFlagSrc = () => {
+      const conuntryCode = getCountryCode(props.node as unknown as GridNode);
+      return conuntryCode.toLocaleLowerCase() != "ch"
+        ? `https://www.worldatlas.com/r/w425/img/flag/${conuntryCode?.toLocaleLowerCase()}-flag.jpg`
+        : `https://www.worldatlas.com/r/w425/img/flag/${conuntryCode?.toLocaleLowerCase()}-flag.png`;
+    };
 
     function normalizeBytesResourse(name: "mru" | "sru" | "hru") {
       return () => {
@@ -166,7 +178,7 @@ export default {
     const sruText = computed(normalizeBytesResourse("sru"));
     const hruText = computed(normalizeBytesResourse("hru"));
 
-    return { flag, cruText, mruText, sruText, hruText, checkSerialNumber };
+    return { cruText, mruText, sruText, hruText, checkSerialNumber, getCountryFlagSrc };
   },
 };
 </script>

--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -120,7 +120,7 @@
 
 <script lang="ts">
 import type { NodeInfo } from "@threefold/grid_client";
-import { type GridNode } from "@threefold/gridproxy_client";
+import type { GridNode } from "@threefold/gridproxy_client";
 import { computed, type PropType } from "vue";
 
 import { getCountryCode } from "@/utils/get_nodes";

--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -30,8 +30,10 @@
       <VTooltip :text="node?.location.country" :disabled="!node">
         <template #activator="{ props }">
           <VAvatar size="40">
+            <span v-if="countryFlagSrc.length === 0" class="flag-avatar">NA</span>
             <img
-              :src="getCountryFlagSrc()"
+              v-else
+              :src="countryFlagSrc"
               class="h-100"
               :alt="(node?.location.country ?? 'node') + '-flag'"
               v-bind="props"
@@ -121,7 +123,7 @@
 <script lang="ts">
 import type { NodeInfo } from "@threefold/grid_client";
 import type { GridNode } from "@threefold/gridproxy_client";
-import { computed, type PropType } from "vue";
+import { computed, type PropType, ref } from "vue";
 
 import { getCountryCode } from "@/utils/get_nodes";
 
@@ -141,12 +143,20 @@ export default {
     "node:select": (node: NodeInfo) => true || node,
   },
   setup(props) {
-    const getCountryFlagSrc = () => {
+    const countryFlagSrc = computed(() => {
       const conuntryCode = getCountryCode(props.node as unknown as GridNode);
-      return conuntryCode.toLocaleLowerCase() != "ch"
-        ? `https://www.worldatlas.com/r/w425/img/flag/${conuntryCode?.toLocaleLowerCase()}-flag.jpg`
-        : `https://www.worldatlas.com/r/w425/img/flag/${conuntryCode?.toLocaleLowerCase()}-flag.png`;
-    };
+
+      if (conuntryCode.length > 2) {
+        return "";
+      }
+
+      const imageUrl =
+        conuntryCode.toLocaleLowerCase() != "ch"
+          ? `https://www.worldatlas.com/r/w425/img/flag/${conuntryCode?.toLocaleLowerCase()}-flag.jpg`
+          : `https://www.worldatlas.com/r/w425/img/flag/${conuntryCode?.toLocaleLowerCase()}-flag.png`;
+
+      return imageUrl;
+    });
 
     function normalizeBytesResourse(name: "mru" | "sru" | "hru") {
       return () => {
@@ -178,7 +188,17 @@ export default {
     const sruText = computed(normalizeBytesResourse("sru"));
     const hruText = computed(normalizeBytesResourse("hru"));
 
-    return { cruText, mruText, sruText, hruText, checkSerialNumber, getCountryFlagSrc };
+    return { cruText, mruText, sruText, hruText, checkSerialNumber, countryFlagSrc };
   },
 };
 </script>
+
+<style scoped>
+.flag-avatar {
+  padding: 20px;
+  background-color: var(--primary);
+  border-radius: 50%;
+  color: white;
+  font-weight: 700;
+}
+</style>

--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -120,7 +120,7 @@
 
 <script lang="ts">
 import type { NodeInfo } from "@threefold/grid_client";
-import { GridNode } from "@threefold/gridproxy_client";
+import { type GridNode } from "@threefold/gridproxy_client";
 import { computed, type PropType } from "vue";
 
 import { getCountryCode } from "@/utils/get_nodes";


### PR DESCRIPTION
### Description

- The issue was identified as a result of errors in the image link, leading to problems with image reloading.
- The necessary changes were made to the code, particularly in the image loading section, to rectify the issue.

### Changes

- Resolved the issue related to image reloading, ensuring that the bug no longer occurs.
- Implemented a fix to address the error encountered while attempting to load certain images.
- Replaced the hard-coded flag source with a dynamic function call (`getCountryFlagSrc`) for improved flexibility and accuracy.
- Added a tooltip displaying the node's country information.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2024

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/3a30de77-0894-45c6-a392-21c6fdd00e05)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/eaab29c9-0aa9-4c99-9825-d70d10d2e41b)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/dced301e-fc47-475e-9f50-22f6af0d4f1c)

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
