### PR TITLE
Make ssh key editable

### DIFF
--- a/packages/playground/src/components/ssh_keys/ManageSshDeployemnt.vue
+++ b/packages/playground/src/components/ssh_keys/ManageSshDeployemnt.vue
@@ -83,7 +83,12 @@
   </v-dialog>
 
   <!-- View SSH Key -->
-  <ssh-data-dialog :open="isViewSSHKey" :selected-key="selectedKey" @close="onCloseSelectKey" />
+  <ssh-data-dialog
+    :open="isViewSSHKey"
+    :selected-key="selectedKey"
+    :all-keys="selectedKeys"
+    @close="onCloseSelectKey"
+  />
 </template>
 
 <script lang="ts">

--- a/packages/playground/src/components/ssh_keys/SshDataDialog.vue
+++ b/packages/playground/src/components/ssh_keys/SshDataDialog.vue
@@ -18,7 +18,7 @@
                 <v-text-field
                   v-bind="{ ...copyInputProps }"
                   :label="_key"
-                  v-model="currentKey[_key]"
+                  v-model="currentKey[_key as keyof SSHKeyData]"
                   :readonly="_key === 'fingerPrint'"
                   :rules="[(value: string) => !!value || `${_key} is required.`]"
                 />

--- a/packages/playground/src/components/ssh_keys/SshDataDialog.vue
+++ b/packages/playground/src/components/ssh_keys/SshDataDialog.vue
@@ -10,8 +10,12 @@
         <v-toolbar color="primary" class="custom-toolbar">
           <p class="mb-5">SSH-Key Details</p>
         </v-toolbar>
-
         <v-card-text>
+          <VAlert type="info" class="mb-5">
+            Updating your SSH key will lead to the loss of all associated deployments. Please consider this before
+            making any changes.
+          </VAlert>
+
           <template v-for="[_key, value] of Object.entries(selectedKey).sort()" :key="_key">
             <template v-if="!notNeededFields.includes(_key)">
               <CopyInputWrapper v-if="_key !== 'publicKey'" :data="value" #="{ props: copyInputProps }">

--- a/packages/playground/src/components/ssh_keys/SshDataDialog.vue
+++ b/packages/playground/src/components/ssh_keys/SshDataDialog.vue
@@ -11,11 +11,6 @@
           <p class="mb-5">SSH-Key Details</p>
         </v-toolbar>
         <v-card-text>
-          <VAlert type="info" class="mb-5">
-            Updating your SSH key will lead to the loss of all associated deployments. Please consider this before
-            making any changes.
-          </VAlert>
-
           <template v-for="[_key, value] of Object.entries(selectedKey).sort()" :key="_key">
             <template v-if="!notNeededFields.includes(_key)">
               <CopyInputWrapper v-if="_key !== 'publicKey'" :data="value" #="{ props: copyInputProps }">

