### PR TITLE
Display prepend icons in mnemonic input when validate

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -155,15 +155,10 @@
                               :disabled="creatingAccount || activatingAccount || activating"
                               @click:append="reloadValidation"
                             >
-                              <template
-                                v-slot:prepend-inner
-                                v-if="
-                                  (mnemonic && validateMnemonic(mnemonic)) ||
-                                  ((mnemonic.length === 64 || mnemonic.length === 66) &&
-                                    isAddress(mnemonic.length === 66 ? mnemonic : `0x${mnemonic}`))
-                                "
-                              >
-                                <v-icon color="green"> mdi-check </v-icon>
+                              <template v-slot:prepend-inner v-if="validationProps.hint || validationProps.error">
+                                <v-icon :color="validationProps.error ? 'red' : 'green'">
+                                  {{ validationProps.error ? "mdi-close" : "mdi-check" }}
+                                </v-icon>
                               </template></VTextField
                             >
                           </div>


### PR DESCRIPTION
### Description

Display prepend icons in mnemonic input when it's valid and when it's not valid.

### Changes

[Screencast from 02-05-24 17:19:30.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/11662805/53a8b2ed-c2b4-43be-95b7-c78b0eb109d8)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2588
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
