### PR TITLE
Fix Reserve Btn Color & Text Alignment in Node Card Title & Subtitle 

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -1,6 +1,6 @@
 <template>
   <VCard
-    class="tf-node-card rounded-0 w-100 pb-3"
+    class="tf-node-card rounded-0 w-100 pb-3 text-left"
     :class="{ 'selected-node': status !== 'Init' }"
     :color="
       status === 'Valid'

--- a/packages/playground/src/dashboard/components/reserve_action_btn.vue
+++ b/packages/playground/src/dashboard/components/reserve_action_btn.vue
@@ -21,7 +21,7 @@
       v-if="node.rentedByTwinId === 0"
       :disabled="disableButton || hasInsufficientBalance"
       @click.stop="reserveNode"
-      color="anchor"
+      color="primary"
     >
       Reserve
     </v-btn>

--- a/packages/playground/src/dashboard/components/reserve_action_btn.vue
+++ b/packages/playground/src/dashboard/components/reserve_action_btn.vue
@@ -21,6 +21,7 @@
       v-if="node.rentedByTwinId === 0"
       :disabled="disableButton || hasInsufficientBalance"
       @click.stop="reserveNode"
+      color="anchor"
     >
       Reserve
     </v-btn>


### PR DESCRIPTION
### Changes

- added reserve btn color=primary 
-  added text-left to node card

### Related Issues

#2804

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist
- [x] Screenshots/Video attached (needed for UI changes)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/71971153-0a25-4752-930e-d2e16cf6bb1c)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/56790126/98d8b4d8-077a-4f0d-b8f0-8b4584ddefe3)
