### PR TITLE
Add peertube, funkwhale and casperlabs automated tests to the grid client using jest

### DIFF
--- a/packages/grid_client/tests/modules/applications/casperlabs.test.ts
+++ b/packages/grid_client/tests/modules/applications/casperlabs.test.ts
@@ -5,12 +5,14 @@ import { FilterOptions, GatewayNameModel, generateString, GridClient, MachinesMo
 import { config, getClient } from "../../client_loader";
 import { bytesToGB, generateInt, getOnlineNode, log, splitIP } from "../../utils";
 
+jest.setTimeout(900000);
+
 let gridClient: GridClient;
 let deploymentName: string;
 
 beforeAll(async () => {
   gridClient = await getClient();
-  deploymentName = "cl" + generateString(15);
+  deploymentName = "cl" + generateString(10);
   gridClient.clientOptions.projectName = `casperlabs/${deploymentName}`;
   gridClient._connect();
   return gridClient;

--- a/packages/grid_client/tests/modules/applications/casperlabs.test.ts
+++ b/packages/grid_client/tests/modules/applications/casperlabs.test.ts
@@ -68,7 +68,7 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
     farmId: 1,
     availableFor: await gridClient.twins.get_my_twin_id(),
   } as FilterOptions);
-  if (gatewayNodes.length == 0) throw new Error("no nodes available to complete this test");
+  if (gatewayNodes.length == 0) throw new Error("no gateway nodes available to complete this test");
   const GatewayNode = gatewayNodes[generateInt(0, gatewayNodes.length - 1)];
 
   //Node Selection
@@ -193,10 +193,16 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
     const wait = await setTimeout(5000, "Waiting for gateway to be ready");
     log(wait);
 
-    axios
+    await axios
       .get(site)
-      .then(() => {
+      .then(res => {
         log("gateway is reachable");
+        log(res.status);
+        log(res.statusText);
+        log(res.data);
+        expect(res.status).toBe(200);
+        expect(res.statusText).toBe("OK");
+        expect(res.data).toContain("Your Casper node is now running succesfully on the ThreeFold Grid.");
         reachable = true;
       })
       .catch(() => {
@@ -204,20 +210,9 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
       });
     if (reachable) {
       break;
+    } else if (i == 180) {
+      throw new Error("Gateway is unreachable after multiple retries");
     }
-  }
-
-  if (reachable) {
-    axios.get(site).then(res => {
-      log(res.status);
-      log(res.statusText);
-      log(res.data);
-      expect(res.status).toBe(200);
-      expect(res.statusText).toBe("OK");
-      expect(res.data).toContain("Your Casper node is now running succesfully on the ThreeFold Grid.");
-    });
-  } else {
-    throw new Error("Gateway is unreachable after multiple retries");
   }
 });
 

