### PR TITLE
fix listing multiple vms in same deployment

### DIFF
--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -221,12 +221,17 @@ async function loadDeployments() {
   failedDeployments.value = vms.failedDeployments;
 
   count.value = vms.count;
-  items.value = vms.items.map(([leader, ...workers]) => {
-    if (workers.length) {
-      leader.workers = workers;
-    }
-    return leader;
-  });
+  items.value = vms.items
+    .map((vm: any) => {
+      if (props.projectName.toLowerCase() === ProjectName.Caprover.toLowerCase()) {
+        const [leader, ...workers] = vm;
+        leader.workers = workers;
+        return leader;
+      }
+
+      return vm;
+    })
+    .flat();
 
   loading.value = false;
 }

--- a/packages/playground/src/utils/load_deployment.ts
+++ b/packages/playground/src/utils/load_deployment.ts
@@ -127,9 +127,11 @@ export async function loadVms(grid: GridClient, options: LoadVMsOptions = {}) {
   );
 
   const data = vms.map((vm, index) => {
-    vm[0].billing = formatConsumption(consumptions[index] as number);
-    if (wireguards[index] && wireguards[index].length > 0) {
-      vm[0].wireguard = wireguards[index][0];
+    for (let i = 0; i < vm.length; i++) {
+      vm[i].billing = formatConsumption(consumptions[index] as number);
+      if (wireguards[index] && wireguards[index].length > 0) {
+        vm[i].wireguard = wireguards[index][0];
+      }
     }
 
     return vm;


### PR DESCRIPTION
### Description

When deploying 2 VMs on a single deployment, the dashboard can list only one of the VMs.

### Changes

- Handled case of leader and workers only for caprover.
- Rest of Soultions will be listed as leaders.
 
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2509
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
