### PR TITLE
Reset values of public config values on dialog close

### DIFF
--- a/packages/playground/src/dashboard/components/public_config.vue
+++ b/packages/playground/src/dashboard/components/public_config.vue
@@ -16,7 +16,7 @@
     </v-tooltip>
 
     <template v-if="showDialogue">
-      <v-dialog v-model="showDialogue" max-width="600">
+      <v-dialog v-model="showDialogue" max-width="600" @click:outside="reset">
         <v-card>
           <v-toolbar color="primary" dark class="custom-toolbar">
             <p class="mb-5">Add a public config to your node with ID: {{ $props.nodeId }}</p>
@@ -112,7 +112,15 @@
 
             <!-- Close and Save Buttons -->
             <div>
-              <v-btn @click="showDialogue = false" variant="outlined" color="anchor">Close</v-btn>
+              <v-btn
+                @click="
+                  showDialogue = false;
+                  reset();
+                "
+                variant="outlined"
+                color="anchor"
+                >Close</v-btn
+              >
               <v-btn
                 color="secondary"
                 variant="outlined"
@@ -241,7 +249,10 @@ export default {
             ip4: { ip: config.value.ipv4, gw: config.value.gw4 },
             ip6:
               config.value.ipv6 && config.value.gw6
-                ? { ip: config.value.ipv6 as string, gw: config.value.gw6 as string }
+                ? {
+                    ip: config.value.ipv6 as string,
+                    gw: config.value.gw6 as string,
+                  }
                 : null,
             domain: config.value.domain || null,
           },
@@ -286,6 +297,13 @@ export default {
       config.value = defualtNodeConfig.value;
     }
 
+    function reset() {
+      config.value.ipv4 = defualtNodeConfig.value.ipv4;
+      config.value.ipv6 = defualtNodeConfig.value.ipv6;
+      config.value.gw4 = defualtNodeConfig.value.gw4;
+      config.value.gw6 = defualtNodeConfig.value.gw6;
+      config.value.domain = defualtNodeConfig.value.domain;
+    }
     return {
       showDialogue,
       isAdding,
@@ -299,6 +317,7 @@ export default {
       AddConfig,
       removeConfig,
       isNodeHasConfig,
+      reset,
     };
   },
 };


### PR DESCRIPTION
### Description

Reset values of public config values on dialog close via the close button or clicking outside the dialog.

### Changes

[Screencast from 05-03-24 11:32:08.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/11662805/1b8c152e-462b-40f1-ab2b-e0cfe10c25b5)

### Related Issues

[#2271](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2271)

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
