### PR TITLE
Fix checking on rentContractId while choosing node

### DIFF
--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -208,9 +208,11 @@ export async function validateRentContract(
   }
 
   try {
-    const contractInfo = await gridStore.grid.contracts.get({ id: node.rentContractId });
-    if (contractInfo.state.gracePeriod) {
-      throw `You can't deploy on node ${node.nodeId}, its rent contract in grace period. `;
+    if (node.rentContractId !== 0) {
+      const contractInfo = await gridStore.grid.contracts.get({ id: node.rentContractId });
+      if (contractInfo.state.gracePeriod) {
+        throw `You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`;
+      }
     }
 
     return true;
@@ -219,7 +221,6 @@ export async function validateRentContract(
       error,
       "Something went wrong while checking status of the node. Please check your connection and try again.",
     );
-
     throw err;
   }
 }


### PR DESCRIPTION
### Description

- While checking on grace period, the request was sent before check if rent contract id is zero or not.
### Changes

- Added condition to prevent errors from returning

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/5b9384f3-3829-401b-9e96-2537176eca64)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
