### PR TITLE
Wait for the opening connection in rmb client before closing it

### DIFF
--- a/packages/rmb_direct_client/lib/client.ts
+++ b/packages/rmb_direct_client/lib/client.ts
@@ -185,9 +185,17 @@ class Client {
     }
   }
 
+  private dropPingEnvelope() {
+    for (const id of this.responses.keys()) {
+      const envelope = this.responses.get(id);
+      if (envelope?.has_ping) this.responses.delete(id);
+    }
+  }
+
   private async waitForResponses(timeoutInSeconds = 2 * 60): Promise<void> {
     const start = new Date().getTime();
     while (new Date().getTime() < start + timeoutInSeconds * 1000) {
+      this.dropPingEnvelope();
       if (this.responses.size === 0) return;
       this.logPendingResponses();
       await new Promise(f => setTimeout(f, 1000));

--- a/packages/rmb_direct_client/lib/client.ts
+++ b/packages/rmb_direct_client/lib/client.ts
@@ -204,6 +204,7 @@ class Client {
   }
 
   async disconnect() {
+    if (this.con.readyState === this.con.CONNECTING) await this.waitForOpenConnection();
     if (this.__pingPongTimeout) clearTimeout(this.__pingPongTimeout);
     this.con.removeAllListeners();
     await this.waitForResponses();


### PR DESCRIPTION
### Description

- Drop ping envelopes when disconnecting the rmb client
- Wait for the connection to be opened in case it's opening before closing it

### Related Issues

- #2611 

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
