### PR TITLE
Fix balance rule

### DIFF
--- a/packages/playground/src/utils/pricing_calculator.ts
+++ b/packages/playground/src/utils/pricing_calculator.ts
@@ -1,7 +1,8 @@
-import { isInt, max, min, required } from "./validators";
+import { isInt, isNumeric, max, min, required } from "./validators";
 
 function _applyRules(rules: Array<(value: string) => { message: string } | void>): (value: string) => true | string {
   return (value: string) => {
+    value = value?.toString();
     for (const rule of rules) {
       const res = rule(value);
       if (res && res.message) {
@@ -47,7 +48,7 @@ export const hruRules = _applyRules([
 ]);
 
 export const balanceRules = _applyRules([
-  isInt("Balance must be a valid integer."),
+  isNumeric("Balance must be a valid number."),
   min("Balance should be a positive integer and more than 1 TFT.", 1),
 ]);
 

--- a/packages/playground/src/utils/pricing_calculator.ts
+++ b/packages/playground/src/utils/pricing_calculator.ts
@@ -49,7 +49,7 @@ export const hruRules = _applyRules([
 
 export const balanceRules = _applyRules([
   isNumeric("Balance must be a valid number."),
-  min("Balance should be a positive integer and more than 1 TFT.", 1),
+  min("Minimum allowed balance is 0.", 0),
 ]);
 
 export function normalizePrice(price: number) {


### PR DESCRIPTION
### Description

Issue happened because of type mismatch in balance field when balance is being updated.


### Chnages

- Edited _applyRules function to stringify the value before running any validations. 
- Changed balance rule to isNumeric instead of isInt
- Changed min balance to 0


[balance.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/40770501/654e5846-9fb1-468e-bdad-649e272de1f5)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2826

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
