### PR TITLE
showing the discount icon only if the node is dedicated

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -194,7 +194,7 @@
       </VRow>
       <div class="mt-5 ml-auto text-right">
         <v-tooltip bottom color="primary" close-delay="100" :disabled="!(node && node.dedicated)">
-          <template v-slot:activator="{ isActive, props }" v-if="num_gpu!">
+          <template v-slot:activator="{ isActive, props }" v-if="node && node.dedicated">
             <span v-bind="props" v-on="isActive" class="font-weight-bold"
               ><v-icon class="scale_beat mr-2" color="warning">mdi-brightness-percent</v-icon
               >{{ (price_usd! / 24 / 30).toFixed(2) }} USD/Hour</span


### PR DESCRIPTION
### Description

showing the discount icon only if the node is dedicated


### Related Issues

- #2803
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
