### PR TITLE
Fix reserve button issues in Node finder

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -194,7 +194,7 @@
           v-if="node?.dedicated && node?.status !== 'down'"
           class="ml-4"
           :node="(node as GridNode)"
-          @updateTable="$emit('reloadTable')"
+          @updateTable="$emit('reload-table', node.nodeId)"
         />
       </div>
     </template>
@@ -224,7 +224,7 @@ export default {
   },
   emits: {
     "node:select": (node: NodeInfo) => true || node,
-    reloadTable: () => true,
+    "reload-table": (id: number) => id,
   },
   setup(props) {
     const node = ref(props.node);

--- a/packages/playground/src/components/nodes_table.vue
+++ b/packages/playground/src/components/nodes_table.vue
@@ -26,7 +26,7 @@
 
           <tbody class="mx-4 my-4">
             <tr v-for="node in modelValue" v-bind:key="node.id" @click="openSheet($event, node)">
-              <TfNodeDetailsCard :node="node" />
+              <TfNodeDetailsCard :node="node" @reload-table="$emit('reloadTable', node.nodeId)" />
             </tr>
           </tbody>
         </v-data-table-server>

--- a/packages/playground/src/components/nodes_table.vue
+++ b/packages/playground/src/components/nodes_table.vue
@@ -26,7 +26,11 @@
 
           <tbody class="mx-4 my-4">
             <tr v-for="node in modelValue" v-bind:key="node.id" @click="openSheet($event, node)">
-              <TfNodeDetailsCard :node="node" @reload-table="$emit('reloadTable', node.nodeId)" />
+              <TfNodeDetailsCard
+                :key="node.rentedByTwinId"
+                :node="node"
+                @reload-table="$emit('reloadTable', node.nodeId)"
+              />
             </tr>
           </tbody>
         </v-data-table-server>

--- a/packages/playground/src/dashboard/components/reserve_action_btn.vue
+++ b/packages/playground/src/dashboard/components/reserve_action_btn.vue
@@ -18,7 +18,6 @@
     </v-dialog>
     <v-btn
       size="small"
-      variant="outlined"
       :loading="loadingReserveNode"
       :disabled="disableButton"
       v-if="node.rentedByTwinId === 0"
@@ -31,7 +30,6 @@
     <v-btn
       size="small"
       color="error"
-      variant="outlined"
       :loading="loadingUnreserveBtn"
       :disabled="disableButton"
       v-if="node.rentedByTwinId === profile?.twinId"
@@ -45,7 +43,7 @@
 <script lang="ts">
 import type { GridNode } from "@threefold/gridproxy_client";
 import { InsufficientBalanceError } from "@threefold/types";
-import { type PropType, ref } from "vue";
+import { computed, type PropType, ref } from "vue";
 
 import { useProfileManager } from "@/stores";
 import { createCustomToast, ToastType } from "@/utils/custom_toast";
@@ -62,7 +60,9 @@ export default {
   },
   setup(props, { emit }) {
     const profileManager = useProfileManager();
-    const profile = profileManager.profile;
+    const profile = computed(() => {
+      return profileManager.profile ?? null;
+    });
     const openUnreserveDialog = ref(false);
     const loadingUnreserveNode = ref(false);
     const loadingUnreserveBtn = ref(false);
@@ -76,7 +76,7 @@ export default {
     async function unReserveNode() {
       loadingUnreserveNode.value = true;
       try {
-        const grid = await getGrid(profile!);
+        const grid = await getGrid(profile.value!);
         createCustomToast(`Verify contracts for node ${props.node.nodeId}`, ToastType.info);
 
         const result = (await grid?.contracts.getActiveContracts({ nodeId: +props.node.nodeId })) as any;
@@ -113,9 +113,9 @@ export default {
 
     async function reserveNode() {
       try {
-        if (profile) {
+        if (profile.value) {
           loadingReserveNode.value = true;
-          const grid = await getGrid(profile);
+          const grid = await getGrid(profile.value);
           createCustomToast("Transaction Submitted", ToastType.info);
           await grid?.nodes.reserve({ nodeId: +props.node.nodeId });
           createCustomToast(`Transaction succeeded node ${props.node.nodeId} Reserved`, ToastType.success);


### PR DESCRIPTION
### Changes

- Made profile value in reserve button is computed
- Fix reloadTable emits typos
- Used Vue reactivity to update the node card upon reserving/unreserving a node by setting the key to the node card component to node.rentedByTwinId
- Removed outlined from the reserve/unreserve button as it was faded inside the card

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2520

### Documentation PR

For UI changes, Plaese provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
