### PR TITLE
Fix: Gateway contract isn't deleted after deleting CasperLabs instance

### DIFF
--- a/packages/playground/src/utils/delete_deployment.ts
+++ b/packages/playground/src/utils/delete_deployment.ts
@@ -65,6 +65,7 @@ export function solutionHasGateway(projectName: ProjectName) {
     ProjectName.Funkwhale,
     ProjectName.Mastodon,
     ProjectName.Mattermost,
+    ProjectName.Casperlabs,
     ProjectName.Owncloud,
     ProjectName.Peertube,
     ProjectName.Subsquid,


### PR DESCRIPTION
### Description

Fix deleting the gateway contract in the Casperlabs solution by adding the 'Casperlabs' project name in the solutionHasGateway function.

### Changes

- added the `Casperlabs` project name in the `solutionHasGateway` function.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2621

### Screenshots/Video

[Screencast from 05-07-2024 02:12:16 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/4ba77ae7-0e06-4b17-b34b-e5ba480d49d9)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
