### PR TITLE
Fix outdated links on the landing page and minting details

### DIFF
--- a/packages/playground/public/info/minting.md
+++ b/packages/playground/public/info/minting.md
@@ -17,4 +17,4 @@ The TFT minting address on Stellar Chain:
 
 <br />
 
-For more questions about minting, please contact the [support team](https://threefoldfaq.crisp.help/en/) or click on the chat icon.
+For more questions about minting, please contact the [support team](https://threefold.io/) or click on the chat icon.

--- a/packages/playground/public/info/minting.md
+++ b/packages/playground/public/info/minting.md
@@ -17,4 +17,4 @@ The TFT minting address on Stellar Chain:
 
 <br />
 
-For more questions about minting, please contact the [support team](https://threefold.io/support/) or click on the chat icon.
+For more questions about minting, please contact the [support team](https://threefoldfaq.crisp.help/en/) or click on the chat icon.

--- a/packages/playground/src/components/logged_in_landing.vue
+++ b/packages/playground/src/components/logged_in_landing.vue
@@ -74,16 +74,9 @@
               </p>
 
               <div class="d-flex justify-center align-center flex-wrap my-4">
-                <v-btn
-                  color="secondary"
-                  variant="outlined"
-                  class="mr-2"
-                  target="_blank"
-                  href="https://www.threefold.io/grid/"
-                >
+                <v-btn color="secondary" variant="outlined" class="mr-2" target="_blank" href="https://manual.grid.tf/">
                   Learn about the grid
                 </v-btn>
-                <v-btn color="primary" target="_blank" href="https://www.threefold.io/build/"> Use The Grid </v-btn>
               </div>
             </div>
           </v-card>


### PR DESCRIPTION
### Description

Fix outdated links on the landing page and minting details as per discussion with @samtaggart 

### Changes

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/11662805/1cc835c4-e947-4101-9f0a-4bffaa31f0ec)

- ```learn about the grid``` link ----> [manual](https://manual.grid.tf/)
- ```minting support``` link ----> [threefold.io](https://threefold.io/)

### Related Issues

- #2359
- #2363

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
