### PR TITLE
Enable accept T&C btn

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -216,7 +216,6 @@
                       v-show="!termsLoading"
                       :color="theme.name.value === AppThemeSelection.light ? 'black' : 'white'"
                       variant="outlined"
-                      id="accept-terms-and-condation"
                       :text="capitalize('go back')"
                     />
                     <v-btn
@@ -893,11 +892,18 @@ watch(openAcceptTerms, async () => {
 });
 
 function onScroll(e: UIEvent) {
-  const target = e.target as HTMLElement;
-  if (target.scrollTop + target.clientHeight >= target.scrollHeight) {
-    if (!termsLoading.value) {
-      disableTermsBtn.value = false;
-    }
+  const buttonElement = document.getElementById("accept-terms-and-condation");
+
+  if (!buttonElement) {
+    return;
+  }
+
+  const buttonRect = buttonElement.getBoundingClientRect();
+  const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+
+  // Check if the top of the button is within the viewport
+  if (buttonRect.top >= 0 && buttonRect.bottom <= windowHeight) {
+    disableTermsBtn.value = false;
   }
 }
 </script>

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -207,7 +207,7 @@
               </VTooltip>
 
               <v-dialog v-model="openAcceptTerms" fullscreen>
-                <v-card @scroll="onScroll" v-if="!termsLoading">
+                <v-card v-if="!termsLoading">
                   <v-card-text class="pa-15" v-html="acceptTermsContent"></v-card-text>
                   <div class="terms-footer">
                     <v-btn
@@ -222,8 +222,6 @@
                       @click="shouldActivateAccount ? activateAccount() : createNewAccount()"
                       v-show="!termsLoading"
                       color="primary"
-                      id="accept-terms-and-condation"
-                      :disabled="disableTermsBtn"
                       :text="capitalize('accept terms and conditions')"
                     />
                   </div>
@@ -463,8 +461,6 @@ interface Credentials {
 const keyType = ["sr25519", "ed25519"];
 const keypairType = ref(KeypairType.sr25519);
 const enableReload = ref(true);
-const disableTermsBtn = ref(true);
-
 const theme = useTheme();
 const qrCodeText = ref("");
 const props = defineProps({
@@ -890,22 +886,6 @@ watch(openAcceptTerms, async () => {
     }
   }
 });
-
-function onScroll(e: UIEvent) {
-  const buttonElement = document.getElementById("accept-terms-and-condation");
-
-  if (!buttonElement) {
-    return;
-  }
-
-  const buttonRect = buttonElement.getBoundingClientRect();
-  const windowHeight = window.innerHeight || document.documentElement.clientHeight;
-
-  // Check if the top of the button is within the viewport
-  if (buttonRect.top >= 0 && buttonRect.bottom <= windowHeight) {
-    disableTermsBtn.value = false;
-  }
-}
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
### Description

- We used to show the button only when users reached the bottom of the page because our content came from an iframe and the button was on top of it. Now, we've changed this setup so that the button is always at the end of the window. This made the onscroll function and disableTermBtn unnecessary, so I removed them.

- Remove unused ids

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2549

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
