### PR TITLE
Feature: add error handling to node selector

### DIFF
--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -39,7 +39,9 @@
           </VContainer>
 
           <VContainer v-if="loadedNodes.length === 0 && !(pageCountTask.loading || nodesTask.loading)">
-            <VAlert type="error" text="No Nodes were found!" />
+            <VAlert v-if="loadingError" type="error" :text="loadingError" />
+
+            <VAlert v-else type="error" text="No Nodes were found!" />
           </VContainer>
 
           <div
@@ -141,6 +143,7 @@
 
 <script lang="ts">
 import type { FarmInfo, FilterOptions, NodeInfo } from "@threefold/grid_client";
+import { RequestError } from "@threefold/types";
 import equals from "lodash/fp/equals.js";
 import sample from "lodash/fp/sample.js";
 import { computed, nextTick, onMounted, onUnmounted, type PropType, ref } from "vue";
@@ -207,7 +210,11 @@ export default {
     const filters = computed(() => normalizeNodeFilters(props.filters, options.value));
 
     const reloadNodes = () => nodesTask.value.run(gridStore, props.filters, filters.value, pagination);
-
+    const loadingError = computed(() => {
+      if (!nodesTask.value.error) return "";
+      if (nodesTask.value.error instanceof RequestError) return "Failed to fetch nodes due to a network error";
+      else return "Something went wrong while getting nodes, please try again later";
+    });
     let initialized = false;
     onMounted(async () => {
       initialized = true;
@@ -314,7 +321,7 @@ export default {
       reloadNodes,
       resetPageAndReloadNodes,
       pagination,
-
+      loadingError,
       filtersUpdated,
       nodeInputValidateTask,
 


### PR DESCRIPTION
### Description
the current behavior doesn't check on loading error, it only check on the length of the nodes and if it is 0 it show no nodes were found.

### Changes

add error handling to node selector; using computed property to watch the value of `nodesTask.error` and check on the error class 
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/a6009082-158c-485f-a761-4bac352d2f5b)

### Related Issues

- #2383
### Documentation PR

For UI changes, Plaese provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
