### PR TITLE
Add user's email by default in mail server

### DIFF
--- a/packages/playground/src/components/smtp_server.vue
+++ b/packages/playground/src/components/smtp_server.vue
@@ -139,13 +139,16 @@ defineProps<{
 </script>
 
 <script lang="ts">
+import { useProfileManager } from "../stores";
 import type { SMTPServer } from "../types";
 import { generatePassword } from "../utils/strings";
+
+const profileManager = useProfileManager();
 
 export function createSMTPServer(options: Partial<SMTPServer> = {}): SMTPServer {
   return {
     enabled: options.enabled || false,
-    username: options.username || "",
+    username: profileManager.profile?.email || options.username || "",
     email: options.email || "",
     hostname: options.hostname || "smtp.gmail.com",
     port: options.port || 587,


### PR DESCRIPTION
### Description

- I was unable to deploy a Discourse instance and couldn't figure out the error until I clicked on the mail server tab.

### Changes

- User's email added by default like other solutions
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2631
### Documentation PR

[Screencast from 05-09-2024 01:50:31 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/92534450-8756-4f06-b0fa-1d9c4ee1e3f5)



For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
