### PR TITLE
Add workers number chip in k8s & caprover

### DIFF
--- a/packages/playground/src/components/dynamic_tabs.vue
+++ b/packages/playground/src/components/dynamic_tabs.vue
@@ -13,6 +13,7 @@
         }"
       />
       {{ tab.title }}
+      <v-chip color="info" v-if="tab.title === 'Workers'" class="ml-1">{{ tab.workers }}</v-chip>
       <v-chip color="info" v-if="forms[tabs.indexOf(tab)]?.pending" class="ml-1">
         Validating
         <v-progress-circular class="ml-1" indeterminate size="20" width="2" />
@@ -49,6 +50,7 @@ export interface Tab {
   value: string;
   icon?: string;
   imgPath?: string;
+  workers?: number;
 }
 
 const props = defineProps<{

--- a/packages/playground/src/components/dynamic_tabs.vue
+++ b/packages/playground/src/components/dynamic_tabs.vue
@@ -13,7 +13,7 @@
         }"
       />
       {{ tab.title }}
-      <v-chip color="info" v-if="tab.title === 'Workers'" class="ml-1">{{ tab.workers }}</v-chip>
+      <v-chip color="info" v-if="tab.workers && tab.workers > 0" class="ml-1">{{ tab.workers }}</v-chip>
       <v-chip color="info" v-if="forms[tabs.indexOf(tab)]?.pending" class="ml-1">
         Validating
         <v-progress-circular class="ml-1" indeterminate size="20" width="2" />

--- a/packages/playground/src/weblets/tf_caprover.vue
+++ b/packages/playground/src/weblets/tf_caprover.vue
@@ -21,7 +21,7 @@
       :tabs="[
         { title: 'Config', value: 'config' },
         { title: 'Leader', value: 'leader' },
-        { title: 'Workers', value: 'workers' },
+        { title: 'Workers', value: 'workers', workers: workers.length },
       ]"
       ref="tabs"
     >

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -18,7 +18,7 @@
       :tabs="[
         { title: 'Config', value: 'config' },
         { title: 'Master', value: 'master' },
-        { title: 'Workers', value: 'workers' },
+        { title: 'Workers', value: 'workers', workers: workers.length },
       ]"
       ref="tabs"
     >


### PR DESCRIPTION
### Changes

- Add workers optional prop in tabs
- Apply change in k8s & caprover

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/4bc64e0b-f8cf-421a-ac88-67ced64c5eea)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/de92b0c6-1a6d-455c-aadc-9ec89b127b4b)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2471


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
