### PR TITLE
Add missed IPV4 column for applications

### DIFF
--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -281,6 +281,11 @@ const filteredHeaders = computed(() => {
     ProjectName.Nextcloud,
     ProjectName.Funkwhale,
     ProjectName.Casperlabs,
+    ProjectName.Mattermost,
+    ProjectName.Discourse,
+    ProjectName.Taiga,
+    ProjectName.StaticWebsite,
+    ProjectName.Wordpress,
   ] as string[];
 
   const WireguardSolutions = [ProjectName.VM, ProjectName.Fullvm, ProjectName.Umbrel] as string[];

--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -275,8 +275,6 @@ const filteredHeaders = computed(() => {
     ProjectName.VM,
     ProjectName.Fullvm,
     ProjectName.Presearch,
-    ProjectName.Algorand,
-    ProjectName.Subsquid,
     ProjectName.Umbrel,
     ProjectName.Nextcloud,
     ProjectName.Funkwhale,


### PR DESCRIPTION
### Description

Update IPV4 column for applications
### Changes

Applications that missed IPv4 column:

- Mattermost
- Discourse
- Taiga
- Static websites
- Wordpress

IPv4 columns removed from:
- Subsquid
- Algorand

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2527
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2715

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
