### PR TITLE
Add the last deployment date on the node details pop up

### DIFF
--- a/packages/gridproxy_client/src/modules/gateways.ts
+++ b/packages/gridproxy_client/src/modules/gateways.ts
@@ -37,6 +37,7 @@ export interface NodeStats {
   users: {
     deployments: number;
     workloads: number;
+    last_deployment_timestamp: number;
   };
 }
 

--- a/packages/playground/src/components/node_details_cards/node_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/node_details_card.vue
@@ -53,6 +53,13 @@ export default {
           name: "Number of Deployments",
           value: props.node.stats && props.node.stats.system ? props.node.stats.users.deployments.toString() : "N/A",
         },
+        {
+          name: "Last Deployment",
+          value:
+            props.node.stats && props.node.stats.system
+              ? toHumanDate(props.node.stats.users.last_deployment_timestamp)
+              : "N/A",
+        },
       ];
     };
 

--- a/packages/playground/src/components/node_details_cards/node_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/node_details_card.vue
@@ -55,10 +55,9 @@ export default {
         },
         {
           name: "Last Deployment",
-          value:
-            props.node.stats && props.node.stats.users
-              ? toHumanDate(props.node.stats.users.last_deployment_timestamp)
-              : "N/A",
+          value: props.node.stats?.users?.last_deployment_timestamp
+            ? toHumanDate(props.node.stats.users.last_deployment_timestamp)
+            : "N/A",
         },
       ];
     };

--- a/packages/playground/src/components/node_details_cards/node_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/node_details_card.vue
@@ -47,16 +47,16 @@ export default {
         { name: "Certification Type", value: props.node.certificationType },
         {
           name: "Number of Workloads",
-          value: props.node.stats && props.node.stats.system ? props.node.stats.users.workloads.toString() : "N/A",
+          value: props.node.stats && props.node.stats.users ? props.node.stats.users.workloads.toString() : "N/A",
         },
         {
           name: "Number of Deployments",
-          value: props.node.stats && props.node.stats.system ? props.node.stats.users.deployments.toString() : "N/A",
+          value: props.node.stats && props.node.stats.users ? props.node.stats.users.deployments.toString() : "N/A",
         },
         {
           name: "Last Deployment",
           value:
-            props.node.stats && props.node.stats.system
+            props.node.stats && props.node.stats.users
               ? toHumanDate(props.node.stats.users.last_deployment_timestamp)
               : "N/A",
         },

--- a/packages/playground/src/types/index.ts
+++ b/packages/playground/src/types/index.ts
@@ -281,6 +281,7 @@ export const nodeStatsInitializer: NodeStats = {
   users: {
     deployments: 0,
     workloads: 0,
+    last_deployment_timestamp: 0,
   },
 };
 


### PR DESCRIPTION
### Description

Add last deployment timestamp to node details card

### Changes

- Updated the NodeStats interface to include last_deployment_timestamp
- Added a new field 'Last Deployment' to the node details card in the dashboard
- Display the last deployment timestamp in human-readable format if available

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2348

### Screenshots/Video

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/c064c7b0-88b2-49d1-9889-632a5d0821be)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
