### PR TITLE
Fix: show failed to load deployments  in deployment list

### DIFF
--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -210,11 +210,7 @@ async function loadDeployments() {
   chunk3.items = chunk3.items.map(markAsFromAnotherClient);
 
   const vms = mergeLoadedDeployments(chunk1, chunk2, chunk3 as any);
-  failedDeployments.value = [
-    ...(Array.isArray((chunk1 as any).failedDeployments) ? (chunk1 as any).failedDeployments : []),
-    ...(Array.isArray((chunk2 as any).failedDeployments) ? (chunk2 as any).failedDeployments : []),
-    ...(Array.isArray((chunk3 as any).failedDeployments) ? (chunk3 as any).failedDeployments : []),
-  ];
+  failedDeployments.value = vms.failedDeployments;
 
   count.value = vms.count;
   items.value = vms.items.map(([leader, ...workers]) => {

--- a/packages/playground/src/utils/load_deployment.ts
+++ b/packages/playground/src/utils/load_deployment.ts
@@ -272,6 +272,7 @@ function insertIfNotFound(newItems: LoadedDeployments<any>, oldItems: LoadedDepl
     for (const i of oldItems.items) {
       if (item.deploymentName === i.deploymentName) {
         found = true;
+        newItems.count--;
       }
     }
     if (!found) {

--- a/packages/playground/src/utils/load_deployment.ts
+++ b/packages/playground/src/utils/load_deployment.ts
@@ -8,6 +8,7 @@ import { migrateModule } from "./migration";
 export interface LoadedDeployments<T> {
   count: number;
   items: T[];
+  failedDeployments: FailedDeployment[];
 }
 
 interface FailedDeployment {
@@ -258,10 +259,10 @@ export function mergeLoadedDeployments<T>(...deployments: LoadedDeployments<T>[]
   return deployments.reduce(
     (res, current) => {
       insertIfNotFound(current, res);
-      res.count = res.items.length;
+      res.count += current.count;
       return res;
     },
-    { count: 0, items: [] },
+    { count: 0, items: [], failedDeployments: [] },
   );
 }
 
@@ -275,6 +276,18 @@ function insertIfNotFound(newItems: LoadedDeployments<any>, oldItems: LoadedDepl
     }
     if (!found) {
       oldItems.items.push(item);
+    }
+  }
+  for (const item of newItems.failedDeployments) {
+    let found = false;
+    for (const i of oldItems.failedDeployments) {
+      if (item.name === i.name) {
+        found = true;
+        newItems.count--;
+      }
+    }
+    if (!found) {
+      oldItems.failedDeployments.push(item);
     }
   }
 }


### PR DESCRIPTION
check if the failed deployments repeated and handle count in this case include failedDeployments in mergeLoadedDeployments function add failedDeployments to loaddeployments type"

### Description

the `count` was incorrectly assigned to the items length so the alert never appear  

### Changes

- add `failedDeployments` to  `LoadedDeployments` interface,
- add merge failed deployment logic to `mergeLoadedDeployments` function and filter repeated items

### Related Issues

 - #2402


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
