### PR TITLE
Revert IPerf changes in Node Finder

### DIFF
--- a/packages/playground/src/components/node_details_cards/card_details.vue
+++ b/packages/playground/src/components/node_details_cards/card_details.vue
@@ -19,14 +19,14 @@
 
         <v-row class="bb-gray" v-for="item in items" :key="item.name">
           <v-col v-if="$props.iperf" class="font-14 d-flex justify-space-between">
-            <p class="ml-20 font-14">{{ item.name }}</p>
+            <p class="ml-20 font-14">{{ item.name }}/{{ item.type }}</p>
             <div>
               <v-icon icon="mdi-arrow-up"></v-icon>
-              <span class="mx-2">{{ item.uploadSpeed }}</span>
+              <span class="mx-3">{{ item.uploadSpeed }}</span>
             </div>
             <div>
               <v-icon icon="mdi-arrow-down"></v-icon>
-              <span class="mx-2">{{ item.downloadSpeed }}</span>
+              <span class="mx-3">{{ item.downloadSpeed }}</span>
             </div>
           </v-col>
           <v-col v-if="!$props.iperf" class="d-flex justify-start align-center ml-3">

--- a/packages/playground/src/components/node_details_cards/iperf_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/iperf_details_card.vue
@@ -15,7 +15,7 @@ import { onMounted, type PropType, ref } from "vue";
 
 import type { NodeDetailsCard } from "@/types";
 
-import { gridProxyClient } from "../../clients";
+import { useGrid } from "../../stores";
 import formatResourceSize from "../../utils/format_resource_size";
 import CardDetails from "./card_details.vue";
 
@@ -30,6 +30,7 @@ export default {
   },
 
   setup(props) {
+    const gridStore = useGrid();
     const loading = ref<boolean>(false);
     const IperfDetails = ref<NodeDetailsCard[]>();
     const errorMessage = ref("");
@@ -49,23 +50,29 @@ export default {
     });
 
     function format(speed: number) {
-      return formatResourceSize(speed, true).toLocaleLowerCase() + "ps" || "-";
+      return formatResourceSize(speed) + "/s" || "-";
     }
-
+    function isIPv4(ip: string) {
+      const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
+      return ipv4Regex.test(ip);
+    }
     const getNodeIPerfCard = async (): Promise<NodeDetailsCard[]> => {
-      const { speed } = await gridProxyClient.nodes.byId(props.node.nodeId);
-      const upload = format(speed.upload);
-      const download = format(speed.download);
-      IperfDetails.value = [
-        {
-          name: "Speed",
-          uploadSpeed: upload,
-          downloadSpeed: download,
-        },
-      ];
+      const res = await gridStore.grid.zos.getNodeIPerfTest({ nodeId: props.node.nodeId });
+      // filter the returned result to show node other than the one being tested against
+      const array = res.result
+        .filter(
+          (node: any) => node.download_speed && node.upload_speed && !node.error && node.node_id !== props.node.nodeId,
+        )
+        .slice(0, 4)
+        .map((node: any) => ({
+          name: node.test_type.toLocaleUpperCase(),
+          type: isIPv4(node.node_ip) ? "IPv4" : "IPv6",
+          downloadSpeed: format(node.download_speed),
+          uploadSpeed: format(node.upload_speed),
+        }));
+      IperfDetails.value = array;
       return IperfDetails.value;
     };
-
     return {
       IperfDetails,
       loading,


### PR DESCRIPTION
### Description

Get IPerf details from zos instead of grid proxy


When grid is initialized and node is up:

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/6072c30b-bc0b-4e72-977d-cee9e9f58e2c)


When grid is not initialized or node is down:

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/bfeb31e6-74ea-4a2e-91f9-84b7d3a4a4ef)


### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2735

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
