### PR TITLE
Fix stats summary endpoint delay 

### DIFF
--- a/packages/new_stats/nginx/conf.d/default.conf
+++ b/packages/new_stats/nginx/conf.d/default.conf
@@ -14,6 +14,11 @@ server {
         default_type application/json;
         js_content main.getStats;
     }
+        location /api/stats-update {
+        add_header 'Access-Control-Allow-Origin' '*';
+        default_type application/json;
+        js_content main.updateStats;
+    }
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html

--- a/packages/new_stats/nginx/njs/stats.js
+++ b/packages/new_stats/nginx/njs/stats.js
@@ -13,25 +13,21 @@ let URLS = [
 
 async function getStats(r) {
   const cachedData = cache.readCache(cache_path);
-  if (cachedData.valid) {
-    r.return(200, JSON.stringify(cachedData.summary));
-    return;
-  }
-  r.log(`Outdated cache, trying to update it...`);
 
+  r.return(200, JSON.stringify(cachedData.summary));
+}
+
+async function updateStats(r) {
   try {
     const stats = await fetchStats(r);
     r.return(200, JSON.stringify(stats));
     return;
   } catch (error) {
     r.error(`Failed to fetch stats: ${error}`);
-    cachedData.summary.outdated = true;
-    if (cachedData.error) r.error(`Failed to read cached data due to ${cachedData.error} \nretuning Dummy data`);
-    r.return(200, JSON.stringify(cachedData.summary));
+    r.return(500, `Failed to fetch stats: ${error}`);
     return;
   }
 }
-
 function initTargeRequests(urls) {
   return urls.map(url =>
     //   eslint-disable-next-line no-undef
@@ -136,4 +132,4 @@ function toTeraOrGiga(value) {
 }
 
 // Exporting the main function for Nginx
-export default { getStats };
+export default { getStats, updateStats };


### PR DESCRIPTION


### Description

If a request takes too long, it adversely impacts the responsiveness of the playground UI. Therefore, we must expedite the process of obtaining stats. While timeouts are an option, we discovered that even after returning, promises persist, leading to potential duplication of time if we attempt to call the summary endpoint while a previous request is still pending.

Due to the limited functionality of NJS, we are unable to utilize AbortController, even with the [NJS node module](https://nginx.org/en/docs/njs/node_modules.html). To address this issue, the proposed solution involves implementing two separate endpoints to mitigate the aforementioned problem.

Additionally, the cached stats summary can be updated by calling the stats-updated endpoint. We can incorporate this step into the nightly workflow or a similar process to ensure the stats are regularly refreshed without impacting the UI's responsiveness.


### Changes
make the stats-summary always return the cached data 
add  new endpoint stats-update, that updates the cache

### Related Issues

#2357


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
