### PR TITLE
Move to error input whenever user start deploying

### DIFF
--- a/packages/playground/src/components/dynamic_tabs.vue
+++ b/packages/playground/src/components/dynamic_tabs.vue
@@ -45,6 +45,8 @@ import { computed, ref, watch } from "vue";
 
 import { useFormRef } from "@/hooks/form_validator";
 
+import { useWebletLayoutServie } from "./weblet_layout.vue";
+
 export interface Tab {
   title: string;
   value: string;
@@ -65,12 +67,17 @@ const emits = defineEmits<{
   (event: "tab:change", value: number): void;
 }>();
 
+const webletLayoutServie = useWebletLayoutServie();
 const forms = useFormRef(true);
 
 const activeTab = ref<number>(props.modelValue ?? 0);
 watch(activeTab, t => {
   emits("update:modelValue", t);
   emits("tab:change", t);
+});
+
+webletLayoutServie.set(forms.value, (tab: number) => {
+  activeTab.value = tab;
 });
 
 const valid = computed(() => forms.value.reduce((r, f) => r && (f.valid as unknown as boolean), true));

--- a/packages/playground/src/components/form_validator.vue
+++ b/packages/playground/src/components/form_validator.vue
@@ -17,7 +17,7 @@ export default {
   emits: { "update:modelValue": (value: boolean) => value },
   setup(props, { emit, expose }) {
     const statusMap = ref(new Map<string, ValidatorStatus>());
-    const serviceMap = new Map<string, InputValidatorService>();
+    const serviceMap = ref(new Map<string, InputValidatorService>());
 
     const valid = computed(() =>
       [...statusMap.value.values()].every(status => {
@@ -32,15 +32,15 @@ export default {
     const form: FormValidatorService = {
       register(uid, service) {
         statusMap.value.set(uid, ValidatorStatus.Init);
-        serviceMap.set(uid, service);
+        serviceMap.value.set(uid, service);
       },
       unregister(uid) {
         statusMap.value.delete(uid);
-        serviceMap.delete(uid);
+        serviceMap.value.delete(uid);
       },
 
       async validate() {
-        const valids = await Promise.all([...serviceMap.values()].map(({ validate }) => validate()));
+        const valids = await Promise.all([...serviceMap.value.values()].map(({ validate }) => validate()));
         return valids.every(valid => valid);
       },
 
@@ -51,14 +51,16 @@ export default {
       },
 
       reset() {
-        [...serviceMap.values()].map(({ reset }) => reset());
+        [...serviceMap.value.values()].map(({ reset }) => reset());
       },
 
-      get: uid => serviceMap.get(uid),
+      get: uid => serviceMap.value.get(uid),
 
       valid,
       invalid: computed(() => [...statusMap.value.values()].some(status => status === ValidatorStatus.Invalid)),
       pending: computed(() => [...statusMap.value.values()].some(status => status === ValidatorStatus.Pending)),
+      validOnInit: props.validOnInit,
+      inputs: computed(() => [...serviceMap.value.values()] as any),
     };
 
     provideForm(form);

--- a/packages/playground/src/components/input_validator.vue
+++ b/packages/playground/src/components/input_validator.vue
@@ -1,15 +1,17 @@
 <template>
-  <slot
-    :props="{
-      onBlur,
-      loading,
-      errorMessages,
-      error: showError,
-      hint: inputHint,
-      'persistent-hint': hintPersistent,
-      class: extraClass,
-    }"
-  ></slot>
+  <div ref="inputElement" class="input-validator">
+    <slot
+      :props="{
+        onBlur,
+        loading,
+        errorMessages,
+        error: showError,
+        hint: inputHint,
+        'persistent-hint': hintPersistent,
+        class: extraClass,
+      }"
+    ></slot>
+  </div>
 </template>
 
 <script lang="ts">
@@ -54,6 +56,7 @@ export default {
     const { uid: _uid } = getCurrentInstance() as { uid: number };
     const uid = props.inputName || _uid.toString();
     const form = useForm();
+    const inputElement = ref<HTMLElement | null>(null);
 
     const required = computed(() => props.rules.some(rule => "required" in (rule("") || {})));
 
@@ -138,6 +141,7 @@ export default {
 
     // Set Form connection
     const obj: InputValidatorService = {
+      $el: inputElement,
       validate: validate as InputValidatorService["validate"],
       setStatus,
       reset() {
@@ -153,6 +157,7 @@ export default {
     expose(obj);
 
     return {
+      inputElement,
       onBlur: computed(() => (blured.value ? undefined : onBlur)),
       loading: computed(() => status.value === ValidatorStatus.Pending),
       errorMessages: computed(() => (error.value ? [error.value] : [])),

--- a/packages/playground/src/components/node_selector/TfDomainName.vue
+++ b/packages/playground/src/components/node_selector/TfDomainName.vue
@@ -8,98 +8,103 @@
       </div>
     </input-tooltip>
 
-    <VForm v-model="domainNameValid">
-      <VExpandTransition>
-        <input-tooltip tooltip="Domain Name that will points to this instance" v-if="enableCustomDomain">
-          <VTextField
-            ref="customDomainInput"
-            label="Custom Domain"
-            placeholder="Your custom domain"
-            v-model="customDomain"
-            @vue:mounted="customDomain && ($refs.customDomainInput as VInput).validate()"
-            validate-on="input"
-            :rules="[
-              d => (d ? true : 'Domain name is required.'),
-              d => validators.isFQDN('Please provide a valid domain name.')(d)?.message || true,
-            ]"
-            @blur="($refs.customDomainInput as VInput).validate()"
-          />
-        </input-tooltip>
-      </VExpandTransition>
+    <div ref="input">
+      <VForm v-model="domainNameValid">
+        <VExpandTransition>
+          <input-tooltip tooltip="Domain Name that will points to this instance" v-if="enableCustomDomain">
+            <VTextField
+              ref="customDomainInput"
+              label="Custom Domain"
+              placeholder="Your custom domain"
+              v-model="customDomain"
+              @vue:mounted="customDomain && ($refs.customDomainInput as VInput).validate()"
+              validate-on="input"
+              :rules="[
+                d => (d ? true : 'Domain name is required.'),
+                d => validators.isFQDN('Please provide a valid domain name.')(d)?.message || true,
+              ]"
+              @blur="($refs.customDomainInput as VInput).validate()"
+            />
+          </input-tooltip>
+        </VExpandTransition>
 
-      <VExpandTransition>
-        <input-tooltip
-          tooltip="Creates a subdomain for your instance on the selected domain to be able to access your instance from the browser."
-          v-if="!disableSelectedDomain"
-        >
-          <VAutocomplete
-            ref="domainInput"
-            validate-on="input"
-            label="Select domain"
-            placeholder="Select a domain"
-            :items="loadedDomains"
-            :loading="domainsTask.loading"
-            item-title="publicConfig.domain"
-            v-model="selectedDomain"
-            :error-messages="domainsTask.error?.message"
-            @vue:mounted="selectedDomain && ($refs.domainInput as VInput).validate()"
-            :rules="[d => (d ? true : 'Domain is required.')]"
-            @update:menu="opened => !opened && $nextTick().then(() => ($refs.domainInput as VInput).validate())"
-            @blur="$nextTick().then(() => ($refs.domainInput as VInput).validate())"
-            return-object
+        <VExpandTransition>
+          <input-tooltip
+            tooltip="Creates a subdomain for your instance on the selected domain to be able to access your instance from the browser."
+            v-if="!disableSelectedDomain"
           >
-            <template #append-item v-if="pagination.page !== -1">
-              <VContainer>
-                <VBtn
-                  @click="reloadDomains()"
-                  block
-                  color="secondary"
-                  variant="tonal"
-                  :loading="domainsTask.loading"
-                  prepend-icon="mdi-reload"
-                >
-                  Load More Domains
-                </VBtn>
-              </VContainer>
-            </template>
-            <template v-slot:append>
-              <v-slide-x-reverse-transition mode="out-in">
-                <v-icon icon="mdi-reload" @click="reloadDomains()"></v-icon>
-              </v-slide-x-reverse-transition>
-            </template>
-          </VAutocomplete>
-        </input-tooltip>
-      </VExpandTransition>
+            <VAutocomplete
+              ref="domainInput"
+              validate-on="input"
+              label="Select domain"
+              placeholder="Select a domain"
+              :items="loadedDomains"
+              :loading="domainsTask.loading"
+              item-title="publicConfig.domain"
+              v-model="selectedDomain"
+              :error-messages="domainsTask.error?.message"
+              @vue:mounted="selectedDomain && ($refs.domainInput as VInput).validate()"
+              :rules="[d => (d ? true : 'Domain is required.')]"
+              @update:menu="opened => !opened && $nextTick().then(() => ($refs.domainInput as VInput).validate())"
+              @blur="$nextTick().then(() => ($refs.domainInput as VInput).validate())"
+              return-object
+            >
+              <template #append-item v-if="pagination.page !== -1">
+                <VContainer>
+                  <VBtn
+                    @click="reloadDomains()"
+                    block
+                    color="secondary"
+                    variant="tonal"
+                    :loading="domainsTask.loading"
+                    prepend-icon="mdi-reload"
+                  >
+                    Load More Domains
+                  </VBtn>
+                </VContainer>
+              </template>
+              <template v-slot:append>
+                <v-slide-x-reverse-transition mode="out-in">
+                  <v-icon icon="mdi-reload" @click="reloadDomains()"></v-icon>
+                </v-slide-x-reverse-transition>
+              </template>
+            </VAutocomplete>
+          </input-tooltip>
+        </VExpandTransition>
 
-      <v-alert
-        v-if="
-          !disableSelectedDomain &&
-          useFQDN &&
-          modelValue &&
-          modelValue.customDomain &&
-          selectedDomain?.publicConfig?.ipv4
-        "
-        class="mb-4"
-        type="warning"
-        variant="tonal"
-      >
-        Before starting the deployment, Please make sure to create an A record on your name provider with
-        <span class="font-weight-bold">{{ customDomain }}</span> pointing to
-        <span class="font-weight-bold">{{ selectedDomain.publicConfig.ipv4.split("/")[0] }}</span>
-      </v-alert>
-    </VForm>
+        <v-alert
+          v-if="
+            !disableSelectedDomain &&
+            useFQDN &&
+            modelValue &&
+            modelValue.customDomain &&
+            selectedDomain?.publicConfig?.ipv4
+          "
+          class="mb-4"
+          type="warning"
+          variant="tonal"
+        >
+          Before starting the deployment, Please make sure to create an A record on your name provider with
+          <span class="font-weight-bold">{{ customDomain }}</span> pointing to
+          <span class="font-weight-bold">{{ selectedDomain.publicConfig.ipv4.split("/")[0] }}</span>
+        </v-alert>
+      </VForm>
+    </div>
   </section>
 </template>
 
 <script lang="ts">
 import type { FarmInfo, FilterOptions, NodeInfo } from "@threefold/grid_client";
-import { computed, nextTick, onUnmounted, type PropType, ref, watch } from "vue";
+import { noop } from "lodash";
+import { computed, getCurrentInstance, nextTick, onUnmounted, type PropType, ref, watch } from "vue";
 import { onMounted } from "vue";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { VInput } from "vuetify/components/VInput";
 
+import type { InputValidatorService } from "@/hooks/input_validator";
+
 import { useAsync, usePagination, useWatchDeep } from "../../hooks";
-import { ValidatorStatus } from "../../hooks/form_validator";
+import { useForm, ValidatorStatus } from "../../hooks/form_validator";
 import { useGrid } from "../../stores";
 import type { DomainInfo, SelectionDetailsFilters } from "../../types/nodeSelector";
 import { getNodePageCount, loadNodes } from "../../utils/nodeSelector";
@@ -122,6 +127,7 @@ export default {
   },
   setup(props, ctx) {
     const gridStore = useGrid();
+    const input = ref<HTMLElement>();
 
     const loadedDomains = ref<NodeInfo[]>([]);
     const domainsTask = useAsync(loadNodes, {
@@ -192,13 +198,33 @@ export default {
       ctx.emit("update:model-value", domain);
     }
 
+    /* Adapter to work with old code validation */
+    const { uid } = getCurrentInstance() as { uid: number };
+    const form = useForm();
+
+    const fakeService: InputValidatorService = {
+      validate: () => Promise.resolve(true),
+      setStatus: noop,
+      reset: noop,
+      status: ValidatorStatus.Init,
+      error: null,
+      $el: input,
+    };
+
+    onMounted(() => form?.register(uid.toString(), fakeService));
+    onUnmounted(() => form?.unregister(uid.toString()));
+
     onMounted(bindStatus);
     function bindStatus(status?: ValidatorStatus): void {
-      ctx.emit("update:status", status || ValidatorStatus.Init);
+      const s = status || ValidatorStatus.Init;
+      fakeService.status = s;
+      form?.updateStatus(uid.toString(), s);
+      ctx.emit("update:status", s);
     }
 
     return {
       pagination,
+      input,
 
       domainNameValid,
 

--- a/packages/playground/src/components/node_selector/TfSelectGpu.vue
+++ b/packages/playground/src/components/node_selector/TfSelectGpu.vue
@@ -1,39 +1,44 @@
 <template>
-  <input-tooltip
-    tooltip="Please select at least one card from the available GPU cards. Note that if you have a deployment that already uses certain cards, they will not appear in the selection area. You have the option to select one or more cards.."
-  >
-    <VAutocomplete
-      label="GPU Cards"
-      placeholder="Select GPU Cards"
-      class="w-100"
-      multiple
-      :model-value="$props.modelValue"
-      @update:model-value="
-        bindModelValue($event);
-        bindStatus($event.length === 0 ? ValidatorStatus.Invalid : ValidatorStatus.Valid);
-      "
-      :items="(cardsTask.data as GPUCardInfo[])"
-      item-title="device"
-      :loading="cardsTask.loading"
-      :error="!!cardsTask.error"
-      :error-messages="
-        $props.status === ValidatorStatus.Invalid ? 'Please select at least 1 GPU card.' : cardsTask.error?.message
-      "
-      return-object
-      :disabled="!$props.validNode"
-      :hint="$props.validNode ? undefined : 'Please select a valid node to load it\'s GPU cards.'"
-      :persistent-hint="!$props.validNode"
-      @update:menu="opened => !opened && $props.modelValue.length === 0 && bindStatus(ValidatorStatus.Invalid)"
-    />
-  </input-tooltip>
+  <div ref="input">
+    <input-tooltip
+      tooltip="Please select at least one card from the available GPU cards. Note that if you have a deployment that already uses certain cards, they will not appear in the selection area. You have the option to select one or more cards.."
+    >
+      <VAutocomplete
+        label="GPU Cards"
+        placeholder="Select GPU Cards"
+        class="w-100"
+        multiple
+        :model-value="$props.modelValue"
+        @update:model-value="
+          bindModelValue($event);
+          bindStatus($event.length === 0 ? ValidatorStatus.Invalid : ValidatorStatus.Valid);
+        "
+        :items="(cardsTask.data as GPUCardInfo[])"
+        item-title="device"
+        :loading="cardsTask.loading"
+        :error="!!cardsTask.error"
+        :error-messages="
+          $props.status === ValidatorStatus.Invalid ? 'Please select at least 1 GPU card.' : cardsTask.error?.message
+        "
+        return-object
+        :disabled="!$props.validNode"
+        :hint="$props.validNode ? undefined : 'Please select a valid node to load it\'s GPU cards.'"
+        :persistent-hint="!$props.validNode"
+        @update:menu="opened => !opened && $props.modelValue.length === 0 && bindStatus(ValidatorStatus.Invalid)"
+      />
+    </input-tooltip>
+  </div>
 </template>
 
 <script lang="ts">
 import type { GPUCardInfo, NodeInfo } from "@threefold/grid_client";
-import { onMounted, onUnmounted, type PropType } from "vue";
+import { noop } from "lodash";
+import { getCurrentInstance, onMounted, onUnmounted, type PropType, ref } from "vue";
+
+import type { InputValidatorService } from "@/hooks/input_validator";
 
 import { useAsync, useWatchDeep } from "../../hooks";
-import { ValidatorStatus } from "../../hooks/form_validator";
+import { useForm, ValidatorStatus } from "../../hooks/form_validator";
 import { useGrid } from "../../stores";
 import { getNodeGpuCards } from "../../utils/nodeSelector";
 
@@ -51,6 +56,7 @@ export default {
   },
   setup(props, ctx) {
     const gridStore = useGrid();
+    const input = ref<HTMLElement>();
     const cardsTask = useAsync(getNodeGpuCards, { default: [] });
 
     useWatchDeep(
@@ -79,11 +85,31 @@ export default {
       bindModelValue();
       bindStatus();
     });
+
+    /* Adapter to work with old code validation */
+    const { uid } = getCurrentInstance() as { uid: number };
+    const form = useForm();
+
+    const fakeService: InputValidatorService = {
+      validate: () => Promise.resolve(true),
+      setStatus: noop,
+      reset: noop,
+      status: ValidatorStatus.Init,
+      error: null,
+      $el: input,
+    };
+
+    onMounted(() => form?.register(uid.toString(), fakeService));
+    onUnmounted(() => form?.unregister(uid.toString()));
+
     function bindStatus(status?: ValidatorStatus) {
-      ctx.emit("update:status", status || ValidatorStatus.Init);
+      const s = status || ValidatorStatus.Init;
+      fakeService.status = s;
+      form?.updateStatus(uid.toString(), s);
+      ctx.emit("update:status", s);
     }
 
-    return { ValidatorStatus, cardsTask, bindModelValue, bindStatus };
+    return { input, ValidatorStatus, cardsTask, bindModelValue, bindStatus };
   },
 };
 </script>

--- a/packages/playground/src/components/node_selector/TfSelectionDetails.vue
+++ b/packages/playground/src/components/node_selector/TfSelectionDetails.vue
@@ -16,26 +16,28 @@
         </InputTooltip>
       </v-radio-group>
 
-      <template v-if="wayToSelect === 'automated'">
-        <TfSelectLocation v-model="location" title="Choose a Location" :status="NodeStatus.Up" />
-        <TfSelectFarm :valid-filters="validFilters" :filters="filters" :location="location" v-model="farm" />
-        <TfAutoNodeSelector
+      <div ref="input">
+        <template v-if="wayToSelect === 'automated'">
+          <TfSelectLocation v-model="location" title="Choose a Location" :status="NodeStatus.Up" />
+          <TfSelectFarm :valid-filters="validFilters" :filters="filters" :location="location" v-model="farm" />
+          <TfAutoNodeSelector
+            :valid-filters="validFilters"
+            :filters="filters"
+            :location="location"
+            :farm="farm"
+            v-model="node"
+            v-model:status="nodeStatus"
+          />
+        </template>
+
+        <TfManualNodeSelector
           :valid-filters="validFilters"
           :filters="filters"
-          :location="location"
-          :farm="farm"
           v-model="node"
           v-model:status="nodeStatus"
+          v-else
         />
-      </template>
-
-      <TfManualNodeSelector
-        :valid-filters="validFilters"
-        :filters="filters"
-        v-model="node"
-        v-model:status="nodeStatus"
-        v-else
-      />
+      </div>
 
       <VExpandTransition>
         <TfSelectGpu
@@ -108,6 +110,7 @@ export default {
     "update:status": (value: ValidatorStatus) => true || value,
   },
   setup(props, ctx) {
+    const input = ref<HTMLElement>();
     const filtersValidator = computed(() => createSelectionDetailsFiltersValidator(props.filtersValidators));
     const validFilters = computed(() => filtersValidator.value.safeParse(props.filters).success);
 
@@ -147,6 +150,7 @@ export default {
       reset: noop,
       status: ValidatorStatus.Init,
       error: null,
+      $el: input,
     };
 
     onMounted(() => form?.register(uid.toString(), fakeService));
@@ -186,6 +190,7 @@ export default {
     watch(
       status,
       status => {
+        fakeService.status = status;
         form?.updateStatus(uid.toString(), status);
         bindStatus(status);
       },
@@ -202,6 +207,7 @@ export default {
     }
 
     return {
+      input,
       validFilters,
       ValidatorStatus,
       wayToSelect,

--- a/packages/playground/src/components/ssh_keys/ManageSshDeployemnt.vue
+++ b/packages/playground/src/components/ssh_keys/ManageSshDeployemnt.vue
@@ -1,33 +1,36 @@
 <template>
-  <v-card class="my-6" variant="tonal">
-    <v-card-title>
-      <v-icon>mdi-key-chain</v-icon>
-      Manage SSH keys
-    </v-card-title>
-    <v-card-text>
-      SSH grants secure remote access to your deployed machine for seamless management and execution of commands.
-      <v-alert v-if="selectedKeys.length === 0" type="warning" class="mt-2">
-        Attention: It appears that no SSH keys have been selected. In order to access your deployment, you must send at
-        least one SSH key. You can manage your SSH keys from the
-        <router-link :to="DashboardRoutes.Deploy.SSHKey">SSH keys management page</router-link> and add more as needed.
-      </v-alert>
-    </v-card-text>
-
-    <VDivider />
-
-    <v-card-actions>
-      <VSpacer />
-      <v-btn
-        color="primary"
-        variant="flat"
-        @click="openManageDialog = true"
-        class="mr-2 my-1"
-        :disabled="sshKeysManagement.list() && sshKeysManagement.list().length === 0"
-      >
+  <div ref="inputElement">
+    <v-card class="my-6" variant="tonal">
+      <v-card-title>
+        <v-icon>mdi-key-chain</v-icon>
         Manage SSH keys
-      </v-btn>
-    </v-card-actions>
-  </v-card>
+      </v-card-title>
+      <v-card-text>
+        SSH grants secure remote access to your deployed machine for seamless management and execution of commands.
+        <v-alert v-if="selectedKeys.length === 0" type="warning" class="mt-2">
+          Attention: It appears that no SSH keys have been selected. In order to access your deployment, you must send
+          at least one SSH key. You can manage your SSH keys from the
+          <router-link :to="DashboardRoutes.Deploy.SSHKey">SSH keys management page</router-link> and add more as
+          needed.
+        </v-alert>
+      </v-card-text>
+
+      <VDivider />
+
+      <v-card-actions>
+        <VSpacer />
+        <v-btn
+          color="primary"
+          variant="flat"
+          @click="openManageDialog = true"
+          class="mr-2 my-1"
+          :disabled="sshKeysManagement.list() && sshKeysManagement.list().length === 0"
+        >
+          Manage SSH keys
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </div>
 
   <v-dialog v-model="openManageDialog" max-width="850">
     <v-card>
@@ -113,6 +116,7 @@ export default defineComponent({
   },
 
   setup(_, { emit }) {
+    const inputElement = ref<HTMLElement>();
     const defaultKeyData = { createdAt: "", id: 0, publicKey: "", name: "", isActive: false };
     const openManageDialog = ref<boolean>(false);
     const selectedKey = ref<SSHKeyData>(defaultKeyData);
@@ -174,6 +178,7 @@ export default defineComponent({
       reset: noop,
       status: ValidatorStatus.Init,
       error: null,
+      $el: inputElement,
     };
 
     onMounted(() => form?.register(`${uid}`, fakeService));
@@ -182,12 +187,15 @@ export default defineComponent({
     watch(
       () => selectedKeys.value.length,
       num => {
-        form?.updateStatus(`${uid}`, num === 0 ? ValidatorStatus.Invalid : ValidatorStatus.Valid);
+        const status = num === 0 ? ValidatorStatus.Init : ValidatorStatus.Valid;
+        fakeService.status = status;
+        form?.updateStatus(`${uid}`, status);
       },
       { immediate: true },
     );
 
     return {
+      inputElement,
       openManageDialog,
       selectedKeys,
       selectedKey,

--- a/packages/playground/src/hooks/form_validator.ts
+++ b/packages/playground/src/hooks/form_validator.ts
@@ -19,6 +19,8 @@ export interface FormValidatorService {
   valid: ComputedRef<boolean>;
   invalid: ComputedRef<boolean>;
   pending: ComputedRef<boolean>;
+  validOnInit: boolean;
+  inputs: ComputedRef<InputValidatorService[]>;
 }
 
 export const formValidatorKey = Symbol("form:validator");

--- a/packages/playground/src/hooks/input_validator.ts
+++ b/packages/playground/src/hooks/input_validator.ts
@@ -8,6 +8,7 @@ export interface InputValidatorService {
   reset(): void;
   status: ValidatorStatus;
   error: string | null;
+  $el?: Ref<HTMLElement | null | undefined> | null;
 }
 
 export function useInputRef(isArray: true): Ref<InputValidatorService[]>;

--- a/packages/playground/src/weblets/freeflow.vue
+++ b/packages/playground/src/weblets/freeflow.vue
@@ -74,8 +74,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="primary" variant="tonal" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -132,10 +132,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy" :disabled="tabs?.invalid || network?.error"
-        >Deploy
-      </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -173,10 +173,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" :disabled="tabs?.invalid || network?.error" @click="deploy"
-        >Deploy</v-btn
-      >
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -172,8 +172,8 @@
 
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_caprover.vue
+++ b/packages/playground/src/weblets/tf_caprover.vue
@@ -86,8 +86,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -64,8 +64,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -91,8 +91,9 @@
         </SmtpServer>
       </template>
     </d-tabs>
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="tabs?.invalid"> Deploy </v-btn>
+
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -116,8 +116,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -75,8 +75,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy" :disabled="tabs?.invalid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -73,8 +73,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="tabs?.invalid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_nextcloud.vue
+++ b/packages/playground/src/weblets/tf_nextcloud.vue
@@ -63,8 +63,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_node_pilot.vue
+++ b/packages/playground/src/weblets/tf_node_pilot.vue
@@ -87,8 +87,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -113,8 +113,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="tabs?.invalid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -90,8 +90,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -98,10 +98,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" :disabled="tabs?.invalid || network?.error" @click="deploy">
-        Deploy
-      </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_staticwebsite.vue
+++ b/packages/playground/src/weblets/tf_staticwebsite.vue
@@ -92,8 +92,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -76,8 +76,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -124,8 +124,8 @@
       </template>
     </d-tabs>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="tabs?.invalid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -110,8 +110,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -117,8 +117,8 @@
       <manage-ssh-deployemnt @selected-keys="updateSSHkeyEnv($event)" />
     </form-validator>
 
-    <template #footer-actions>
-      <v-btn color="secondary" variant="outlined" @click="deploy()" :disabled="!valid"> Deploy </v-btn>
+    <template #footer-actions="{ validateBeforeDeploy }">
+      <v-btn color="secondary" variant="outlined" @click="validateBeforeDeploy(deploy)" text="Deploy" />
     </template>
   </weblet-layout>
 </template>


### PR DESCRIPTION
### Description
Move to error input whenever user start deploying

### Changes
- feat: Connect domainName to form_validator so it can be focused
- feat: Connect selectGPU to form_validator so it can be focused
- feat: Use new validateBeforeDeploy util in all solutions
- feat: Add htmlElement in InputValidatorService
- feat: inputs ref in FormValidatorService
- feat: Add ref wrapper in ManageSShDeployment
- feat: Add ref wrapper in TfSelectionDetails
- feat: Add ref wrapper in input_validator
- feat: turn serviceMap into ref to update inputs whenever it changes
- feat: Use webletlayout service in dynamic tabs
- feat: Expose webletlayout service from weblet_layout to allow updating view from weblet_layout component

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2741

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
