### PR TITLE
add copy icon to all public config fields

### DIFF
--- a/packages/playground/src/components/node_details_cards/public_config_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/public_config_details_card.vue
@@ -40,7 +40,13 @@ export default {
 
     const getNodeTwinDetailsCard = (): NodeDetailsCard[] => {
       return [
-        { name: "IPv4", value: props.node.publicConfig.ipv4 },
+        {
+          name: "IPv4",
+          value: props.node.publicConfig.ipv4,
+          icon: "mdi-content-copy",
+          callback: copy,
+          hint: "Copy the IPv4 to the clipboard.",
+        },
         {
           name: "IPv6",
           value: props.node.publicConfig.ipv6,
@@ -48,9 +54,27 @@ export default {
           callback: copy,
           hint: "Copy the IPv6 to the clipboard.",
         },
-        { name: "GW4", value: props.node.publicConfig.gw4 },
-        { name: "GW6", value: props.node.publicConfig.gw6 },
-        { name: "Domain", value: props.node.publicConfig.domain },
+        {
+          name: "GW4",
+          value: props.node.publicConfig.gw4,
+          icon: "mdi-content-copy",
+          callback: copy,
+          hint: "Copy the GW4 to the clipboard.",
+        },
+        {
+          name: "GW6",
+          value: props.node.publicConfig.gw6,
+          icon: "mdi-content-copy",
+          callback: copy,
+          hint: "Copy the GW6 to the clipboard.",
+        },
+        {
+          name: "Domain",
+          value: props.node.publicConfig.domain,
+          icon: "mdi-content-copy",
+          callback: copy,
+          hint: "Copy the Domain to the clipboard.",
+        },
       ];
     };
 


### PR DESCRIPTION
### Description

- IPV6 field was the only one with copy icon
### Changes

- Added copy icons to all fields 
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2665
### Documentation PR
![Screenshot from 2024-05-19 14-50-58](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/955dd0d4-f0ff-4f6f-9204-64204eb7c886)

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
