### PR TITLE
Edit SMTP email tooltip & label in discourse only

### DIFF
--- a/packages/playground/src/components/smtp_server.vue
+++ b/packages/playground/src/components/smtp_server.vue
@@ -24,9 +24,9 @@
         ]"
         #="{ props }"
       >
-        <input-tooltip tooltip="SMTP admin email.">
+        <input-tooltip :tooltip="isDiscourse ? 'SMTP admin email, Username or API key.' : 'SMTP admin email'">
           <v-text-field
-            :label="isDiscourse ? 'Admin Email/Username' : 'Admin Email'"
+            label="Admin Email"
             placeholder="email@example.com"
             v-model="$props.modelValue.username"
             v-bind="props"


### PR DESCRIPTION
### Description

Edit SMTP email tooltip & label in discourse only

### Changes

- Edit email tooltip to include apikey & username
- Edit discourse email label to be as other SMTP solutions

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2152

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
