### PR TITLE
Add ubuntu-23.10 & Arch flists in Micro & Full VM

### DIFF
--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -164,7 +164,7 @@ const images: VmImage[] = [
   {
     name: "Ubuntu-23.10",
     flist: "https://hub.grid.tf/petep.3bot/ubuntu23.10_mycelium.flist",
-    entryPoint: "/zinit.sh",
+    entryPoint: "/sbin/zinit init",
   },
   {
     name: "Ubuntu-22.04",

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -162,11 +162,6 @@ const profileManager = useProfileManager();
 const solution = ref() as Ref<SolutionFlavor>;
 const images: VmImage[] = [
   {
-    name: "Ubuntu-23.10",
-    flist: "https://hub.grid.tf/petep.3bot/ubuntu23.10_mycelium.flist",
-    entryPoint: "/sbin/zinit init",
-  },
-  {
     name: "Ubuntu-22.04",
     flist: "https://hub.grid.tf/tf-official-vms/ubuntu-22.04.flist",
     entryPoint: "/init.sh",

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -162,6 +162,11 @@ const profileManager = useProfileManager();
 const solution = ref() as Ref<SolutionFlavor>;
 const images: VmImage[] = [
   {
+    name: "Ubuntu-23.10",
+    flist: "https://hub.grid.tf/petep.3bot/ubuntu23.10_mycelium.flist",
+    entryPoint: "/init.sh",
+  },
+  {
     name: "Ubuntu-22.04",
     flist: "https://hub.grid.tf/tf-official-vms/ubuntu-22.04.flist",
     entryPoint: "/init.sh",
@@ -174,6 +179,11 @@ const images: VmImage[] = [
   {
     name: "Ubuntu-18.04",
     flist: "https://hub.grid.tf/tf-official-vms/ubuntu-18.04-lts.flist",
+    entryPoint: "/init.sh",
+  },
+  {
+    name: "Arch",
+    flist: "https://hub.grid.tf/petep.3bot/arch_mycelium.flist",
     entryPoint: "/init.sh",
   },
   {

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -164,7 +164,7 @@ const images: VmImage[] = [
   {
     name: "Ubuntu-23.10",
     flist: "https://hub.grid.tf/petep.3bot/ubuntu23.10_mycelium.flist",
-    entryPoint: "/init.sh",
+    entryPoint: "/zinit.sh",
   },
   {
     name: "Ubuntu-22.04",
@@ -179,11 +179,6 @@ const images: VmImage[] = [
   {
     name: "Ubuntu-18.04",
     flist: "https://hub.grid.tf/tf-official-vms/ubuntu-18.04-lts.flist",
-    entryPoint: "/init.sh",
-  },
-  {
-    name: "Arch",
-    flist: "https://hub.grid.tf/petep.3bot/arch_mycelium.flist",
     entryPoint: "/init.sh",
   },
   {

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -201,7 +201,7 @@ const images = [
   {
     name: "Ubuntu-23.10",
     flist: "https://hub.grid.tf/petep.3bot/ubuntu23.10_mycelium.flist",
-    entryPoint: "/init.sh",
+    entryPoint: "/zinit.sh",
   },
   {
     name: "Ubuntu-22.04",
@@ -211,7 +211,7 @@ const images = [
   {
     name: "Arch",
     flist: "https://hub.grid.tf/petep.3bot/arch_mycelium.flist",
-    entryPoint: "/init.sh",
+    entryPoint: "/zinit.sh",
   },
   {
     name: "Debian-12",

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -199,9 +199,19 @@ const tabs = ref();
 
 const images = [
   {
+    name: "Ubuntu-23.10",
+    flist: "https://hub.grid.tf/petep.3bot/ubuntu23.10_mycelium.flist",
+    entryPoint: "/init.sh",
+  },
+  {
     name: "Ubuntu-22.04",
     flist: "https://hub.grid.tf/tf-official-apps/threefoldtech-ubuntu-22.04.flist",
     entryPoint: "/sbin/zinit init",
+  },
+  {
+    name: "Arch",
+    flist: "https://hub.grid.tf/petep.3bot/arch_mycelium.flist",
+    entryPoint: "/init.sh",
   },
   {
     name: "Debian-12",

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -201,7 +201,7 @@ const images = [
   {
     name: "Ubuntu-23.10",
     flist: "https://hub.grid.tf/petep.3bot/ubuntu23.10_mycelium.flist",
-    entryPoint: "/zinit.sh",
+    entryPoint: "/sbin/zinit init",
   },
   {
     name: "Ubuntu-22.04",
@@ -211,7 +211,7 @@ const images = [
   {
     name: "Arch",
     flist: "https://hub.grid.tf/petep.3bot/arch_mycelium.flist",
-    entryPoint: "/zinit.sh",
+    entryPoint: "/sbin/zinit init",
   },
   {
     name: "Debian-12",


### PR DESCRIPTION
### Description

Add ubuntu-23.10 & Arch flists in Micro & Full VM

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2504
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2505


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
