### PR TITLE
dashboard with bootstrap view

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -347,7 +347,7 @@ const routes: AppRoute[] = [
       {
         title: "Node Installer",
         icon: "mdi-earth",
-        url: DashboardRoutes.Farms.NodeInstaller,
+        route: DashboardRoutes.TFChain.NodeInstaller,
         tooltip: "Download Zero-OS Images.",
       },
       {

--- a/packages/playground/src/dashboard/node_installer_view.vue
+++ b/packages/playground/src/dashboard/node_installer_view.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <iframe :src="ruta" height="1400" width="100%"></iframe>
+  </div>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    ruta: "https://bootstrap.grid.tf/",
+  }),
+};
+</script>

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -408,6 +408,11 @@ function createTFFarmsRoutes(): RouteRecordRaw[] {
           meta: { title: "Farm Finder", publicPath: true, sidebarBreakpoint: 1000, filtersCollapsibleBreakpoint: 1350 },
         },
         {
+          path: DashboardRoutes.TFChain.NodeInstaller,
+          component: () => import("../dashboard/node_installer_view.vue"),
+          meta: { title: "Node Installer" },
+        },
+        {
           path: DashboardRoutes.Farms.Simulator,
           component: () => import("../dashboard/simulator_view.vue"),
           meta: { title: "Twin", publicPath: true },

--- a/packages/playground/src/router/routes.ts
+++ b/packages/playground/src/router/routes.ts
@@ -42,6 +42,7 @@ enum TFChainRoutes {
   TFTokenBridge = "/tf-chain/token-bridge/",
   TFTokenTransfer = "/tf-chain/token-transfer/",
   TFMintingReports = "/tf-chain/minting-reports/",
+  NodeInstaller = "/tf-chain/node-installer/",
 }
 
 enum OtherRoutes {


### PR DESCRIPTION
# Related Issue

#2584 

# Work Done

- Integrated the bootstrap page within the Dashboard

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/77026219/8d522dd2-a383-487d-a886-3d961791b4c9)

# Tests

- I can deploy on a full VM the dashboard, go to the bootstrap page within the dashboard and download a bootstrap image