### PR TITLE
Enhance validator form

### DIFF
--- a/packages/playground/src/components/form_validator.vue
+++ b/packages/playground/src/components/form_validator.vue
@@ -16,8 +16,8 @@ export default {
   },
   emits: { "update:modelValue": (value: boolean) => value },
   setup(props, { emit, expose }) {
-    const statusMap = ref(new Map<number, ValidatorStatus>());
-    const serviceMap = new Map<number, InputValidatorService>();
+    const statusMap = ref(new Map<string, ValidatorStatus>());
+    const serviceMap = new Map<string, InputValidatorService>();
 
     const valid = computed(() =>
       [...statusMap.value.values()].every(status => {
@@ -53,6 +53,8 @@ export default {
       reset() {
         [...serviceMap.values()].map(({ reset }) => reset());
       },
+
+      get: uid => serviceMap.get(uid),
 
       valid,
       invalid: computed(() => [...statusMap.value.values()].some(status => status === ValidatorStatus.Invalid)),

--- a/packages/playground/src/components/input_validator.vue
+++ b/packages/playground/src/components/input_validator.vue
@@ -43,6 +43,7 @@ export default {
     hint: String,
     disableValidation: Boolean,
     debounceTime: Number,
+    inputName: String,
   },
   emits: {
     "update:modelValue": (valid: boolean) => valid,
@@ -50,7 +51,8 @@ export default {
     "update:error": (error: string | null) => true || error,
   },
   setup(props, { emit, expose }) {
-    const { uid } = getCurrentInstance() as { uid: number };
+    const { uid: _uid } = getCurrentInstance() as { uid: number };
+    const uid = props.inputName || _uid.toString();
     const form = useForm();
 
     const required = computed(() => props.rules.some(rule => "required" in (rule("") || {})));

--- a/packages/playground/src/components/node_selector/TfSelectionDetails.vue
+++ b/packages/playground/src/components/node_selector/TfSelectionDetails.vue
@@ -149,8 +149,8 @@ export default {
       error: null,
     };
 
-    onMounted(() => form?.register(uid, fakeService));
-    onUnmounted(() => form?.unregister(uid));
+    onMounted(() => form?.register(uid.toString(), fakeService));
+    onUnmounted(() => form?.unregister(uid.toString()));
 
     const invalid = computed(() => {
       return (
@@ -186,7 +186,7 @@ export default {
     watch(
       status,
       status => {
-        form?.updateStatus(uid, status);
+        form?.updateStatus(uid.toString(), status);
         bindStatus(status);
       },
       { deep: true, immediate: true },

--- a/packages/playground/src/hooks/form_validator.ts
+++ b/packages/playground/src/hooks/form_validator.ts
@@ -10,11 +10,12 @@ export enum ValidatorStatus {
 }
 
 export interface FormValidatorService {
-  register(uid: number, service: InputValidatorService): void;
-  updateStatus(uid: number, status: ValidatorStatus): void;
+  register(uid: string, service: InputValidatorService): void;
+  updateStatus(uid: string, status: ValidatorStatus): void;
   validate(): Promise<boolean>;
-  unregister(uid: number): void;
+  unregister(uid: string): void;
   reset(): void;
+  get(name: string): InputValidatorService | undefined;
   valid: ComputedRef<boolean>;
   invalid: ComputedRef<boolean>;
   pending: ComputedRef<boolean>;


### PR DESCRIPTION
### Description
Allow to validate specific field using formRef

### Implementation Usage (Example)
```html
 <input-validator
                input-name="input_special_name" // optional
                // ...
              >
              // ...
              </input-validator>
```

```ts
formRef.value?.get("input_special_name")?.validate(); // should validate that field if exists
```

### Changes
- feat: Add support for input-name prop to specifiy specific uid
- feat: Allow to query specific input using passed uid

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1818

### Documentation PR

For UI changes, Plaese provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
