### PR TITLE
Enhancement: Updated the node status<standby> color in the node card component from red to yellow color

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -91,7 +91,7 @@
             <template #activator="{ props }">
               <VChip
                 v-bind="props"
-                :color="node?.status === 'up' ? 'success' : 'error'"
+                :color="getNodeStatusColor(node?.status)"
                 class="mr-2"
                 :text="capitalize(node.status)"
               />
@@ -437,6 +437,16 @@ export default {
       ctx.emit("update:node", n);
     }
 
+    function getNodeStatusColor(status: string): string {
+      if (status === "up") {
+        return "success";
+      } else if (status === "standby") {
+        return "warning";
+      } else {
+        return "error";
+      }
+    }
+
     return {
       cruText,
       mruText,
@@ -454,14 +464,15 @@ export default {
       manual,
       rentedByUser,
       loadingStakingDiscount,
+      stakingDiscount,
 
       toReadableDate,
-      stakingDiscount,
       checkSerialNumber,
       capitalize,
       formatResourceSize,
       formatSpeed,
       onReserveChange,
+      getNodeStatusColor,
     };
   },
 };


### PR DESCRIPTION
### Description

Updated the node status<standby> color in the node card component from red to yellow color

### Changes

- Created `getNodeStatusColor` to return the color based on the node status
`Success` for `UP`
`Warning` for `StandBy`
`Error` for `Down`

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2639

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/0d615ddb-c639-44bb-8972-c7a3963c7f47)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/8ab72a5b-9723-4b9b-aa46-b7ec18c01a4d)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/4e6bd585-87e4-47ad-b463-67364c52025d)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
