### PR TITLE
fix mycelium check for network error

### DIFF
--- a/packages/playground/src/components/networks.vue
+++ b/packages/playground/src/components/networks.vue
@@ -137,7 +137,7 @@ export default {
       props.ipv6 === null &&
       props.planetary === null &&
       props.wireguard === null &&
-      props.mycelium
+      props.mycelium === null
     ) {
       throw new Error("You must provide at least one network  option");
     }


### PR DESCRIPTION


### Changes

just made it check if mycelium is null before returning error for network option needs to be selected. 

### Related Issues

[#2819](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2819)


no more errors displayed

![Screenshot from 2024-06-03 19-37-09](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/2414bafb-2726-4bd4-83bd-febbf1025d7c)


