### PR TITLE
add warning alert to add twin id as memo text

### DIFF
--- a/packages/playground/src/components/copy_readonly_input.vue
+++ b/packages/playground/src/components/copy_readonly_input.vue
@@ -1,6 +1,7 @@
 <template>
   <copy-input-wrapper :data="data" :loading="loading" #="{ props }">
     <v-textarea
+      class="copy-input-wrapper"
       readonly
       variant="outlined"
       :label="label"
@@ -9,22 +10,27 @@
       no-resize
       :rows="3"
       :loading="loading"
+      :hint="hint"
+      :persistent-hint="!!hint"
       v-if="textarea"
     />
     <v-text-field
+      class="copy-input-wrapper"
       variant="outlined"
       readonly
       :label="label"
       :model-value="data"
       v-bind="props"
       :loading="loading"
+      :hint="hint"
+      :persistent-hint="!!hint"
       v-else
     />
   </copy-input-wrapper>
 </template>
 
 <script lang="ts" setup>
-defineProps<{ label: string; data: any; textarea?: boolean; loading?: boolean }>();
+defineProps<{ label: string; data: any; textarea?: boolean; loading?: boolean; hint?: string }>();
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/components/deposit_dialog.vue
+++ b/packages/playground/src/components/deposit_dialog.vue
@@ -36,7 +36,7 @@
                   target="_blank"
                   >Learn more?</v-btn
                 >
-                <div style="position: absolute; bottom: 10rem">
+                <div style="position: absolute; bottom: 11rem">
                   <p :style="{ paddingBottom: '3rem', color: '#7de3c8' }">Waiting for receiving TFTs{{ dots }}</p>
                 </div>
               </v-col>
@@ -64,11 +64,16 @@
               </v-col>
               <v-divider class="my-4" horizontal></v-divider>
             </v-row>
-            <v-alert type="warning" variant="tonal" class="d-flex row justify-start text-subtitle-1">
-              <p :style="{ maxWidth: '880px' }">
-                Amount: should be larger than {{ depositFee }}TFT (deposit fee is: {{ depositFee }}TFT)
-              </p>
-            </v-alert>
+            <div class="mt-4">
+              <v-alert type="warning" variant="tonal" class="my-5 text-subtitle-1">
+                <p :style="{ maxWidth: '880px' }">
+                  Amount: should be larger than {{ depositFee }}TFT (deposit fee is: {{ depositFee }}TFT)
+                </p>
+              </v-alert>
+              <v-alert type="warning" variant="tonal" class="text-subtitle-1">
+                <p :style="{ maxWidth: '880px' }">Add Twin ID as Memo Text</p>
+              </v-alert>
+            </div>
           </v-container>
           <v-card-actions class="justify-end">
             <v-btn variant="outlined" color="anchor" class="mr-2 px-3" @click="closeDialog"> Close </v-btn>

--- a/packages/playground/src/components/deposit_dialog.vue
+++ b/packages/playground/src/components/deposit_dialog.vue
@@ -7,17 +7,18 @@
       @update:model-value="closeDialog"
     >
       <v-card>
-        <v-toolbar color="primary" dark class="d-flex justify-center bold-text"> Deposit TFT </v-toolbar>
+        <VCardTitle class="bg-primary">Deposit TFT</VCardTitle>
         <v-card-text>
           <v-container>
-            <v-row class="py-2 pb-5">
+            <v-row class="py-2">
               <v-col cols="6" class="mx-4">
                 <div class="mb-2">
-                  <p class="mb-8">
+                  <p>
                     Deposit your TFTs to Threefold Bridge using a
                     {{ selectedName ? selectedName.charAt(0).toUpperCase() + selectedName.slice(1) : "" }}
                     transaction.
                   </p>
+                  <p class="mt-1 mb-8 text-secondary text-sm-subtitle-2 font-weight-bold">Deposit fee is 1 TFT</p>
                 </div>
                 <input-tooltip
                   v-if="selectedName == 'stellar'"
@@ -28,15 +29,14 @@
                   <CopyReadonlyInput label="Destination" :data="depositWallet"></CopyReadonlyInput>
                 </input-tooltip>
                 <CopyReadonlyInput v-else label="Destination" :data="depositWallet"></CopyReadonlyInput>
-                <CopyReadonlyInput label="Memo Text" :data="`twin_${twinId}`"></CopyReadonlyInput>
-                <v-btn
-                  variant="outlined"
-                  color="secondary"
-                  :href="`${MANUAL_URL}/documentation/threefold_token/tft_bridges/tft_bridges.html`"
-                  target="_blank"
-                  >Learn more?</v-btn
-                >
-                <div style="position: absolute; bottom: 11rem">
+                <div class="memo-text-warn">
+                  <CopyReadonlyInput
+                    label="Memo Text"
+                    :data="`twin_${twinId}`"
+                    hint="Add twin ID as memo text or you will lose your tokens"
+                  />
+                </div>
+                <div style="margin-top: 5rem">
                   <p :style="{ paddingBottom: '3rem', color: '#7de3c8' }">Waiting for receiving TFTs{{ dots }}</p>
                 </div>
               </v-col>
@@ -62,21 +62,18 @@
                   </div>
                 </div>
               </v-col>
-              <v-divider class="my-4" horizontal></v-divider>
+              <v-divider horizontal></v-divider>
             </v-row>
-            <div class="mt-4">
-              <v-alert type="warning" variant="tonal" class="my-5 text-subtitle-1">
-                <p :style="{ maxWidth: '880px' }">
-                  Amount: should be larger than {{ depositFee }}TFT (deposit fee is: {{ depositFee }}TFT)
-                </p>
-              </v-alert>
-              <v-alert type="warning" variant="tonal" class="text-subtitle-1">
-                <p :style="{ maxWidth: '880px' }">Add Twin ID as Memo Text</p>
-              </v-alert>
-            </div>
           </v-container>
           <v-card-actions class="justify-end">
             <v-btn variant="outlined" color="anchor" class="mr-2 px-3" @click="closeDialog"> Close </v-btn>
+            <v-btn
+              variant="outlined"
+              color="secondary"
+              :href="`${MANUAL_URL}/documentation/threefold_token/tft_bridges/tft_bridges.html`"
+              target="_blank"
+              text="Learn more?"
+            />
           </v-card-actions>
         </v-card-text>
       </v-card>
@@ -189,5 +186,9 @@ export default defineComponent({
 .bold-text {
   font-weight: 500;
   padding-left: 1rem;
+}
+
+.memo-text-warn .copy-input-wrapper .v-messages__message {
+  color: rgb(var(--v-theme-warning));
 }
 </style>


### PR DESCRIPTION


### Changes

Added alert warning in deposit dialog in bridge view to warn user to add twin ID as memo text

### Related Issues

#2413 

### Documentation PR

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/c931f5ec-3452-4a32-bf4b-d29b6333e63b)

