### PR TITLE
Add support for rentable filter in node finder page

### DIFF
--- a/packages/playground/src/components/filters/TfFilter.vue
+++ b/packages/playground/src/components/filters/TfFilter.vue
@@ -85,7 +85,11 @@ export default {
     }));
 
     filtersContainerService.register(props.value.queryRoute, service);
-    onUnmounted(() => filtersContainerService.unregister(props.value.queryRoute));
+    onUnmounted(() => {
+      const changed = props.value.modelValue !== initialValue;
+      changed && ctx.emit("update:model-value", initialValue);
+      filtersContainerService.unregister(props.value.queryRoute, changed);
+    });
 
     return { colProps };
   },

--- a/packages/playground/src/components/filters/TfFiltersContainer.vue
+++ b/packages/playground/src/components/filters/TfFiltersContainer.vue
@@ -99,7 +99,7 @@ export interface FilterService {
 
 export interface FiltersContainerService {
   register(name: string, service: ComputedRef<FilterService>): void;
-  unregister(name: string): void;
+  unregister(name: string, changed?: boolean): void;
 }
 
 export function useFiltersContainerService() {
@@ -129,7 +129,15 @@ export default {
         filters.value.set(name, service);
       },
 
-      unregister(name) {
+      unregister(name, changed) {
+        if (changed) {
+          const query = { ...router.currentRoute.value.query };
+          if (name in query) {
+            delete query[name];
+            router.replace({ query });
+            ctx.emit("apply");
+          }
+        }
         filters.value.delete(name);
       },
     };

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -41,6 +41,17 @@
             />
           </TfFilter>
 
+          <TfFilter query-route="rentable" v-model="filters.rentable" v-if="profileManager.profile">
+            <v-switch
+              color="primary"
+              inset
+              label="Rentable (Only)"
+              v-model="filters.rentable"
+              density="compact"
+              hide-details
+            />
+          </TfFilter>
+
           <TfFilter class="mt-4" query-route="node-status" v-model="filters.status">
             <v-select
               :model-value="filters.status || undefined"
@@ -419,6 +430,7 @@ import { useRoute } from "vue-router";
 import NodeDetails from "@/components/node_details.vue";
 import NodesTable from "@/components/nodes_table.vue";
 import router from "@/router";
+import { useProfileManager } from "@/stores";
 import type { GridProxyRequestConfig } from "@/types";
 import { getNode, requestNodes } from "@/utils/get_nodes";
 import { convertToBytes } from "@/utils/get_nodes";
@@ -428,6 +440,7 @@ import TfFiltersContainer from "../components/filters/TfFiltersContainer.vue";
 import TfFiltersLayout from "../components/filters/TfFiltersLayout.vue";
 import TfSelectFarm from "../components/node_selector/TfSelectFarm.vue";
 import TfSelectLocation from "../components/node_selector/TfSelectLocation.vue";
+
 export default {
   components: {
     NodesTable,
@@ -439,6 +452,7 @@ export default {
     TfFiltersLayout,
   },
   setup() {
+    const profileManager = useProfileManager();
     const size = ref(window.env.PAGE_SIZE);
     const page = ref(1);
     const nodeId = ref<number>(0);
@@ -460,6 +474,7 @@ export default {
       gpu: false,
       publicIPs: "",
       dedicated: false,
+      rentable: false,
     });
 
     const loading = ref<boolean>(true);
@@ -506,6 +521,8 @@ export default {
             dedicated: filters.value.dedicated || undefined,
             sortBy: SortBy.Status,
             sortOrder: SortOrder.Asc,
+            rentable: filters.value.rentable && profileManager.profile ? filters.value.rentable : undefined,
+            availableFor: filters.value.rentable && profileManager.profile ? profileManager.profile.twinId : undefined,
           },
           { loadFarm: true },
         );
@@ -562,6 +579,7 @@ export default {
     }
 
     return {
+      profileManager,
       loading,
       nodesCount,
       nodes,


### PR DESCRIPTION
### Description
Add support for rentable filter in node finder page

### Changes
- feat: Support rentable filter and clear query when unregister a filter

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2523

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/a2a5b385-5f9a-42ba-9f7f-84bab7637584)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/7eefa427-4a91-4e38-8071-da73e7890f2a)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
