### PR TITLE
Fix naming issue when importing ssh key

### DIFF
--- a/packages/playground/src/components/ssh_keys/SshFormDialog.vue
+++ b/packages/playground/src/components/ssh_keys/SshFormDialog.vue
@@ -175,16 +175,15 @@ function createNewSSHKey() {
     id: keyId,
     publicKey: sshKey.value,
     createdAt: sshKeysManagement.formatDate(now),
-    name: "",
+    name: keyName.value,
     isActive: true,
   };
 
   createdKey.value.publicKey = sshKey.value;
   const parts = createdKey.value.publicKey.split(" ");
 
-  if (parts.length === 3) {
+  if (parts.length === 3 && keyName.value === "") {
     const importedKeyName = parts[parts.length - 1];
-
     if (importedKeyName.length < 30 && sshKeysManagement.availableName(importedKeyName)) {
       keyName.value = parts[parts.length - 1];
     }


### PR DESCRIPTION
### Description

- When importing key and add name, while saving it's renamed to the name in key.

### Changes

- Added condition to not extract name from key unless the field is empty
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2705
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

[Screencast from 05-23-2024 10:50:18 AM.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/54944491/f9b6ca85-a091-4903-8774-ee0e5cd61ec4)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