--- a/packages/grid_client/tests/modules/applications/casperlabs.test.ts
+++ b/packages/grid_client/tests/modules/applications/casperlabs.test.ts
@@ -1,0 +1,267 @@
+import axios from "axios";
+import { setTimeout } from "timers/promises";
+
+import { FilterOptions, GatewayNameModel, generateString, GridClient, MachinesModel, randomChoice } from "../../../src";
+import { config, getClient } from "../../client_loader";
+import { bytesToGB, generateInt, getOnlineNode, log, splitIP } from "../../utils";
+
+jest.setTimeout(300000);
+
+let gridClient: GridClient;
+let deploymentName: string;
+
+beforeAll(async () => {
+  gridClient = await getClient();
+  deploymentName = generateString(15);
+  gridClient.clientOptions.projectName = `casperlabs/${deploymentName}`;
+  gridClient._connect();
+  return gridClient;
+});
+
+//Private IP Regex
+const ipRegex = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/;
+
+test("TC2683 - Applications: Deploy Casperlabs", async () => {
+  /**********************************************
+     Test Suite: Grid3_Client_TS (Automated)
+     Test Cases: TC2683 - Applications: Deploy Casperlabs
+     Scenario:
+        - Generate Test Data/casperlabs Config/Gateway Config.
+        - Select a Node To Deploy the casperlabs on.
+        - Select a Gateway Node To Deploy the gateway on.
+        - Deploy the casperlabs solution.
+        - Assert that the generated data matches
+          the deployment details.
+        - Pass the IP of the Created casperlabs to the Gateway
+          Config.
+        - Deploy the Gateway.
+        - Assert that the generated data matches
+          the deployment details.
+        - Assert that the Gateway points at the IP
+          of the created casperlabs.
+        - Assert that the returned domain is working
+          and returns correct data.
+    **********************************************/
+
+  //Test Data
+  const name = "gw" + generateString(10).toLowerCase();
+  const tlsPassthrough = false;
+  let cpu = generateInt(1, 4);
+  let memory = generateInt(1, 6);
+  let rootfsSize = generateInt(0, 2);
+  let diskSize = generateInt(1, 20);
+  const networkName = generateString(15);
+  const vmName = generateString(15);
+  const diskName = generateString(15);
+  const mountPoint = "/data";
+  const publicIp = false;
+  const ipRangeClassA = "10." + generateInt(1, 255) + ".0.0/16";
+  const ipRangeClassB = "172." + generateInt(16, 31) + ".0.0/16";
+  const ipRangeClassC = "192.168.0.0/16";
+  const ipRange = randomChoice([ipRangeClassA, ipRangeClassB, ipRangeClassC]);
+  const metadata = "{'deploymentType': 'casperlabs'}";
+  const description = "test deploying Casperlabs via ts grid3 client";
+
+  //GatewayNode Selection
+  const gatewayNodes = await gridClient.capacity.filterNodes({
+    gateway: true,
+    farmId: 1,
+    availableFor: await gridClient.twins.get_my_twin_id(),
+  } as FilterOptions);
+  if (gatewayNodes.length == 0) throw new Error("no nodes available to complete this test");
+  const GatewayNode = gatewayNodes[generateInt(0, gatewayNodes.length - 1)];
+
+  //Node Selection
+  let nodes;
+  try {
+    nodes = await gridClient.capacity.filterNodes({
+      cru: cpu,
+      mru: memory,
+      sru: rootfsSize + diskSize,
+      farmId: 1,
+      availableFor: await gridClient.twins.get_my_twin_id(),
+    } as FilterOptions);
+  } catch (error) {
+    //Log the resources that were not found.
+    log("A Node was not found with the generated resources." + error);
+    log("Regenerating test data with lower resources....");
+
+    //Generate lower resources.
+    cpu = generateInt(1, cpu);
+    memory = generateInt(1, memory);
+    rootfsSize = generateInt(2, rootfsSize);
+    diskSize = generateInt(1, diskSize);
+
+    //Search for another node with lower resources.
+    nodes = await gridClient.capacity.filterNodes({
+      cru: cpu,
+      mru: memory,
+      sru: rootfsSize + diskSize,
+      farmId: 1,
+      availableFor: await gridClient.twins.get_my_twin_id(),
+    } as FilterOptions);
+  }
+  const nodeId = await getOnlineNode(nodes);
+  if (nodeId == -1) throw new Error("no nodes available to complete this test");
+  const domain = name + "." + GatewayNode.publicConfig.domain;
+
+  //VM Model
+  const vms: MachinesModel = {
+    name: deploymentName,
+    network: {
+      name: networkName,
+      ip_range: ipRange,
+    },
+    machines: [
+      {
+        name: vmName,
+        node_id: nodeId,
+        cpu: cpu,
+        memory: 1024 * memory,
+        rootfs_size: rootfsSize,
+        disks: [
+          {
+            name: diskName,
+            size: diskSize,
+            mountpoint: mountPoint,
+          },
+        ],
+        flist: "https://hub.grid.tf/tf-official-apps/casperlabs-latest.flist",
+        entrypoint: "/sbin/zinit init",
+        public_ip: publicIp,
+        planetary: true,
+        mycelium: false,
+        env: {
+          SSH_KEY: config.ssh_key,
+          CASPERLABS_HOSTNAME: domain,
+        },
+      },
+    ],
+    metadata: metadata,
+    description: description,
+  };
+  const res = await gridClient.machines.deploy(vms);
+  log(res);
+
+  //Contracts Assertions
+  expect(res.contracts.created).toHaveLength(1);
+  expect(res.contracts.updated).toHaveLength(0);
+  expect(res.contracts.deleted).toHaveLength(0);
+
+  const vmsList = await gridClient.machines.list();
+  log(vmsList);
+
+  //VM List Assertions
+  expect(vmsList.length).toBeGreaterThanOrEqual(1);
+  expect(vmsList).toContain(vms.name);
+
+  const result = await gridClient.machines.getObj(vms.name);
+  log(result);
+
+  //VM Assertions
+  expect(result[0].nodeId).toBe(nodeId);
+  expect(result[0].status).toBe("ok");
+  expect(result[0].flist).toBe(vms.machines[0].flist);
+  expect(result[0].entrypoint).toBe(vms.machines[0].entrypoint);
+  expect(result[0].mounts).toHaveLength(1);
+  expect(result[0].interfaces[0]["network"]).toBe(vms.network.name);
+  expect(result[0].interfaces[0]["ip"]).toContain(splitIP(vms.network.ip_range));
+  expect(result[0].interfaces[0]["ip"]).toMatch(ipRegex);
+  expect(result[0].capacity["cpu"]).toBe(cpu);
+  expect(result[0].capacity["memory"]).toBe(memory * 1024);
+  expect(result[0].planetary).toBeDefined();
+  expect(result[0].publicIP).toBeNull();
+  expect(result[0].description).toBe(description);
+  expect(result[0].mounts[0]["name"]).toBe(diskName);
+  expect(result[0].mounts[0]["size"]).toBe(bytesToGB(diskSize));
+  expect(result[0].mounts[0]["mountPoint"]).toBe(mountPoint);
+  expect(result[0].mounts[0]["state"]).toBe("ok");
+
+  const backends = ["http://[" + result[0].planetary + "]:80"];
+  log(backends);
+
+  //Name Gateway Model
+  const gw: GatewayNameModel = {
+    name: name,
+    node_id: GatewayNode.nodeId,
+    tls_passthrough: tlsPassthrough,
+    backends: backends,
+  };
+
+  const gatewayRes = await gridClient.gateway.deploy_name(gw);
+  log(gatewayRes);
+
+  //Contracts Assertions
+  expect(gatewayRes.contracts.created).toHaveLength(1);
+  expect(gatewayRes.contracts.updated).toHaveLength(0);
+  expect(gatewayRes.contracts.deleted).toHaveLength(0);
+  expect(gatewayRes.contracts.created[0].contractType.nodeContract.nodeId).toBe(GatewayNode.nodeId);
+
+  const gatewayResult = await gridClient.gateway.getObj(gw.name);
+  log(gatewayResult);
+
+  //Gateway Assertions
+  expect(gatewayResult[0].name).toBe(name);
+  expect(gatewayResult[0].status).toBe("ok");
+  expect(gatewayResult[0].type).toContain("name");
+  expect(gatewayResult[0].domain).toContain(name);
+  expect(gatewayResult[0].tls_passthrough).toBe(tlsPassthrough);
+  expect(gatewayResult[0].backends).toStrictEqual(backends);
+
+  const site = "https://" + gatewayResult[0].domain;
+  let reachable = false;
+
+  for (let i = 0; i < 3000; i++) {
+    axios
+      .get(site)
+      .then(() => {
+        log("gateway is reachable");
+        reachable = true;
+      })
+      .catch(() => {
+        log("gateway is not reachable");
+      });
+    if (reachable) {
+      break;
+    }
+    const wait = await setTimeout(5000, "Waiting for gateway to be ready");
+    log(wait);
+  }
+
+  if (reachable) {
+    axios.get(site).then(res => {
+      log(res.status);
+      log(res.statusText);
+      log(res.data);
+      expect(res.status).toBe(200);
+      expect(res.statusText).toBe("OK");
+      expect(res.data).toContain("Your Casper node is now running succesfully on the ThreeFold Grid.");
+    });
+  } else {
+    throw new Error("Gateway is unreachable after multiple retries");
+  }
+});
+
+afterEach(async () => {
+  const vmNames = await gridClient.machines.list();
+  for (const name of vmNames) {
+    const res = await gridClient.machines.delete({ name });
+    log(res);
+    expect(res.created).toHaveLength(0);
+    expect(res.updated).toHaveLength(0);
+    expect(res.deleted).toBeDefined();
+  }
+
+  const gwNames = await gridClient.gateway.list();
+  for (const name of gwNames) {
+    const res = await gridClient.gateway.delete_name({ name });
+    log(res);
+    expect(res.created).toHaveLength(0);
+    expect(res.updated).toHaveLength(0);
+    expect(res.deleted).toBeDefined();
+  }
+});
+
+afterAll(async () => {
+  return await gridClient.disconnect();
+}, 130000);

