### PR TITLE
footer coverd by logs

### DIFF
--- a/packages/playground/src/components/logger.vue
+++ b/packages/playground/src/components/logger.vue
@@ -1,5 +1,5 @@
 <template>
-  <VBottomNavigation :height="debugOpened === 0 ? openHeight : undefined">
+  <VBottomNavigation class="border" :height="debugOpened === 0 ? openHeight : undefined">
     <v-expansion-panels :model-value="debugOpened" @update:model-value="bindDebugOpened" :multiple="false">
       <v-expansion-panel eager>
         <v-expansion-panel-title :class="{ 'text-error': !!connectDB.error }">

--- a/packages/playground/src/components/main_footer.vue
+++ b/packages/playground/src/components/main_footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer class="py-5 mainfooter border mt-5">
+  <v-footer class="py-2 mainfooter mt-5">
     <v-container>
       <v-row justify="center" no-gutters>
         <v-col class="px-4" cols="12" md="4">
@@ -9,7 +9,7 @@
                 ? baseUrl + 'images/logoTF_dark.png'
                 : baseUrl + 'images/logoTF_light.png'
             }`"
-            width="160px"
+            width="140px"
             @click="navigateToHome"
             class="clickable-logo"
           />
@@ -81,8 +81,8 @@
           </div>
         </v-col>
       </v-row>
-      <v-divider class="my-4" />
-      <div class="text-center">{{ new Date().getFullYear() }} — ThreeFoldTech</div>
+      <v-divider class="my-3 w-25 mx-auto" />
+      <div class="text-center mb-12">{{ new Date().getFullYear() }} — ThreeFoldTech</div>
     </v-container>
   </v-footer>
 </template>

--- a/packages/playground/src/components/main_footer.vue
+++ b/packages/playground/src/components/main_footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer class="py-2 mainfooter mt-5">
+  <v-footer class="py-3 mainfooter mt-5">
     <v-container>
       <v-row justify="center" no-gutters>
         <v-col class="px-4" cols="12" md="4">


### PR DESCRIPTION
### Description

footer covered by logs 

### Changes
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/99868a97-e34f-4fd8-b75b-0e0e13147de1)

moving the footer up so logs are not covered it also trying to make the logos button clear
I separated the logs from the footer by adding a frame border and made a small border between the footer and the copyright.

### Related Issues
#2262

List of related issues

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
