### PR TITLE
handle twins with only twin ID on gridproxy in twin details card

### DIFF
--- a/packages/playground/src/utils/get_farms.ts
+++ b/packages/playground/src/utils/get_farms.ts
@@ -87,6 +87,9 @@ export async function getFarmTwinByTwinId(queries: Partial<TwinsQuery> = {}): Pr
   try {
     const twins = await gridProxyClient.twins.list(queries);
 
+    if (twins.count == null) {
+      return { twinId: queries.twinId } as Twin;
+    }
     return twins.data[0] as Twin;
   } catch (error) {
     console.error("An error occurred while requesting twins:", error);


### PR DESCRIPTION
### Changes

A corner case was handled where the twin does not have info other than a twin Id on the chain, by simply returning the twin ID to be used in the twin details card while other unavailable fields are set to default values

### Related Issues

[#2668](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2668)


### Checklist
- [ ] Screenshots/Video attached (needed for UI changes)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/23802c0c-57fe-4bfd-ac7c-57fe666ed01f)

