### PR TITLE
Support sorting nodes based on usd_price

### DIFF
--- a/packages/playground/src/components/nodes_table.vue
+++ b/packages/playground/src/components/nodes_table.vue
@@ -3,7 +3,7 @@
     <v-row>
       <v-col>
         <v-data-table-server
-          height="750px"
+          :height="height || '750px'"
           :loading="loading"
           loading-text="Loading nodes..."
           :items="modelValue"
@@ -67,6 +67,7 @@ export default {
       required: true,
       type: Boolean,
     },
+    height: String,
   },
   components: {
     TfNodeDetailsCard,


### PR DESCRIPTION
### Description
Support sorting nodes based on usd_price on node finder

### Changes
- feat: Allow to modify height of table
- feat: Update table height to be as long as the filters
- feat: Add sorting in node finder nodes based on usd_price
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/31bc239e-f25d-4b93-8ce0-f82a32c87061)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/f70fdd2c-4c60-4f47-bf45-5d1c5640fe47)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/945f2827-6327-412c-91bb-35048b7e9cdf)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/31689104/9649ef35-722d-49d4-8e3a-ed8cbca44673)


### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1868

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
