### PR TITLE
Disable sorting public ip in your farms

### DIFF
--- a/packages/playground/src/dashboard/components/public_ips_table.vue
+++ b/packages/playground/src/dashboard/components/public_ips_table.vue
@@ -104,11 +104,13 @@ export default {
         title: "IP",
         align: "center",
         key: "ip",
+        sortable: false,
       },
       {
         title: "Gateway",
         align: "center",
         key: "gateway",
+        sortable: false,
       },
       {
         title: "Deployed Contract ID",


### PR DESCRIPTION
### Description

The farm IP table sorting isn't working.

### Changes

- remove sorting from table
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2390
### Documentation PR

For UI changes, Plaese provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
