### PR TITLE
Add limit for node fee and close dialog after success of failure

### DIFF
--- a/packages/grid_client/src/modules/contracts.ts
+++ b/packages/grid_client/src/modules/contracts.ts
@@ -118,7 +118,7 @@ class Contracts {
   @expose
   @validateInput
   async getDedicatedNodeExtraFee(options: GetDedicatedNodePriceModel) {
-    return await this.client.contracts.getDedicatedNodeExtraFee(options);
+    return (await this.client.contracts.getDedicatedNodeExtraFee(options)) * 1000;
   }
 
   @expose

--- a/packages/grid_client/src/modules/contracts.ts
+++ b/packages/grid_client/src/modules/contracts.ts
@@ -118,7 +118,7 @@ class Contracts {
   @expose
   @validateInput
   async getDedicatedNodeExtraFee(options: GetDedicatedNodePriceModel) {
-    return (await this.client.contracts.getDedicatedNodeExtraFee(options)) * 1000;
+    return await this.client.contracts.getDedicatedNodeExtraFee(options);
   }
 
   @expose

--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -33,7 +33,7 @@
                   validators.required('Fee is required.'),
                   validators.isNumeric('Fee must be a valid number.'),
                   validators.min('Fee must be a 0 or more.', 0),
-                  validators.max('Maximum allowed fee is 1000000000000000', 1000000000000000),
+                  validators.max('Maximum allowed fee is 1000000', 10000000),
                 ]"
                 #="{ props }"
               >

--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -117,7 +117,7 @@ export default {
         isSetting.value = true;
         await gridStore.grid.contracts.setDedicatedNodeExtraFee({
           nodeId: props.nodeId,
-          extraFee: +fee.value / 1000,
+          extraFee: +fee.value,
         });
         createCustomToast("Additional fee is set successfully.", ToastType.success);
         await getExtraFee();

--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -33,6 +33,7 @@
                   validators.required('Fee is required.'),
                   validators.isNumeric('Fee must be a valid number.'),
                   validators.min('Fee must be a 0 or more.', 0),
+                  validators.max('Maximum allowed fee is 1000000000000000', 1000000000000000),
                 ]"
                 #="{ props }"
               >
@@ -116,7 +117,7 @@ export default {
         isSetting.value = true;
         await gridStore.grid.contracts.setDedicatedNodeExtraFee({
           nodeId: props.nodeId,
-          extraFee: +fee.value,
+          extraFee: +fee.value / 1000,
         });
         createCustomToast("Additional fee is set successfully.", ToastType.success);
         await getExtraFee();
@@ -124,6 +125,7 @@ export default {
         createCustomToast("Failed to set additional fees!", ToastType.danger);
       } finally {
         isSetting.value = false;
+        showDialogue.value = false;
       }
     }
 


### PR DESCRIPTION
### Description

- The dialog should be closed automatically after updating the fees.
- There should be max limit for fee

### Changes
- Dialog will close after updating 
- added max limit for fee (max limit accepted by chain)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2638

[Screencast from 05-13-2024 02:25:32 PM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/38b584a7-4db3-44f0-ae8d-4a9dd7dd252d)

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
