### PR TITLE
Add dedicated node discount tooltip

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -224,7 +224,7 @@
 </template>
 <script lang="ts">
 import type { NodeInfo, NodeResources } from "@threefold/grid_client";
-import { CertificationType, GridNode } from "@threefold/gridproxy_client";
+import { CertificationType, type GridNode } from "@threefold/gridproxy_client";
 import { computed, onMounted, ref } from "vue";
 import { capitalize } from "vue";
 

--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -198,15 +198,13 @@
             <v-spacer />
             <ul class="pl-2">
               <li>
-                {{ rentedByUser ? "You receive " : "You'll receive " }} 50%
-                <a target="_blank" :href="manual?.billing_pricing"> discount </a>
-                {{ rentedByUser ? " as you reserve the " : " if you reserve the " }} entire node
+                {{ rentedByUser ? "You receive " : "You'll receive " }} a 50%
+                <a target="_blank" :href="manual?.billing_pricing">discount</a>
+                {{ rentedByUser ? " as you reserve the" : " if you reserve the" }} entire node
               </li>
               <li>
-                {{ rentedByUser ? "You receive " : "You'll receive " }} {{ stakingDiscount }}% discount as per the
-                <a target="_blank" :href="manual?.discount_levels">
-                  <p style="display: inline">staking discounts</p>
-                </a>
+                {{ rentedByUser ? "You receive" : "You'll receive" }} a {{ stakingDiscount }}% discount as per the
+                <a target="_blank" :href="manual?.discount_levels"> staking discounts </a>
               </li>
             </ul>
           </span>

--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -189,7 +189,29 @@
         </VCol>
       </VRow>
       <div class="mt-5 ml-auto text-right">
-        <span v-if="price_usd" class="font-weight-bold">{{ price_usd }} USD/Month</span>
+        <v-tooltip bottom color="primary" close-delay="100" :disabled="!(node && node.dedicated)">
+          <template v-slot:activator="{ isActive, props }">
+            <span v-bind="props" v-on="isActive" class="font-weight-bold">{{ price_usd }} USD/Month</span>
+          </template>
+          <span>
+            Discounts:
+            <v-spacer />
+            <ul class="pl-2">
+              <li>
+                {{ rentedByUser ? "You receive " : "You'll receive " }} 50%
+                <a target="_blank" :href="manual?.billing_pricing"> discount </a>
+                {{ rentedByUser ? " as you reserve the " : " if you reserve an " }} entire node
+              </li>
+              <li>
+                {{ rentedByUser ? "You're receiving " : "You'll be receiving " }} {{ 0 }}% discount as per the
+                <a target="_blank" :href="manual?.discount_levels">
+                  <p style="display: inline">staking discounts</p>
+                </a>
+              </li>
+            </ul>
+          </span>
+        </v-tooltip>
+
         <reserve-btn
           v-if="node?.dedicated && node?.status !== 'down'"
           class="ml-4"
@@ -208,8 +230,10 @@ import { capitalize } from "vue";
 
 import ReserveBtn from "@/dashboard/components/reserve_action_btn.vue";
 import { getCountryCode } from "@/utils/get_nodes";
+import { manual } from "@/utils/manual";
 import toReadableDate from "@/utils/to_readable_data";
 
+import { useProfileManager } from "../../stores";
 import formatResourceSize from "../../utils/format_resource_size";
 import ResourceDetails from "./node_details_internals/ResourceDetails.vue";
 
@@ -227,7 +251,11 @@ export default {
     "reload-table": (id: number) => id,
   },
   setup(props) {
+    const profileManager = useProfileManager();
     const node = ref(props.node);
+    const rentedByUser = computed(() => {
+      return props.node?.rentedByTwinId === profileManager.profile?.twinId;
+    });
     const countryFlagSrc = computed(() => {
       const countryCode = getCountryCode(props.node as GridNode);
       if (countryCode.length > 2) {
@@ -354,6 +382,8 @@ export default {
       speed,
       price_usd,
       dmi,
+      manual,
+      rentedByUser,
       checkSerialNumber,
       capitalize,
       formatResourceSize,

--- a/packages/playground/src/utils/manual.ts
+++ b/packages/playground/src/utils/manual.ts
@@ -11,8 +11,8 @@ export const manual = {
   caprover: `${BASE}/documentation/dashboard/solutions/caprover.html`,
   tf_connect_app: `${BASE}/documentation/threefold_token/storing_tft/tf_connect_app.html`,
   contract_locking: `${BASE}/documentation/developers/tfchain/tfchain.html#contract-locking`,
-  billing_pricing: `${BASE}/dashboard/deploy/dedicated_machines.html#billing--pricing`,
-  discount_levels: `${BASE}/wiki/cloudunits/pricing/staking_discount_levels.html#staking-discount-levels`,
+  billing_pricing: `${BASE}/documentation/dashboard/deploy/dedicated_machines.html#billing--pricing`,
+  discount_levels: `${BASE}/knowledge_base/cloud/pricing/pricing.html#staking-discount`,
   tfchain_stellar_bridge: `${BASE}/documentation/threefold_token/tft_bridges/tfchain_stellar_bridge.html`,
   minting_receipts: `${BASE}/documentation/farmers/3node_building/minting_receipts.html`,
 };


### PR DESCRIPTION
### Description

Add dedicated node discount tooltip when user hovers over the price

Node rented by user:
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/624f61e2-56ca-445c-be7b-c3f8f35eee68)

Node not rented by user:
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/8b05c507-3f57-4717-b9af-87031f763dbd)


### Changes

- Add dedicated node discount tooltip
- Fix tooltips URLs

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2576

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
