### PR TITLE
enable copy ssh on low balance 

### DIFF
--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -21,7 +21,8 @@
             :spellcheck="false"
             v-model.trim="ssh"
             v-bind="{ ...props, ...copyInputProps }"
-            :disabled="updatingSSH || generatingSSH || !hasEnoughBalance"
+            :readonly="!hasEnoughBalance"
+            :disabled="updatingSSH || generatingSSH"
             :hint="
               updatingSSH
                 ? 'Updating your public ssh key.'


### PR DESCRIPTION

### Description

enable copy ssh on low balance

### Changes

 Make the field read-only if the use does not have enough balance.

### Related Issues

- #2276

### Checklist

- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
