### PR TITLE
reorder resource units in node finder to be like my nodes

### DIFF
--- a/packages/playground/src/components/node_resources_charts.vue
+++ b/packages/playground/src/components/node_resources_charts.vue
@@ -68,7 +68,7 @@ export default {
   },
   setup(props) {
     const resources = ref<ResourceWrapper[]>([]);
-    const renamedResources = ["CPU", "RAM", "SSD", "HDD"];
+    const renamedResources = ["CPU", "SSD", "HDD", "RAM"];
     const loading = ref<boolean>(false);
     const indeterminate = ref<boolean>(false);
     const getNodeHealthUrl = async () => {
@@ -79,7 +79,7 @@ export default {
 
     const getNodeResources = async () => {
       loading.value = true;
-      return ["cru", "mru", "sru", "hru"].map((i, idx) => {
+      return ["cru", "sru", "hru", "mru"].map((i, idx) => {
         let value;
         if (props.node.stats && props.node.stats.system) {
           value =


### PR DESCRIPTION
### Description

Having node resource unit order consistency in both my nodes and node finder.

### Changes

reorder resource units in node finder
### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2315

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/0a4d477a-31b7-4c7f-966d-f9a90b373cc1)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/c457b60b-6d43-4dfb-9d9b-8935f2c67191)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
