### PR TITLE
fix: Can't list deployments

### DIFF
--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -37,6 +37,7 @@ export interface GqlBaseContract {
   twinID: string;
   state: string;
   createdAt: string;
+  updatedAt: string;
   solutionProviderID: string;
 }
 

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -177,9 +177,11 @@ class BaseModule {
 
   private async getMyContracts(fetch = false) {
     if (fetch || !this.contracts) {
+      console.log("modulesNames:", modulesNames[this.moduleName]);
+      console.log("moduleName: ", this.moduleName);
       let contracts = await this.tfClient.contracts.listMyNodeContracts({
         graphqlURL: this.config.graphqlURL,
-        type: modulesNames[this.moduleName],
+        type: modulesNames[this.moduleName] ?? this.moduleName,
         projectName: this.projectName,
       });
       const alreadyFetchedContracts: GqlNodeContract[] = [];

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -95,6 +95,7 @@ class BaseModule {
       BaseModule.newContracts.push({
         contractID: String(contract.contractId),
         createdAt: Date.now().toString(),
+        updatedAt: Date.now().toString(),
         deploymentData: contract.contractType.nodeContract.deploymentData,
         deploymentHash: contract.contractType.nodeContract.deploymentHash,
         gridVersion: "4",
@@ -182,12 +183,26 @@ class BaseModule {
         type: modulesNames[this.moduleName] ?? this.moduleName,
         projectName: this.projectName,
       });
+
       const alreadyFetchedContracts: GqlNodeContract[] = [];
+
       for (const contract of BaseModule.newContracts) {
-        if (contract.parsedDeploymentData?.projectName !== this.projectName) continue;
+        if (!contract.parsedDeploymentData?.projectName.includes(this.projectName)) continue;
         if (contract.parsedDeploymentData.type !== modulesNames[this.moduleName]) continue;
-        const c = contracts.filter(c => +c.contractID === +contract.contractID);
-        if (c.length > 0) {
+
+        const filteredContract = contracts.filter(c => c.contractID === contract.contractID);
+
+        const now = new Date();
+        const contractUpdatedAt = new Date(+contract.updatedAt);
+        const beforeOneMin = now.getTime() - contractUpdatedAt.getTime() < 1000 * 60;
+
+        if (filteredContract.length > 0) {
+          if (beforeOneMin) {
+            const idx = contracts.indexOf(filteredContract[0]);
+            contracts[idx] = contract;
+            continue;
+          }
+
           alreadyFetchedContracts.push(contract);
           continue;
         }

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -177,8 +177,6 @@ class BaseModule {
 
   private async getMyContracts(fetch = false) {
     if (fetch || !this.contracts) {
-      console.log("modulesNames:", modulesNames[this.moduleName]);
-      console.log("moduleName: ", this.moduleName);
       let contracts = await this.tfClient.contracts.listMyNodeContracts({
         graphqlURL: this.config.graphqlURL,
         type: modulesNames[this.moduleName] ?? this.moduleName,

--- a/packages/grid_client/src/modules/index.ts
+++ b/packages/grid_client/src/modules/index.ts
@@ -22,3 +22,4 @@ export * from "./farmerbot";
 export * from "./farms";
 export * from "./networks";
 export * from "./bridge";
+export * from "./base";

--- a/packages/grid_client/src/primitives/network.ts
+++ b/packages/grid_client/src/primitives/network.ts
@@ -797,6 +797,7 @@ PersistentKeepalive = 25\nEndpoint = ${endpoint}`;
       Network.newContracts.push({
         contractID: String(AddedContract.contractId),
         createdAt: Date.now().toString(),
+        updatedAt: Date.now().toString(),
         deploymentData: AddedContract.contractType.nodeContract.deploymentData,
         deploymentHash: AddedContract.contractType.nodeContract.deploymentHash,
         gridVersion: "4",

--- a/packages/playground/src/utils/migration.ts
+++ b/packages/playground/src/utils/migration.ts
@@ -28,11 +28,9 @@ async function _migrateOldFullVMs(module: BaseModule) {
         }
 
         oldData.type = "vm";
-        oldData.type = "vm";
-        oldData.projectName = `Fullvm`;
-
         contract.parsedDeploymentData = oldData;
         contract.deploymentData = JSON.stringify(oldData);
+        contract.updatedAt = Date.now().toString();
 
         BaseModule.newContracts.push(contract);
 

--- a/packages/playground/src/utils/migration.ts
+++ b/packages/playground/src/utils/migration.ts
@@ -2,6 +2,11 @@ import type { Contract, ExtrinsicResult } from "@threefold/tfchain_client";
 
 import { BaseModule } from "../../../grid_client/dist/es6/modules/base";
 
+/**
+ * `_migrateOldFullVMs` is a function is implemented to list all old `FullVM` that listed in the old `Playground` with type `Fullvm`
+ * @param `module` takes the `module` which is an instance of the `BaseModule`.
+ * @returns Applying the extrinsic in the chain with the batch request.
+ */
 async function _migrateOldFullVMs(module: BaseModule) {
   module.moduleName = "Fullvm"; // Load old deployments that deployed with `Fullvm` type.
   const deploymentNames = await module._list();

--- a/packages/playground/src/utils/migration.ts
+++ b/packages/playground/src/utils/migration.ts
@@ -28,10 +28,17 @@ async function _migrateOldFullVMs(module: BaseModule) {
         }
 
         oldData.type = "vm";
+        oldData.type = "vm";
+        oldData.projectName = `Fullvm`;
+
+        contract.parsedDeploymentData = oldData;
+        contract.deploymentData = JSON.stringify(oldData);
+
         BaseModule.newContracts.push(contract);
+
         return module.tfClient.contracts.updateNode({
           id: +contract.contractID,
-          data: JSON.stringify(oldData),
+          data: contract.deploymentData,
           hash: contract.deploymentHash,
         });
       }),


### PR DESCRIPTION
### Description

Created a migration function and modified the moduleName to be 'Fullvm' to list all old VMs with 'Fullvm' type.

### Changes

- Created a migration function and modified the moduleName to be 'Fullvm' to list all old VMs with 'Fullvm' type.
- Updated the import of 'BaseModule' in 'migration.ts' to be local dir instead of the dist one to fix the un-exported issue
- Flat the array of the contracts then loop over them all
- Updated the moduleName after listing the 'Fullvm' to 'vm' again to list the other deployments
- Pushed the newly changed contract to the 'newContracts' array to avoid the lag of gql
- Updated the 'moduleName' in 'base.ts' to take 'Fullvm' if the 'moduleNames' is undefined- 

### Related Issues

List of related issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2435

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/070cdc1d-82ce-413a-94a8-fdef705e5b6c)


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