--- a/packages/grid_client/tests/modules/applications/casperlabs.test.ts
+++ b/packages/grid_client/tests/modules/applications/casperlabs.test.ts
@@ -217,7 +217,7 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
   }
 });
 
-afterEach(async () => {
+afterAll(async () => {
   const vmNames = await gridClient.machines.list();
   for (const name of vmNames) {
     const res = await gridClient.machines.delete({ name });
@@ -235,8 +235,6 @@ afterEach(async () => {
     expect(res.updated).toHaveLength(0);
     expect(res.deleted).toBeDefined();
   }
-});
 
-afterAll(async () => {
   return await gridClient.disconnect();
 }, 130000);

--- a/packages/grid_client/tests/modules/applications/casperlabs.test.ts
+++ b/packages/grid_client/tests/modules/applications/casperlabs.test.ts
@@ -48,7 +48,7 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
   const tlsPassthrough = false;
   const cpu = 2;
   const memory = 4;
-  const rootfsSize = 0;
+  const rootfsSize = 2;
   const diskSize = 100;
   const networkName = generateString(15);
   const vmName = generateString(15);
@@ -150,6 +150,7 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
   expect(result[0].planetary).toBeDefined();
   expect(result[0].publicIP).toBeNull();
   expect(result[0].description).toBe(description);
+  expect(result[0].rootfs_size).toBe(bytesToGB(rootfsSize));
   expect(result[0].mounts[0]["name"]).toBe(diskName);
   expect(result[0].mounts[0]["size"]).toBe(bytesToGB(diskSize));
   expect(result[0].mounts[0]["mountPoint"]).toBe(mountPoint);

--- a/packages/grid_client/tests/modules/applications/funkwhale.test.ts
+++ b/packages/grid_client/tests/modules/applications/funkwhale.test.ts
@@ -68,7 +68,7 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
     farmId: 1,
     availableFor: await gridClient.twins.get_my_twin_id(),
   } as FilterOptions);
-  if (gatewayNodes.length == 0) throw new Error("no nodes available to complete this test");
+  if (gatewayNodes.length == 0) throw new Error("no gateway nodes available to complete this test");
   const GatewayNode = gatewayNodes[generateInt(0, gatewayNodes.length - 1)];
 
   //Node Selection
@@ -196,10 +196,16 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
     const wait = await setTimeout(5000, "Waiting for gateway to be ready");
     log(wait);
 
-    axios
+    await axios
       .get(site)
-      .then(() => {
+      .then(res => {
         log("gateway is reachable");
+        log(res.status);
+        log(res.statusText);
+        log(res.data);
+        expect(res.status).toBe(200);
+        expect(res.statusText).toBe("OK");
+        expect(res.data).toContain("Funkwhale");
         reachable = true;
       })
       .catch(() => {
@@ -207,20 +213,9 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
       });
     if (reachable) {
       break;
+    } else if (i == 180) {
+      throw new Error("Gateway is unreachable after multiple retries");
     }
-  }
-
-  if (reachable) {
-    axios.get(site).then(res => {
-      log(res.status);
-      log(res.statusText);
-      log(res.data);
-      expect(res.status).toBe(200);
-      expect(res.statusText).toBe("OK");
-      expect(res.data).toContain("Funkwhale");
-    });
-  } else {
-    throw new Error("Gateway is unreachable after multiple retries");
   }
 });
 

--- a/packages/grid_client/tests/modules/applications/funkwhale.test.ts
+++ b/packages/grid_client/tests/modules/applications/funkwhale.test.ts
@@ -13,7 +13,7 @@ let deploymentName: string;
 beforeAll(async () => {
   gridClient = await getClient();
   deploymentName = generateString(15);
-  gridClient.clientOptions.projectName = `casperlabs/${deploymentName}`;
+  gridClient.clientOptions.projectName = `funkwhale/${deploymentName}`;
   gridClient._connect();
   return gridClient;
 });
@@ -21,24 +21,24 @@ beforeAll(async () => {
 //Private IP Regex
 const ipRegex = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/;
 
-test("TC2683 - Applications: Deploy Casperlabs", async () => {
+test("TC2685 - Applications: Deploy Funkwhale", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)
-     Test Cases: TC2683 - Applications: Deploy Casperlabs
+     Test Cases: TC2685 - Applications: Deploy Funkwhale
      Scenario:
-        - Generate Test Data/casperlabs Config/Gateway Config.
-        - Select a Node To Deploy the casperlabs on.
+        - Generate Test Data/funkwhale Config/Gateway Config.
+        - Select a Node To Deploy the funkwhale on.
         - Select a Gateway Node To Deploy the gateway on.
-        - Deploy the casperlabs solution.
+        - Deploy the funkwhale solution.
         - Assert that the generated data matches
           the deployment details.
-        - Pass the IP of the Created casperlabs to the Gateway
+        - Pass the IP of the Created funkwhale to the Gateway
           Config.
         - Deploy the Gateway.
         - Assert that the generated data matches
           the deployment details.
         - Assert that the Gateway points at the IP
-          of the created casperlabs.
+          of the created funkwhale.
         - Assert that the returned domain is working
           and returns correct data.
     **********************************************/
@@ -59,8 +59,8 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
   const ipRangeClassB = "172." + generateInt(16, 31) + ".0.0/16";
   const ipRangeClassC = "192.168.0.0/16";
   const ipRange = randomChoice([ipRangeClassA, ipRangeClassB, ipRangeClassC]);
-  const metadata = "{'deploymentType': 'casperlabs'}";
-  const description = "test deploying Casperlabs via ts grid3 client";
+  const metadata = "{'deploymentType': 'funkwhale'}";
+  const description = "test deploying Funkwhale via ts grid3 client";
 
   //GatewayNode Selection
   const gatewayNodes = await gridClient.capacity.filterNodes({
@@ -126,14 +126,17 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
             mountpoint: mountPoint,
           },
         ],
-        flist: "https://hub.grid.tf/tf-official-apps/casperlabs-latest.flist",
-        entrypoint: "/sbin/zinit init",
+        flist: "https://hub.grid.tf/tf-official-apps/funkwhale-dec21.flist",
+        entrypoint: "/init.sh",
         public_ip: publicIp,
         planetary: true,
         mycelium: false,
         env: {
           SSH_KEY: config.ssh_key,
-          CASPERLABS_HOSTNAME: domain,
+          FUNKWHALE_HOSTNAME: domain,
+          DJANGO_SUPERUSER_EMAIL: "admin123@funk.whale",
+          DJANGO_SUPERUSER_USERNAME: "admin123",
+          DJANGO_SUPERUSER_PASSWORD: "admin123",
         },
       },
     ],
@@ -235,7 +238,7 @@ test("TC2683 - Applications: Deploy Casperlabs", async () => {
       log(res.data);
       expect(res.status).toBe(200);
       expect(res.statusText).toBe("OK");
-      expect(res.data).toContain("Your Casper node is now running succesfully on the ThreeFold Grid.");
+      expect(res.data).toContain("Funkwhale");
     });
   } else {
     throw new Error("Gateway is unreachable after multiple retries");

--- a/packages/grid_client/tests/modules/applications/funkwhale.test.ts
+++ b/packages/grid_client/tests/modules/applications/funkwhale.test.ts
@@ -5,14 +5,12 @@ import { FilterOptions, GatewayNameModel, generateString, GridClient, MachinesMo
 import { config, getClient } from "../../client_loader";
 import { bytesToGB, generateInt, getOnlineNode, log, splitIP } from "../../utils";
 
-jest.setTimeout(1500000);
-
 let gridClient: GridClient;
 let deploymentName: string;
 
 beforeAll(async () => {
   gridClient = await getClient();
-  deploymentName = generateString(15);
+  deploymentName = "fw" + generateString(15);
   gridClient.clientOptions.projectName = `funkwhale/${deploymentName}`;
   gridClient._connect();
   return gridClient;
@@ -46,10 +44,10 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
   //Test Data
   const name = "gw" + generateString(10).toLowerCase();
   const tlsPassthrough = false;
-  let cpu = generateInt(1, 4);
-  let memory = generateInt(1, 6);
-  let rootfsSize = generateInt(0, 2);
-  let diskSize = generateInt(10, 50);
+  const cpu = 1;
+  const memory = 2;
+  const rootfsSize = 0;
+  const diskSize = 50;
   const networkName = generateString(15);
   const vmName = generateString(15);
   const diskName = generateString(15);
@@ -72,35 +70,13 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
   const GatewayNode = gatewayNodes[generateInt(0, gatewayNodes.length - 1)];
 
   //Node Selection
-  let nodes;
-  try {
-    nodes = await gridClient.capacity.filterNodes({
-      cru: cpu,
-      mru: memory,
-      sru: rootfsSize + diskSize,
-      farmId: 1,
-      availableFor: await gridClient.twins.get_my_twin_id(),
-    } as FilterOptions);
-  } catch (error) {
-    //Log the resources that were not found.
-    log("A Node was not found with the generated resources." + error);
-    log("Regenerating test data with lower resources....");
-
-    //Generate lower resources.
-    cpu = generateInt(1, cpu);
-    memory = generateInt(1, memory);
-    rootfsSize = generateInt(0, rootfsSize);
-    diskSize = generateInt(5, diskSize);
-
-    //Search for another node with lower resources.
-    nodes = await gridClient.capacity.filterNodes({
-      cru: cpu,
-      mru: memory,
-      sru: rootfsSize + diskSize,
-      farmId: 1,
-      availableFor: await gridClient.twins.get_my_twin_id(),
-    } as FilterOptions);
-  }
+  const nodes = await gridClient.capacity.filterNodes({
+    cru: cpu,
+    mru: memory,
+    sru: rootfsSize + diskSize,
+    farmId: 1,
+    availableFor: await gridClient.twins.get_my_twin_id(),
+  } as FilterOptions);
   const nodeId = await getOnlineNode(nodes);
   if (nodeId == -1) throw new Error("no nodes available to complete this test");
   const domain = name + "." + GatewayNode.publicConfig.domain;
@@ -214,7 +190,10 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
   const site = "https://" + gatewayResult[0].domain;
   let reachable = false;
 
-  for (let i = 0; i < 300; i++) {
+  for (let i = 0; i < 180; i++) {
+    const wait = await setTimeout(5000, "Waiting for gateway to be ready");
+    log(wait);
+
     axios
       .get(site)
       .then(() => {
@@ -227,8 +206,6 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
     if (reachable) {
       break;
     }
-    const wait = await setTimeout(5000, "Waiting for gateway to be ready");
-    log(wait);
   }
 
   if (reachable) {

--- a/packages/grid_client/tests/modules/applications/funkwhale.test.ts
+++ b/packages/grid_client/tests/modules/applications/funkwhale.test.ts
@@ -5,12 +5,14 @@ import { FilterOptions, GatewayNameModel, generateString, GridClient, MachinesMo
 import { config, getClient } from "../../client_loader";
 import { bytesToGB, generateInt, getOnlineNode, log, splitIP } from "../../utils";
 
+jest.setTimeout(900000);
+
 let gridClient: GridClient;
 let deploymentName: string;
 
 beforeAll(async () => {
   gridClient = await getClient();
-  deploymentName = "fw" + generateString(15);
+  deploymentName = "fw" + generateString(10);
   gridClient.clientOptions.projectName = `funkwhale/${deploymentName}`;
   gridClient._connect();
   return gridClient;

--- a/packages/grid_client/tests/modules/applications/funkwhale.test.ts
+++ b/packages/grid_client/tests/modules/applications/funkwhale.test.ts
@@ -220,7 +220,7 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
   }
 });
 
-afterEach(async () => {
+afterAll(async () => {
   const vmNames = await gridClient.machines.list();
   for (const name of vmNames) {
     const res = await gridClient.machines.delete({ name });
@@ -238,8 +238,6 @@ afterEach(async () => {
     expect(res.updated).toHaveLength(0);
     expect(res.deleted).toBeDefined();
   }
-});
 
-afterAll(async () => {
   return await gridClient.disconnect();
 }, 130000);

--- a/packages/grid_client/tests/modules/applications/funkwhale.test.ts
+++ b/packages/grid_client/tests/modules/applications/funkwhale.test.ts
@@ -48,7 +48,7 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
   const tlsPassthrough = false;
   const cpu = 1;
   const memory = 2;
-  const rootfsSize = 0;
+  const rootfsSize = 2;
   const diskSize = 50;
   const networkName = generateString(15);
   const vmName = generateString(15);
@@ -153,6 +153,7 @@ test("TC2685 - Applications: Deploy Funkwhale", async () => {
   expect(result[0].planetary).toBeDefined();
   expect(result[0].publicIP).toBeNull();
   expect(result[0].description).toBe(description);
+  expect(result[0].rootfs_size).toBe(bytesToGB(rootfsSize));
   expect(result[0].mounts[0]["name"]).toBe(diskName);
   expect(result[0].mounts[0]["size"]).toBe(bytesToGB(diskSize));
   expect(result[0].mounts[0]["mountPoint"]).toBe(mountPoint);

--- a/packages/grid_client/tests/modules/applications/peertube.test.ts
+++ b/packages/grid_client/tests/modules/applications/peertube.test.ts
@@ -68,7 +68,7 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
     farmId: 1,
     availableFor: await gridClient.twins.get_my_twin_id(),
   } as FilterOptions);
-  if (gatewayNodes.length == 0) throw new Error("no nodes available to complete this test");
+  if (gatewayNodes.length == 0) throw new Error("no gateway nodes available to complete this test");
   const GatewayNode = gatewayNodes[generateInt(0, gatewayNodes.length - 1)];
 
   //Node Selection
@@ -197,14 +197,22 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
     const wait = await setTimeout(5000, "Waiting for gateway to be ready");
     log(wait);
 
-    axios
+    await axios
       .get(site, {
         headers: {
           Accept: header,
         },
       })
-      .then(() => {
+      .then(res => {
         log("gateway is reachable");
+        log(res.status);
+        log(res.statusText);
+        log(res.data);
+        expect(res.status).toBe(200);
+        expect(res.statusText).toBe("OK");
+        expect(res.data).toContain(
+          "PeerTube, an ActivityPub-federated video streaming platform using P2P directly in your web browser.",
+        );
         reachable = true;
       })
       .catch(() => {
@@ -212,22 +220,9 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
       });
     if (reachable) {
       break;
+    } else if (i == 180) {
+      throw new Error("Gateway is unreachable after multiple retries");
     }
-  }
-
-  if (reachable) {
-    axios.get(site, { headers: { Accept: header } }).then(res => {
-      log(res.status);
-      log(res.statusText);
-      log(res.data);
-      expect(res.status).toBe(200);
-      expect(res.statusText).toBe("OK");
-      expect(res.data).toContain(
-        "PeerTube, an ActivityPub-federated video streaming platform using P2P directly in your web browser.",
-      );
-    });
-  } else {
-    throw new Error("Gateway is unreachable after multiple retries");
   }
 });
 

--- a/packages/grid_client/tests/modules/applications/peertube.test.ts
+++ b/packages/grid_client/tests/modules/applications/peertube.test.ts
@@ -5,12 +5,14 @@ import { FilterOptions, GatewayNameModel, generateString, GridClient, MachinesMo
 import { config, getClient } from "../../client_loader";
 import { bytesToGB, generateInt, getOnlineNode, log, splitIP } from "../../utils";
 
+jest.setTimeout(900000);
+
 let gridClient: GridClient;
 let deploymentName: string;
 
 beforeAll(async () => {
   gridClient = await getClient();
-  deploymentName = "pt" + generateString(15);
+  deploymentName = "pt" + generateString(10);
   gridClient.clientOptions.projectName = `peertube/${deploymentName}`;
   gridClient._connect();
   return gridClient;
@@ -196,7 +198,11 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
     log(wait);
 
     axios
-      .get(site)
+      .get(site, {
+        headers: {
+          Accept: header,
+        },
+      })
       .then(() => {
         log("gateway is reachable");
         reachable = true;

--- a/packages/grid_client/tests/modules/applications/peertube.test.ts
+++ b/packages/grid_client/tests/modules/applications/peertube.test.ts
@@ -5,14 +5,12 @@ import { FilterOptions, GatewayNameModel, generateString, GridClient, MachinesMo
 import { config, getClient } from "../../client_loader";
 import { bytesToGB, generateInt, getOnlineNode, log, splitIP } from "../../utils";
 
-jest.setTimeout(1500000);
-
 let gridClient: GridClient;
 let deploymentName: string;
 
 beforeAll(async () => {
   gridClient = await getClient();
-  deploymentName = generateString(15);
+  deploymentName = "pt" + generateString(15);
   gridClient.clientOptions.projectName = `peertube/${deploymentName}`;
   gridClient._connect();
   return gridClient;
@@ -46,10 +44,10 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
   //Test Data
   const name = "gw" + generateString(10).toLowerCase();
   const tlsPassthrough = false;
-  let cpu = generateInt(1, 4);
-  let memory = generateInt(1, 6);
-  let rootfsSize = generateInt(0, 2);
-  let diskSize = generateInt(10, 50);
+  const cpu = 1;
+  const memory = 2;
+  const rootfsSize = 0;
+  const diskSize = 15;
   const networkName = generateString(15);
   const vmName = generateString(15);
   const diskName = generateString(15);
@@ -72,35 +70,13 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
   const GatewayNode = gatewayNodes[generateInt(0, gatewayNodes.length - 1)];
 
   //Node Selection
-  let nodes;
-  try {
-    nodes = await gridClient.capacity.filterNodes({
-      cru: cpu,
-      mru: memory,
-      sru: rootfsSize + diskSize,
-      farmId: 1,
-      availableFor: await gridClient.twins.get_my_twin_id(),
-    } as FilterOptions);
-  } catch (error) {
-    //Log the resources that were not found.
-    log("A Node was not found with the generated resources." + error);
-    log("Regenerating test data with lower resources....");
-
-    //Generate lower resources.
-    cpu = generateInt(1, cpu);
-    memory = generateInt(1, memory);
-    rootfsSize = generateInt(0, rootfsSize);
-    diskSize = generateInt(5, diskSize);
-
-    //Search for another node with lower resources.
-    nodes = await gridClient.capacity.filterNodes({
-      cru: cpu,
-      mru: memory,
-      sru: rootfsSize + diskSize,
-      farmId: 1,
-      availableFor: await gridClient.twins.get_my_twin_id(),
-    } as FilterOptions);
-  }
+  const nodes = await gridClient.capacity.filterNodes({
+    cru: cpu,
+    mru: memory,
+    sru: rootfsSize + diskSize,
+    farmId: 1,
+    availableFor: await gridClient.twins.get_my_twin_id(),
+  } as FilterOptions);
   const nodeId = await getOnlineNode(nodes);
   if (nodeId == -1) throw new Error("no nodes available to complete this test");
   const domain = name + "." + GatewayNode.publicConfig.domain;
@@ -215,13 +191,12 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
   const header =
     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7";
 
-  for (let i = 0; i < 300; i++) {
+  for (let i = 0; i < 180; i++) {
+    const wait = await setTimeout(5000, "Waiting for gateway to be ready");
+    log(wait);
+
     axios
-      .get(site, {
-        headers: {
-          Accept: header,
-        },
-      })
+      .get(site)
       .then(() => {
         log("gateway is reachable");
         reachable = true;
@@ -232,8 +207,6 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
     if (reachable) {
       break;
     }
-    const wait = await setTimeout(5000, "Waiting for gateway to be ready");
-    log(wait);
   }
 
   if (reachable) {

--- a/packages/grid_client/tests/modules/applications/peertube.test.ts
+++ b/packages/grid_client/tests/modules/applications/peertube.test.ts
@@ -227,7 +227,7 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
   }
 });
 
-afterEach(async () => {
+afterAll(async () => {
   const vmNames = await gridClient.machines.list();
   for (const name of vmNames) {
     const res = await gridClient.machines.delete({ name });
@@ -245,8 +245,6 @@ afterEach(async () => {
     expect(res.updated).toHaveLength(0);
     expect(res.deleted).toBeDefined();
   }
-});
 
-afterAll(async () => {
   return await gridClient.disconnect();
 }, 130000);

--- a/packages/grid_client/tests/modules/applications/peertube.test.ts
+++ b/packages/grid_client/tests/modules/applications/peertube.test.ts
@@ -48,7 +48,7 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
   const tlsPassthrough = false;
   const cpu = 1;
   const memory = 2;
-  const rootfsSize = 0;
+  const rootfsSize = 2;
   const diskSize = 15;
   const networkName = generateString(15);
   const vmName = generateString(15);
@@ -152,6 +152,7 @@ test("TC2684 - Applications: Deploy Peertube", async () => {
   expect(result[0].planetary).toBeDefined();
   expect(result[0].publicIP).toBeNull();
   expect(result[0].description).toBe(description);
+  expect(result[0].rootfs_size).toBe(bytesToGB(rootfsSize));
   expect(result[0].mounts[0]["name"]).toBe(diskName);
   expect(result[0].mounts[0]["size"]).toBe(bytesToGB(diskSize));
   expect(result[0].mounts[0]["mountPoint"]).toBe(mountPoint);


### PR DESCRIPTION
### Description

Add peertube, funkwhale and casperlabs  automated test to the grid client using Jest.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1841

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
