### PR TITLE
enhance list requests in nodes and farms tables

### DIFF
--- a/packages/playground/src/views/farms.vue
+++ b/packages/playground/src/views/farms.vue
@@ -1,6 +1,6 @@
 <template>
   <view-layout>
-    <TfFiltersContainer @apply="loadFarms" class="mb-4" :loading="loading">
+    <TfFiltersContainer @apply="loadFarms(true)" class="mb-4" :loading="loading">
       <TfFilter
         query-route="farm-id"
         v-model="filters.farmId"
@@ -146,11 +146,12 @@ const dialog = ref(false);
 
 const totalFarms = ref(0);
 
-async function loadFarms() {
+async function loadFarms(retCount = false) {
   loading.value = true;
+  if (retCount) page.value = 1;
   try {
     const { count, data } = await getAllFarms({
-      retCount: true,
+      retCount,
       farmId: +filters.value.farmId || undefined,
       freeIps: +filters.value.freePublicIps || undefined,
       nameContains: filters.value.farmName || undefined,
@@ -159,7 +160,7 @@ async function loadFarms() {
     });
 
     if (data) {
-      totalFarms.value = count || 0;
+      if (retCount) totalFarms.value = count || 0;
       farms.value = data.map(farm => {
         const ips = farm.publicIps;
         const total = ips.length;

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -6,7 +6,7 @@
   </div>
 
   <view-layout>
-    <TfFiltersContainer class="mb-4" @apply="loadNodes" :loading="loading">
+    <TfFiltersContainer class="mb-4" @apply="loadNodes(true)" :loading="loading">
       <TfFilter
         query-route="node-id"
         :rules="[
@@ -423,14 +423,15 @@ export default {
       loadGpu: false,
     };
 
-    async function loadNodes() {
+    async function loadNodes(retCount = false) {
       loading.value = true;
+      if (retCount) page.value = 1;
       try {
         const { count, data } = await requestNodes(
           {
             page: page.value,
             size: size.value,
-            retCount: true,
+            retCount,
             nodeId: +filters.value.nodeId || undefined,
             farmIds: filters.value.farmId || undefined,
             farmName: filters.value.farmName || undefined,
@@ -452,7 +453,7 @@ export default {
           { loadFarm: true },
         );
         nodes.value = data;
-        nodesCount.value = count ?? 0;
+        if (retCount) nodesCount.value = count ?? 0;
       } catch (err) {
         console.log(err);
       } finally {


### PR DESCRIPTION
### Description

get the total count on_mount and on any change of filters or delete\add actions

### Changes

in general, the tf filter component handle the changes on the params and it also handle on mounted and clear by calling `apply` 
so in case of calling apply, we are passing ret_count flag to be true, the default value of the flag is false
if the flag passed, that's mean we are changing all the table data so we need to reset page to 1 and return count.

### Related Issues

- #1691 

### Documentation PR

For UI changes, Plaese provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
