### PR TITLE
disable mnemonic validation when account is created

### DIFF
--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -138,7 +138,6 @@
                       valid-message="Mnemonic or Hex Seed is valid."
                       #="{ props: validationProps }"
                       ref="mnemonicInput"
-                      :disable-validation="creatingAccount || activatingAccount || activating"
                     >
                       <v-row>
                         <v-col cols="12" md="9">
@@ -722,6 +721,7 @@ async function createNewAccount() {
   openAcceptTerms.value = false;
   termsLoading.value = false;
   enableReload.value = false;
+  mnemonicInput.value.reset();
   clearError();
   creatingAccount.value = true;
   try {


### PR DESCRIPTION
### Description

- Disable mnemonic validation when the account is created.
- Reset mnemonic validation when creating a new account 
### Changes

[Screencast from 08-05-24 15:35:02.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/11662805/cf13d0ac-1408-46ac-b918-dbb1a79ad7bb)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2588#issuecomment-2100078791

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
