### PR TITLE
Edit subdomain char limit

### DIFF
--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -340,7 +340,7 @@ class GetServiceContractModel {
   @Expose() @IsInt() @Min(1) serviceId: number;
 }
 class NameContractGetModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(30) name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength + 20) name: string;
 }
 
 class NodeContractUpdateModel {

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -340,7 +340,7 @@ class GetServiceContractModel {
   @Expose() @IsInt() @Min(1) serviceId: number;
 }
 class NameContractGetModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength) name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(30) name: string;
 }
 
 class NodeContractUpdateModel {

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -263,12 +263,8 @@ export default {
     const networkName = props.vm.interfaces[0].network as string;
 
     onMounted(async () => {
-      const grid = await getGrid(profileManager.profile!);
-      oldPrefix.value =
-        (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
-        grid!.config.twinId;
-      prefix.value = oldPrefix.value + props.vm.name;
-      subdomain.value = generateName({}, 35 - prefix.value.length > 7 ? 7 : 35 - prefix.value.length);
+      prefix.value = props.vm.name;
+      subdomain.value = generateName({}, 35 - prefix.value.length > 5 ? 5 : 35 - prefix.value.length);
       await loadGateways();
     });
 

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -118,7 +118,7 @@
                   validators.isAlphanumeric('Subdomain should consist of letters and numbers only.'),
                   subdomain => validators.isAlpha('Subdomain must start with alphabet char.')(subdomain[0]),
                   validators.minLength('Subdomain must be at least 4 characters.', 4),
-                  subdomain => validators.maxLength('Subdomain cannot exceed 15 characters.', 15)(subdomain),
+                  subdomain => validators.maxLength('Subdomain cannot exceed 30 characters.', 30)(subdomain),
                 ]"
                 :async-rules="[validateSubdomain]"
                 #="{ props }"

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -118,7 +118,7 @@
         <div v-show="gatewayTab === 1">
           <form-validator v-model="valid">
             <input-tooltip
-              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix (${prefix}) is the deployment name.`"
+              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix(${prefix}) is solution name, twin ID, and deployment name.`"
             >
               <input-validator
                 :value="subdomain"
@@ -263,13 +263,12 @@ export default {
     const networkName = props.vm.interfaces[0].network as string;
 
     onMounted(async () => {
+      const grid = await getGrid(profileManager.profile!);
       oldPrefix.value =
         (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
-        profileManager.profile!.twinId +
-        props.vm.name;
-
-      prefix.value = props.vm.name;
-      subdomain.value = generateName({}, 35 - prefix.value.length > 5 ? 5 : 35 - prefix.value.length);
+        grid!.config.twinId;
+      prefix.value = oldPrefix.value + props.vm.name;
+      subdomain.value = generateName({}, 35 - prefix.value.length > 7 ? 7 : 35 - prefix.value.length);
       await loadGateways();
     });
 

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -118,7 +118,7 @@
         <div v-show="gatewayTab === 1">
           <form-validator v-model="valid">
             <input-tooltip
-              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix(${prefix}) is solution name, twin ID, and deployment name.`"
+              :tooltip="`Selecting custom domain sets subdomain as gateway name. Prefix (${prefix}) is the deployment name.`"
             >
               <input-validator
                 :value="subdomain"
@@ -263,6 +263,11 @@ export default {
     const networkName = props.vm.interfaces[0].network as string;
 
     onMounted(async () => {
+      oldPrefix.value =
+        (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
+        profileManager.profile!.twinId +
+        props.vm.name;
+
       prefix.value = props.vm.name;
       subdomain.value = generateName({}, 35 - prefix.value.length > 5 ? 5 : 35 - prefix.value.length);
       await loadGateways();

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -223,7 +223,7 @@ import { deployGatewayName, type GridGateway, loadDeploymentGateways } from "../
 import { getGrid } from "../utils/grid";
 import { normalizeError } from "../utils/helpers";
 import { generateName } from "../utils/strings";
-import { isValidSubdomain } from "../utils/validators";
+import { isAvailableName } from "../utils/validators";
 import IconActionBtn from "./icon_action_btn.vue";
 import ListTable from "./list_table.vue";
 import { useLayout } from "./weblet_layout.vue";
@@ -336,7 +336,7 @@ export default {
 
     async function validateSubdomain() {
       const grid = await getGrid(profileManager.profile!, props.vm.projectName);
-      return await isValidSubdomain(grid!, subdomain.value);
+      return await isAvailableName(grid!, subdomain.value);
     }
 
     return {

--- a/packages/playground/src/utils/validators.ts
+++ b/packages/playground/src/utils/validators.ts
@@ -773,10 +773,9 @@ export async function isValidStellarAddress(target: string): Promise<RuleReturn>
   }
 }
 
-export async function isValidSubdomain(grid: GridClient, subdomain: string) {
-  const valid = await grid.contracts.get_name_contract({ name: subdomain });
-  console.log({ valid });
-  if (subdomain && !!valid) {
-    return { message: "Subdomain  already exists." };
+export async function isAvailableName(grid: GridClient, name: string) {
+  const valid = await grid.contracts.get_name_contract({ name });
+  if (name && !!valid) {
+    return { message: "Name is already taken." };
   }
 }

--- a/packages/playground/src/utils/validators.ts
+++ b/packages/playground/src/utils/validators.ts
@@ -1,3 +1,4 @@
+import type { GridClient } from "@threefold/grid_client";
 import StellarSdk from "stellar-sdk";
 import validator from "validator";
 import type { Options } from "validator/lib/isBoolean";
@@ -769,5 +770,13 @@ export async function isValidStellarAddress(target: string): Promise<RuleReturn>
         ? "Address does not have a valid trustline to TFT"
         : "Address not found";
     return { message };
+  }
+}
+
+export async function isValidSubdomain(grid: GridClient, subdomain: string) {
+  const valid = await grid.contracts.get_name_contract({ name: subdomain });
+  console.log({ valid });
+  if (subdomain && !!valid) {
+    return { message: "Subdomain  already exists." };
   }
 }


### PR DESCRIPTION
### Changes

- Validate subdomain
- Edit subdomain to include prefix by default
- Edit max char subdomain as the validation function used gets a name argument with max 30 char
- Edit max contract name in get_name_contract to 30
- Edit tooltip & table name

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2564


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
