### PR TITLE
Fix farms public IPs table selection

### DIFF
--- a/packages/playground/src/dashboard/components/public_ips_table.vue
+++ b/packages/playground/src/dashboard/components/public_ips_table.vue
@@ -1,20 +1,10 @@
 <template>
   <div>
-    <v-data-table
-      :loading="loadingIps"
-      loading-text="Loading farm IPs..."
+    <ListTable
       :headers="headers"
       :items="copyPublicIps"
-      :items-length="publicIps.length"
-      :items-per-page="size"
-      :page="page"
-      @update:items-per-page="size => updateIPPageSize(size)"
-      @update:page="page => updateIPPage(page)"
-      class="elevation-1 v-data-table-header"
-      :disable-sort="true"
-      hide-default-header
-      hover
-      show-select
+      :loading="loading"
+      :deleting="isRemoving"
       v-model="selectedItems"
     >
       <template v-slot:top>
@@ -35,7 +25,7 @@
       <template #bottom>
         <div class="d-flex align-end justify-end">
           <v-btn
-            class="ma-5"
+            class="ma-3"
             color="error"
             variant="outlined"
             prepend-icon="mdi-delete"
@@ -46,7 +36,7 @@
           </v-btn>
         </div>
       </template>
-    </v-data-table>
+    </ListTable>
     <v-dialog v-model="showDialogue" max-width="600">
       <v-card>
         <v-toolbar color="primary" class="custom-toolbar">
@@ -64,7 +54,8 @@
           <v-btn @click="showDialogue = false" variant="outlined" color="anchor">Close</v-btn>
           <v-btn
             variant="outlined"
-            :text="isRemoving ? 'Deleting..' : 'Confirm'"
+            text="Confirm"
+            :loading="isRemoving"
             color="error"
             :disabled="isRemoving"
             @click="removeFarmIps"
@@ -80,13 +71,14 @@ import type { RemoveFarmIPModel } from "@threefold/grid_client";
 import type { PublicIp } from "@threefold/tfchain_client";
 import { onMounted, ref, watch } from "vue";
 
+import ListTable from "@/components/list_table.vue";
 import { useGrid } from "@/stores";
 import { IPType } from "@/utils/types";
 
 import { createCustomToast, ToastType } from "../../utils/custom_toast";
-
 export default {
   name: "PublicIPsTable",
+  components: { ListTable },
   props: {
     farmId: {
       type: Number,


### PR DESCRIPTION
### Description

Fix farms public IPs table selection by removing the current ```data-table``` and passing props to ```list-table``` component.
### Changes

[Screencast from 16-05-24 16:54:45.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/11662805/36954091-b2a1-4b59-8543-42d9a2e7251f)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2561
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2610

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
