### PR TITLE
add text field for disk mounting point

### DIFF
--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -157,6 +157,20 @@
               <v-text-field label="Size (GB)" type="number" v-model.number="disks[index].size" v-bind="props" />
             </input-tooltip>
           </input-validator>
+          <input-validator
+            :value="disks[index].mountPoint"
+            :rules="[
+              validators.required('Mount Point is required.'),
+              validators.pattern('Mount Point should start with / and have additional characters', {
+                pattern: /^\/.+/,
+              }),
+            ]"
+            #="{ props }"
+          >
+            <input-tooltip tooltip="Disk Size.">
+              <v-text-field label="Mount Point" type="text" v-model="disks[index].mountPoint" v-bind="props" />
+            </input-tooltip>
+          </input-validator>
         </ExpandableLayout>
       </template>
     </d-tabs>


### PR DESCRIPTION
### Description

Adding disk for micro VM is missing the mount point field


### Changes

Added field for mounting point
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2320

[Screencast from 03-04-2024 12:00:47 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/11f64898-9ae9-439e-9f31-773d29223917)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
