### PR TITLE
Include the Workloads info in the stats view in the dashboard and the stats project. 

### DIFF
--- a/packages/gridproxy_client/src/modules/stats.ts
+++ b/packages/gridproxy_client/src/modules/stats.ts
@@ -15,6 +15,7 @@ export interface Stats {
   gateways: number;
   twins: number;
   contracts: number;
+  workloads_number: number;
   nodesDistribution: { [key: string]: number };
   dedicatedNodes: number;
 }

--- a/packages/playground/src/views/stats.vue
+++ b/packages/playground/src/views/stats.vue
@@ -136,6 +136,7 @@ const fetchData = async () => {
         { data: stats!.twins, title: "Twins", icon: "mdi-brain" },
         { data: stats!.publicIps, title: "Public IPs", icon: "mdi-access-point" },
         { data: stats!.contracts, title: "Contracts", icon: "mdi-file-document-edit-outline" },
+        { data: stats!.workloads_number, title: "Number of workloads", icon: "mdi-state-machine" },
       ];
 
       loading.value = false;

--- a/packages/stats/src/components/stats_table.vue
+++ b/packages/stats/src/components/stats_table.vue
@@ -95,6 +95,7 @@ const Istats = computed((): IStatistics[] => {
       { data: formattedStats.value.twins, title: "Twins", icon: "mdi-brain" },
       { data: formattedStats.value.publicIps, title: "Public IPs", icon: "mdi-access-point" },
       { data: formattedStats.value.contracts, title: "Contracts", icon: "mdi-file-document-edit-outline" },
+      { data: formattedStats.value.workloads_number, title: "Number of workloads", icon: "mdi-state-machine" },
     ];
   }
 });

--- a/packages/stats/src/utils/stats.ts
+++ b/packages/stats/src/utils/stats.ts
@@ -5,6 +5,7 @@ import type { NetworkStats } from "@/types";
 function mergeAllStatsData(stats: Stats[]): Stats {
   const res = stats[0];
   for (let i = 1; i < stats.length; i++) {
+    const workloads = isNaN(stats[i].workloads_number) ? 0 : stats[i].workloads_number;
     res.accessNodes += stats[i].accessNodes;
     res.dedicatedNodes += stats[i].dedicatedNodes;
     res.contracts += stats[i].contracts;
@@ -20,6 +21,7 @@ function mergeAllStatsData(stats: Stats[]): Stats {
     res.twins += stats[i].twins;
     res.nodesDistribution = mergeNodeDistribution([res.nodesDistribution, stats[i].nodesDistribution]);
     res.countries = Object.keys(res.nodesDistribution).length;
+    res.workloads_number += workloads;
   }
 
   return res;
@@ -28,6 +30,7 @@ function mergeAllStatsData(stats: Stats[]): Stats {
 function mergeStatsData(stats: Stats[]): Stats {
   const res = stats[0];
   for (let i = 1; i < stats.length; i++) {
+    const workloads = isNaN(stats[i].workloads_number) ? 0 : stats[i].workloads_number;
     res.accessNodes += stats[i].accessNodes;
     res.dedicatedNodes += stats[i].dedicatedNodes;
     res.gateways += stats[i].gateways;
@@ -39,6 +42,7 @@ function mergeStatsData(stats: Stats[]): Stats {
     res.gpus += stats[i].gpus;
     res.nodesDistribution = mergeNodeDistribution([res.nodesDistribution, stats[i].nodesDistribution]);
     res.countries = Object.keys(res.nodesDistribution).length;
+    res.workloads_number += workloads;
   }
   return res;
 }
@@ -86,6 +90,7 @@ export function formatData(network: string[] = ["main"], totalStat: NetworkStats
     contracts: 0,
     nodesDistribution: {},
     dedicatedNodes: 0,
+    workloads_number: 0,
   };
   for (let i = 0; i < network.length; i++) {
     const currentStats = totalStat[network[i]];


### PR DESCRIPTION
### Description

Include the Workloads info in the stats view in the dashboard and the stats project. 

### Changes

- Included the `workloads_number` attr in the stats view in the dashboard
- Included the `workloads_number` attr in the stats project 

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/985
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1792

### Screenshots
- Dashboard

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/f7b928da-06b8-4ea7-a1d2-55e0e129d0b1)


- Stats project 

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/bad98d6e-695a-4278-8d4c-9695e36f21c2)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
