### PR TITLE
Enable SMTP only with public ipv4

### DIFF
--- a/packages/playground/src/components/smtp_server.vue
+++ b/packages/playground/src/components/smtp_server.vue
@@ -5,6 +5,9 @@
       <p v-else>Configure your SMTP Server.</p>
     </v-alert>
 
+    <v-alert variant="tonal" type="warning" class="mt-3">
+      SMTP server requires IPv4. Please ensure that your network configuration supports IPv4.
+    </v-alert>
     <input-tooltip
       v-if="!persistent"
       inline
@@ -31,6 +34,7 @@
             v-model="$props.modelValue.username"
             v-bind="props"
             autofocus
+            class="mt-3"
           />
         </input-tooltip>
       </input-validator>

--- a/packages/playground/src/components/smtp_server.vue
+++ b/packages/playground/src/components/smtp_server.vue
@@ -6,7 +6,7 @@
     </v-alert>
 
     <v-alert variant="tonal" type="warning" class="mt-3">
-      SMTP server requires IPv4. Please ensure that your network configuration supports IPv4.
+      SMTP functionality requires IPv4. Enabling SMTP will automatically activate IPv4.
     </v-alert>
     <input-tooltip
       v-if="!persistent"

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -236,23 +236,14 @@ function generatePubKey(): string {
 function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
-watch(
-  () => smtp.value.enabled,
-  newValue => {
-    if (newValue) {
-      ipv4.value = true;
-    }
-  },
-);
-
-watch(
-  () => ipv4.value,
-  newValue => {
-    if (!newValue && smtp.value.enabled) {
-      smtp.value.enabled = false;
-    }
-  },
-);
+watch([() => smtp.value.enabled, () => ipv4.value], ([smtpEnabled, ipv4Enabled]) => {
+  if (smtpEnabled) {
+    ipv4.value = true;
+  }
+  if (!ipv4Enabled && smtpEnabled) {
+    smtp.value.enabled = false;
+  }
+});
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -236,14 +236,23 @@ function generatePubKey(): string {
 function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
-watch([() => smtp.value.enabled, () => ipv4.value], ([smtpEnabled, ipv4Enabled]) => {
-  if (smtpEnabled) {
-    ipv4.value = true;
-  }
-  if (!ipv4Enabled && smtpEnabled) {
-    smtp.value.enabled = false;
-  }
-});
+
+watch(
+  () => smtp.value.enabled,
+  newValue => {
+    if (newValue) {
+      ipv4.value = true;
+    }
+  },
+);
+watch(
+  () => ipv4.value,
+  newValue => {
+    if (!newValue && smtp.value.enabled) {
+      smtp.value.enabled = false;
+    }
+  },
+);
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -58,7 +58,7 @@
           :medium="{ cpu: 2, memory: 4, disk: 50 }"
           :large="{ cpu: 4, memory: 16, disk: 100 }"
         />
-        <Networks v-model:mycelium="mycelium" />
+        <Networks v-model:mycelium="mycelium" v-model:ipv4="ipv4" />
 
         <input-tooltip inline tooltip="Click to know more about dedicated machines." :href="manual.dedicated_machines">
           <v-switch color="primary" inset label="Dedicated" v-model="dedicated" hide-details />
@@ -101,7 +101,7 @@
 import type { GridClient } from "@threefold/grid_client";
 import { Buffer } from "buffer";
 import TweetNACL from "tweetnacl";
-import { computed, type Ref, ref } from "vue";
+import { computed, type Ref, ref, watch } from "vue";
 
 import { manual } from "@/utils/manual";
 
@@ -236,6 +236,23 @@ function generatePubKey(): string {
 function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
+watch(
+  () => smtp.value.enabled,
+  newValue => {
+    if (newValue) {
+      ipv4.value = true;
+    }
+  },
+);
+
+watch(
+  () => ipv4.value,
+  newValue => {
+    if (!newValue && smtp.value.enabled) {
+      smtp.value.enabled = false;
+    }
+  },
+);
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -218,14 +218,22 @@ function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
 
-watch([() => smtp.value.enabled, () => ipv4.value], ([smtpEnabled, ipv4Enabled]) => {
-  if (smtpEnabled) {
-    ipv4.value = true;
-  }
-  if (!ipv4Enabled && smtpEnabled) {
-    smtp.value.enabled = false;
-  }
-});
+watch(
+  () => smtp.value.enabled,
+  newValue => {
+    if (newValue) {
+      ipv4.value = true;
+    }
+  },
+);
+watch(
+  () => ipv4.value,
+  newValue => {
+    if (!newValue && smtp.value.enabled) {
+      smtp.value.enabled = false;
+    }
+  },
+);
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -218,23 +218,14 @@ function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
 
-watch(
-  () => smtp.value.enabled,
-  newValue => {
-    if (newValue) {
-      ipv4.value = true;
-    }
-  },
-);
-
-watch(
-  () => ipv4.value,
-  newValue => {
-    if (!newValue && smtp.value.enabled) {
-      smtp.value.enabled = false;
-    }
-  },
-);
+watch([() => smtp.value.enabled, () => ipv4.value], ([smtpEnabled, ipv4Enabled]) => {
+  if (smtpEnabled) {
+    ipv4.value = true;
+  }
+  if (!ipv4Enabled && smtpEnabled) {
+    smtp.value.enabled = false;
+  }
+});
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -42,7 +42,7 @@
           :medium="{ cpu: 2, memory: 4, disk: 50 }"
           :large="{ cpu: 4, memory: 16, disk: 100 }"
         />
-        <Networks v-model:mycelium="mycelium" />
+        <Networks v-model:mycelium="mycelium" v-model:ipv4="ipv4" />
 
         <input-tooltip inline tooltip="Click to know more about dedicated machines." :href="manual.dedicated_machines">
           <v-switch color="primary" inset label="Dedicated" v-model="dedicated" hide-details />
@@ -68,7 +68,6 @@
 
         <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
       </template>
-
       <template #smtp>
         <SmtpServer v-model="smtp" />
       </template>
@@ -82,7 +81,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { computed, type Ref, ref } from "vue";
+import { computed, type Ref, ref, watch } from "vue";
 
 import { manual } from "@/utils/manual";
 
@@ -218,6 +217,24 @@ async function deploy() {
 function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
+
+watch(
+  () => smtp.value.enabled,
+  newValue => {
+    if (newValue) {
+      ipv4.value = true;
+    }
+  },
+);
+
+watch(
+  () => ipv4.value,
+  newValue => {
+    if (!newValue && smtp.value.enabled) {
+      smtp.value.enabled = false;
+    }
+  },
+);
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -121,7 +121,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { computed, type Ref, ref } from "vue";
+import { computed, type Ref, ref, watch } from "vue";
 
 import { manual } from "@/utils/manual";
 
@@ -264,6 +264,22 @@ async function deploy() {
 function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
+watch(
+  () => smtp.value.enabled,
+  newValue => {
+    if (newValue) {
+      ipv4.value = true;
+    }
+  },
+);
+watch(
+  () => ipv4.value,
+  newValue => {
+    if (!newValue && smtp.value.enabled) {
+      smtp.value.enabled = false;
+    }
+  },
+);
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -90,7 +90,7 @@
           :small="{ cpu: 2, memory: 4, disk: 100 }"
           :medium="{ cpu: 4, memory: 8, disk: 150 }"
         />
-        <Networks v-model:mycelium="mycelium" />
+        <Networks v-model:mycelium="mycelium" v-model:ipv4="ipv4" />
 
         <input-tooltip inline tooltip="Click to know more about dedicated machines." :href="manual.dedicated_machines">
           <v-switch color="primary" inset label="Dedicated" v-model="dedicated" hide-details />
@@ -132,7 +132,7 @@
 
 <script lang="ts" setup>
 import type { GridClient } from "@threefold/grid_client";
-import { computed, type Ref, ref } from "vue";
+import { computed, type Ref, ref, watch } from "vue";
 
 import { manual } from "@/utils/manual";
 
@@ -274,6 +274,24 @@ async function deploy() {
 function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
+
+watch(
+  () => smtp.value.enabled,
+  newValue => {
+    if (newValue) {
+      ipv4.value = true;
+    }
+  },
+);
+
+watch(
+  () => ipv4.value,
+  newValue => {
+    if (!newValue && smtp.value.enabled) {
+      smtp.value.enabled = false;
+    }
+  },
+);
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -275,23 +275,14 @@ function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
 
-watch(
-  () => smtp.value.enabled,
-  newValue => {
-    if (newValue) {
-      ipv4.value = true;
-    }
-  },
-);
-
-watch(
-  () => ipv4.value,
-  newValue => {
-    if (!newValue && smtp.value.enabled) {
-      smtp.value.enabled = false;
-    }
-  },
-);
+watch([() => smtp.value.enabled, () => ipv4.value], ([smtpEnabled, ipv4Enabled]) => {
+  if (smtpEnabled) {
+    ipv4.value = true;
+  }
+  if (!ipv4Enabled && smtpEnabled) {
+    smtp.value.enabled = false;
+  }
+});
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -275,14 +275,22 @@ function updateSSHkeyEnv(selectedKeys: string) {
   selectedSSHKeys.value = selectedKeys;
 }
 
-watch([() => smtp.value.enabled, () => ipv4.value], ([smtpEnabled, ipv4Enabled]) => {
-  if (smtpEnabled) {
-    ipv4.value = true;
-  }
-  if (!ipv4Enabled && smtpEnabled) {
-    smtp.value.enabled = false;
-  }
-});
+watch(
+  () => smtp.value.enabled,
+  newValue => {
+    if (newValue) {
+      ipv4.value = true;
+    }
+  },
+);
+watch(
+  () => ipv4.value,
+  newValue => {
+    if (!newValue && smtp.value.enabled) {
+      smtp.value.enabled = false;
+    }
+  },
+);
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
### Description

The SMTP ports are blocked on the private network. so to have it working, the solution should have a public IP.

### Changes

- alert added telling user that smtp server need ipv4.
- If user enabled smtp without ipv4, ipv4 will be enabled automatically.
- If user diasbled ipv4 with smtp enabled, smtp will be disabled automatically.
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2522
### Documentation PR

[Screencast from 05-12-2024 03:18:03 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/d72fc748-8a28-4d8d-a837-2e201bfa340a)


For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