--- a/packages/playground/src/components/ssh_keys/SshDataDialog.vue
+++ b/packages/playground/src/components/ssh_keys/SshDataDialog.vue
@@ -91,6 +91,7 @@ export default defineComponent({
       newValue => {
         if (newValue) {
           currentKey.value = { ...props.selectedKey };
+          loading.value = false;
         }
       },
     );
@@ -99,14 +100,12 @@ export default defineComponent({
     const sshKeysManagement = new SSHKeysManagement();
     const updateKey = () => {
       loading.value = true;
-      ctx.emit("update", currentKey);
-      ctx.emit("close");
-      loading.value = false;
+      ctx.emit("update", currentKey.value);
     };
 
     function sshRules(value: any) {
       return [
-        (v: string) => !!v || "SSH key is required.",
+        (v: string) => !!v || " The SSH key is required.",
         (v: string) =>
           sshKeysManagement.isValidSSHKey(v) ||
           "The SSH key you provided is not valid. Please double-check that it is copied correctly and follows the correct format.",

--- a/packages/playground/src/components/ssh_keys/SshDataDialog.vue
+++ b/packages/playground/src/components/ssh_keys/SshDataDialog.vue
@@ -8,23 +8,29 @@
     <template v-slot:default>
       <v-card>
         <v-toolbar color="primary" class="custom-toolbar">
-          <p class="mb-5">SSH-Key Detials</p>
+          <p class="mb-5">SSH-Key Details</p>
         </v-toolbar>
 
         <v-card-text>
           <template v-for="[_key, value] of Object.entries(selectedKey).sort()" :key="_key">
             <template v-if="!notNeededFields.includes(_key)">
               <CopyInputWrapper v-if="_key !== 'publicKey'" :data="value" #="{ props: copyInputProps }">
-                <v-text-field v-bind="{ ...copyInputProps }" :label="_key" :model-value="value" :readonly="true" />
+                <v-text-field
+                  v-bind="{ ...copyInputProps }"
+                  :label="_key"
+                  v-model="currentKey[_key]"
+                  :readonly="_key === 'fingerPrint'"
+                  :rules="[(value: string) => !!value || `${_key} is required.`]"
+                />
               </CopyInputWrapper>
               <CopyInputWrapper v-else :data="value" #="{ props: copyInputProps }">
                 <v-textarea
                   :class="value.length ? 'ssh-key' : ''"
-                  :model-value="value"
-                  :readonly="true"
+                  v-model="currentKey[_key]"
                   label="Public SSH Key"
                   no-resize
                   :spellcheck="false"
+                  :rules="sshRules(currentKey[_key])"
                   v-bind="{ ...copyInputProps }"
                 />
               </CopyInputWrapper>
@@ -49,6 +55,7 @@
           <v-spacer></v-spacer>
           <div class="mt-2">
             <v-btn color="white" variant="outlined" text="Close" @click="$emit('close')"></v-btn>
+            <v-btn color="primary" variant="outlined" text="Save" @click="updateKey" :loading="loading"></v-btn>
           </div>
         </v-card-actions>
       </v-card>
@@ -57,13 +64,14 @@
 </template>
 
 <script lang="ts">
-import { capitalize, defineComponent, type PropType } from "vue";
+import { capitalize, defineComponent, type PropType, ref, watch } from "vue";
 
 import type { SSHKeyData } from "@/types";
+import SSHKeysManagement from "@/utils/ssh";
 
 export default defineComponent({
   name: "SSHDataDialog",
-  emits: ["close"],
+  emits: ["close", "update"],
   props: {
     open: {
       type: Boolean,
@@ -74,11 +82,44 @@ export default defineComponent({
       required: true,
     },
   },
-  setup() {
+  setup(props, ctx) {
+    const currentKey = ref<SSHKeyData>(props.selectedKey);
+    const loading = ref<boolean>(false);
+
+    watch(
+      () => props.open,
+      newValue => {
+        if (newValue) {
+          currentKey.value = { ...props.selectedKey };
+        }
+      },
+    );
+
     const notNeededFields = ["id", "activating", "deleting", "isActive", "createdAt"];
+    const sshKeysManagement = new SSHKeysManagement();
+    const updateKey = () => {
+      loading.value = true;
+      ctx.emit("update", currentKey);
+      ctx.emit("close");
+      loading.value = false;
+    };
+
+    function sshRules(value: any) {
+      return [
+        (v: string) => !!v || "SSH key is required.",
+        (v: string) =>
+          sshKeysManagement.isValidSSHKey(v) ||
+          "The SSH key you provided is not valid. Please double-check that it is copied correctly and follows the correct format.",
+      ];
+    }
+
     return {
       notNeededFields,
       capitalize,
+      updateKey,
+      currentKey,
+      sshRules,
+      loading,
     };
   },
 });

--- a/packages/playground/src/components/ssh_keys/SshDataDialog.vue
+++ b/packages/playground/src/components/ssh_keys/SshDataDialog.vue
@@ -20,7 +20,7 @@
                   :label="_key"
                   v-model="currentKey[_key as keyof SSHKeyData]"
                   :readonly="_key === 'fingerPrint'"
-                  :rules="[(value: string) => !!value || `${_key} is required.`]"
+                  :rules="[(value: string) => !!value || `${_key} is required.`, _key === 'name' ? validateName(currentKey.name): true]"
                 />
               </CopyInputWrapper>
               <CopyInputWrapper v-else :data="value" #="{ props: copyInputProps }">
@@ -81,6 +81,10 @@ export default defineComponent({
       type: Object as PropType<SSHKeyData>,
       required: true,
     },
+    allKeys: {
+      type: Object as PropType<SSHKeyData[]>,
+      required: true,
+    },
   },
   setup(props, ctx) {
     const currentKey = ref<SSHKeyData>(props.selectedKey);
@@ -109,7 +113,22 @@ export default defineComponent({
         (v: string) =>
           sshKeysManagement.isValidSSHKey(v) ||
           "The SSH key you provided is not valid. Please double-check that it is copied correctly and follows the correct format.",
+        (v: string) => {
+          if (v === props.selectedKey.publicKey) {
+            return true;
+          }
+          const found = props.allKeys.find(key => key.publicKey === v);
+          return found ? "You have another key with the same public key." : true;
+        },
       ];
+    }
+
+    function validateName(name: string): string | boolean {
+      if (name === props.selectedKey.name) {
+        return true;
+      }
+      const found = props.allKeys.find(key => key.name === name);
+      return found ? "You have another key with the same name." : true;
     }
 
     return {
@@ -119,6 +138,7 @@ export default defineComponent({
       currentKey,
       sshRules,
       loading,
+      validateName,
     };
   },
 });

--- a/packages/playground/src/utils/ssh.ts
+++ b/packages/playground/src/utils/ssh.ts
@@ -165,9 +165,7 @@ class SSHKeysManagement {
   list(): SSHKeyData[] {
     let keys: SSHKeyData[] = [];
 
-    if (!this.migrated()) {
-      return [];
-    } else {
+    if (this.migrated()) {
       keys = this.oldKey as unknown as SSHKeyData[];
     }
 

--- a/packages/playground/src/utils/ssh.ts
+++ b/packages/playground/src/utils/ssh.ts
@@ -166,7 +166,7 @@ class SSHKeysManagement {
     let keys: SSHKeyData[] = [];
 
     if (!this.migrated()) {
-      keys = this.migrate();
+      return [];
     } else {
       keys = this.oldKey as unknown as SSHKeyData[];
     }

--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -97,7 +97,13 @@
   />
 
   <!-- View -->
-  <ssh-data-dialog :open="isViewKey" :selected-key="selectedKey" @close="isViewKey = false" @update="updateKeys" />
+  <ssh-data-dialog
+    :open="isViewKey"
+    :all-keys="allKeys"
+    :selected-key="selectedKey"
+    @close="isViewKey = false"
+    @update="updateKeys"
+  />
 </template>
 
 <script lang="ts" setup>

--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -97,7 +97,7 @@
   />
 
   <!-- View -->
-  <ssh-data-dialog :open="isViewKey" :selected-key="selectedKey" @close="isViewKey = false" />
+  <ssh-data-dialog :open="isViewKey" :selected-key="selectedKey" @close="isViewKey = false" @update="updateKeys" />
 </template>
 
 <script lang="ts" setup>
@@ -274,6 +274,17 @@ const addKey = async (key: SSHKeyData) => {
   savingKey.value = false;
   loading.value = false;
   closeDialog();
+};
+
+const updateKeys = async (updatedKey: any) => {
+  const index = allKeys.value.findIndex(key => key.id === updatedKey.value.id);
+  allKeys.value[index] = { ...updatedKey.value };
+  try {
+    await sshKeysManagement.update(allKeys.value);
+    createCustomToast("SSH Key updated successfully.", ToastType.success);
+  } catch (error) {
+    createCustomToast("Failed to update your SSH Key!", ToastType.danger);
+  }
 };
 
 const generateSSHKeys = async (key: SSHKeyData) => {

--- a/packages/playground/src/views/sshkey_view.vue
+++ b/packages/playground/src/views/sshkey_view.vue
@@ -276,14 +276,16 @@ const addKey = async (key: SSHKeyData) => {
   closeDialog();
 };
 
-const updateKeys = async (updatedKey: any) => {
-  const index = allKeys.value.findIndex(key => key.id === updatedKey.value.id);
-  allKeys.value[index] = { ...updatedKey.value };
+const updateKeys = async (updatedKey: SSHKeyData) => {
+  const index = allKeys.value.findIndex(key => key.id === updatedKey.id);
+  allKeys.value[index] = { ...updatedKey };
   try {
     await sshKeysManagement.update(allKeys.value);
     createCustomToast("SSH Key updated successfully.", ToastType.success);
   } catch (error) {
-    createCustomToast("Failed to update your SSH Key!", ToastType.danger);
+    createCustomToast("Failed to update the SSH Key.", ToastType.danger);
+  } finally {
+    isViewKey.value = false;
   }
 };
 


### PR DESCRIPTION
### Description

Once the user creates or import an ssh key he can not edit it or change any field.

### Changes

- When user opens ssh key dialog, all fields editable now except the `fingerprint`.
- User can  update name or ssh key itself with the required validations.
- All changes will updated directly to the table, with toast showing if it went right or wrong.
- Fix `Maximum call stack size` issue.
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2628
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2666
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

[Screencast from 05-07-2024 03:33:31 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/a2cf1b22-58da-4154-8a82-f5d1e680365f)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
