### PR TITLE
Adding a note to notify the user that bandwidth affects the cost of deployment

### DIFF
--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -80,7 +80,7 @@
             You selected a certified node. Please note that this deployment costs more TFT.
           </div>
         </div>
-
+        <div>Please Note that the Bandwidth affects the total cost.</div>
         <a :href="manual.pricing" target="_blank" class="app-link">
           Learn more about the pricing and how to unlock discounts.
         </a>


### PR DESCRIPTION

### Description

Adding a note to notify the user that bandwidth affects the cost of deployment
![Screenshot from 2024-06-03 17-17-10](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/b0c6b313-a2e0-4455-8e28-cb2bcf964101)


### Related Issues

- #2791


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
