### PR TITLE
Fix: public ip range

### DIFF
--- a/packages/playground/src/dashboard/components/add_ip.vue
+++ b/packages/playground/src/dashboard/components/add_ip.vue
@@ -183,7 +183,9 @@ export default {
         };
       }
       if (
-        parseInt(toPublicIP.value.split("/")[0].split(".")[3]) - parseInt(publicIP.value.split("/")[0].split(".")[3]) >
+        parseInt(toPublicIP.value.split("/")[0].split(".")[3]) -
+          parseInt(publicIP.value.split("/")[0].split(".")[3]) +
+          1 >
         16
       ) {
         return {


### PR DESCRIPTION

### Description

there was a mistake while calculating the number of ips in the provided range

### Changes
getting the difference between the two octets will lead to ignoring one ip
if we have 1,2,3 the deference between the start and the end is 2 but actually we have three  
![Screenshot from 2024-04-15 11-18-43](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/14c96f1c-1f3b-4124-9d40-24a75500198a)

### Related Issues

- #2400 

### Documentation PR

For UI changes, Plaese provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
