### PR TITLE
fix farm name validation

### DIFF
--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -33,9 +33,8 @@
                   validators.pattern('Farm name should not contain whitespaces.', {
                     pattern: /^[^\s]+$/,
                   }),
-
-                  validateFarmName,
                 ]"
+                :async-rules="[validateFarmName]"
                 #="{ props }"
               >
                 <v-text-field
@@ -105,11 +104,11 @@ export default {
         isCreating.value = false;
       }
     }
-    function validateFarmName(name: string) {
+    async function validateFarmName(name: string) {
       if (!name.split("").every((c: string) => /[a-zA-Z0-9\-_]/.test(c))) {
         return { message: "Farm name can only contain alphabetic letters, numbers, '-' or '_'" };
       }
-      const names = props.userFarms.getFarmsNames();
+      const names = await props.userFarms.getFarmsNames();
       if (names.includes(props.name.toLocaleLowerCase())) {
         return { message: "Farm name already exists!" };
       }

--- a/packages/playground/src/dashboard/components/user_farms.vue
+++ b/packages/playground/src/dashboard/components/user_farms.vue
@@ -333,8 +333,12 @@ export default {
       refreshPublicIPs.value = !refreshPublicIPs.value;
     }
 
-    function getFarmsNames() {
-      return farms.value?.map(farm => farm.name.toLocaleLowerCase());
+    async function getFarmsNames() {
+      const { data } = await gridProxyClient.farms.list({
+        retCount: true,
+        twinId,
+      });
+      return data.map(farm => farm.name.toLocaleLowerCase());
     }
 
     context.expose({ getFarmsNames, reloadFarms });


### PR DESCRIPTION
### Description

You can't create a farm name that already exists, and the validation is working correctly.
But when the farm isn't listed on the table, like in the video, or is listed on another page, the validation will not work.

### Changes

- checking validation name against all farm names
### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2587

[Screencast from 05-12-2024 10:57:07 AM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/303d9c95-45fb-49f5-bfc6-aed1523f3b73)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
