### PR TITLE
Make defined error when adding ip exists

### DIFF
--- a/packages/playground/src/dashboard/components/add_ip.vue
+++ b/packages/playground/src/dashboard/components/add_ip.vue
@@ -104,6 +104,7 @@
 </template>
 
 <script lang="ts">
+import { TFChainErrors } from "@threefold/types";
 import { contains } from "cidr-tools";
 import { getIPRange } from "get-ip-range";
 import { default as PrivateIp } from "private-ip";
@@ -259,8 +260,13 @@ export default {
         createCustomToast("IP is added successfully.", ToastType.success);
         showDialogue.value = false;
       } catch (error) {
-        console.log(error);
-        createCustomToast(`Failed to add IP. ${error}`, ToastType.danger);
+        if (error instanceof TFChainErrors.tfgridModule.IpExists) {
+          console.log(error);
+          createCustomToast(`IP already exists.`, ToastType.danger);
+        } else {
+          console.log(error);
+          createCustomToast(`Failed to add IP. ${error}`, ToastType.danger);
+        }
       } finally {
         isAdding.value = false;
         reset();


### PR DESCRIPTION
### Description

I get an alert with a very long message of the error from the client that might not be understood by the user, when user tries to add existing ip.
### Changes

- checked on error with types package to check if error related to ip or not.
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2411

![Screenshot from 2024-04-15 12-16-33](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/c0b44f56-cbe2-45eb-89ae-8340ccc4ff07)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
