### PR TITLE
Fix err msg in loadk8s & loadVms

### DIFF
--- a/packages/playground/src/utils/load_deployment.ts
+++ b/packages/playground/src/utils/load_deployment.ts
@@ -78,16 +78,13 @@ export async function loadVms(grid: GridClient, options: LoadVMsOptions = {}) {
     try {
       const result = await Promise.race([machinePromise, timeoutPromise]);
       if (result instanceof Error && result.message === "Timeout") {
-        console.log(`%c[Error] Timeout loading deployment with name ${name}`, "color: rgb(207, 102, 121)");
+        console.error(`Timeout loading deployment with name ${name}`);
         return null;
       } else {
         return result;
       }
     } catch (e) {
-      console.log(
-        `%c[Error] failed to load deployment with name ${name}:\n${normalizeError(e, "No errors were provided.")}`,
-        "color: rgb(207, 102, 121)",
-      );
+      console.error(`Failed to load deployment with name ${name}:\n${normalizeError(e, "No errors were provided.")}`);
       failedDeployments.push({ name, nodes: nodeIds, contracts: contracts });
     }
   });
@@ -197,19 +194,16 @@ export async function loadK8s(grid: GridClient) {
 
       const result = await Promise.race([clusterPromise, timeoutPromise]);
       if (result instanceof Error && result.message === "Timeout") {
-        console.log(`%c[Error] Timeout loading deployment with name ${name}`, "color: rgb(207, 102, 121)");
+        console.error(`Timeout loading deployment with name ${name}`);
         return null;
       } else if ((result as any).masters.length === 0 && (result as any).workers.length === 0) {
-        console.log(`%c[Error] failed to load deployment with name ${name}}`, "color: rgb(207, 102, 121)");
+        console.error(`Failed to load deployment with name ${name}}`);
         failedDeployments.push({ name, nodes: nodeIds, contracts: contracts });
       } else {
         return result;
       }
     } catch (e) {
-      console.log(
-        `%c[Error] failed to load deployment with name ${name}:\n${normalizeError(e, "No errors were provided.")}`,
-        "color: rgb(207, 102, 121)",
-      );
+      console.error(`Failed to load deployment with name ${name}:\n${normalizeError(e, "No errors were provided.")}`);
       failedDeployments.push({ name, nodes: nodeIds, contracts: contracts });
     }
   });


### PR DESCRIPTION
### Description

The issue happened because we used console log instead of console error.

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/48abdef3-1919-4019-8061-c01b203dd382)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/4b671d1f-b5b5-492c-b378-1bac631a542b)


### Changes

- Use console.err instead of console.log and remove color and rephrase err msgs in load vms & load k8s

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2227

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
