### PR TITLE
link manual in minting page

### DIFF
--- a/packages/playground/src/utils/manual.ts
+++ b/packages/playground/src/utils/manual.ts
@@ -14,4 +14,5 @@ export const manual = {
   billing_pricing: `${BASE}/dashboard/deploy/dedicated_machines.html#billing--pricing`,
   discount_levels: `${BASE}/wiki/cloudunits/pricing/staking_discount_levels.html#staking-discount-levels`,
   tfchain_stellar_bridge: `${BASE}/documentation/threefold_token/tft_bridges/tfchain_stellar_bridge.html`,
+  minting_receipts: `${BASE}/documentation/farmers/3node_building/minting_receipts.html`,
 };

--- a/packages/playground/src/views/minting_view.vue
+++ b/packages/playground/src/views/minting_view.vue
@@ -28,6 +28,10 @@
       </FormValidator>
     </v-form>
     <v-container class="mt-8" v-if="item && item.Minting">
+      <VAlert type="info" class="mb-10">
+        For more information about Minting Receipts check,
+        <a class="app-link" target="_blank" :href="manual.minting_receipts" v-text="'Minting Receipts'" />
+      </VAlert>
       <v-card>
         <v-card-title class="font-weight-bold bg-primary">Node Info</v-card-title>
         <v-list class="custom-list">
@@ -181,6 +185,7 @@ import { ref } from "vue";
 
 import type { AsyncRule, RuleReturn } from "@/components/input_validator.vue";
 import { useInputRef } from "@/hooks/input_validator";
+import { manual } from "@/utils/manual";
 
 import { getMintingData } from "../utils/mintings";
 


### PR DESCRIPTION
### Description

- Minting receipts part in manual linked to the page 

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1998

![Screenshot from 2024-04-14 13-25-47](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/da3c866b-4df0-4ca2-92af-f59e186bbcf0)

### Documentation PR

For UI changes, Plaese provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
