### PR TITLE
Fix manage multiple vms deployment

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -273,7 +273,9 @@ export default {
         loadingGateways.value = true;
         updateGrid(grid, { projectName: props.vm.projectName });
 
-        const { gateways: gws, failedToList } = await loadDeploymentGateways(grid!);
+        const { gateways: gws, failedToList } = await loadDeploymentGateways(grid!, {
+          filter: gw => gw.backends.some(bk => bk.includes(ip)),
+        });
         gateways.value = gws;
         failedToListGws.value = failedToList;
       } catch (error) {

--- a/packages/playground/src/utils/gateway.ts
+++ b/packages/playground/src/utils/gateway.ts
@@ -75,7 +75,11 @@ export async function rollbackDeployment(grid: GridClient, name: string) {
 }
 
 export type GridGateway = Awaited<ReturnType<GridClient["gateway"]["getObj"]>>[0];
-export async function loadDeploymentGateways(grid: GridClient) {
+interface LoadDeploymentGatewaysOptions {
+  filter?: (gateway: GridGateway) => boolean;
+}
+
+export async function loadDeploymentGateways(grid: GridClient, options?: LoadDeploymentGatewaysOptions) {
   const failedToList: string[] = [];
   const gws = await grid.gateway.list();
   const items = await Promise.all(
@@ -97,5 +101,13 @@ export async function loadDeploymentGateways(grid: GridClient) {
         .finally(() => timeout && clearTimeout(timeout));
     }),
   );
-  return { gateways: items.flat().filter(Boolean) as GridGateway[], failedToList };
+
+  const filter = options?.filter ?? (() => true);
+  return {
+    gateways: items
+      .flat()
+      .filter(Boolean)
+      .filter(filter as any) as GridGateway[],
+    failedToList,
+  };
 }

--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -26,9 +26,9 @@
             @click="openDialog(tabs[activeTab].value, item)"
           />
 
-          <IconActionBtn icon="mdi-cog" tooltip="Manage Domains" @click="dialog = item.deploymentName" />
+          <IconActionBtn icon="mdi-cog" tooltip="Manage Domains" @click="dialog = item.name" />
 
-          <ManageGatewayDialog v-if="dialog === item.deploymentName" :vm="item" @close="dialog = undefined" />
+          <ManageGatewayDialog v-if="dialog === item.name" :vm="item" @close="dialog = undefined" />
         </template>
 
         <template #VM-actions="{ item }">
@@ -42,10 +42,10 @@
             icon="mdi-cog"
             tooltip="Manage Domains"
             :disabled="item.fromAnotherClient"
-            @click="dialog = item.deploymentName"
+            @click="dialog = item.name"
           />
 
-          <ManageGatewayDialog v-if="dialog === item.deploymentName" :vm="item" @close="dialog = undefined" />
+          <ManageGatewayDialog v-if="dialog === item.name" :vm="item" @close="dialog = undefined" />
         </template>
 
         <template #CapRover-actions="{ item, update }">
@@ -60,10 +60,10 @@
             icon="mdi-view-dashboard"
             :href="'http://captain.' + item.env.CAPROVER_ROOT_DOMAIN"
           />
-          <IconActionBtn icon="mdi-cog" tooltip="Manage Workers" @click="dialog = item.deploymentName" />
+          <IconActionBtn icon="mdi-cog" tooltip="Manage Workers" @click="dialog = item.name" />
 
           <ManageCaproverWorkerDialog
-            v-if="dialog === item.deploymentName"
+            v-if="dialog === item.name"
             :master="item"
             :data="item.workers || []"
             :project-name="item.projectName"
@@ -317,11 +317,11 @@
               icon="mdi-cog"
               :disabled="item.fromAnotherClient"
               tooltip="Manage Workers"
-              @click="dialog = item.deploymentName"
+              @click="dialog = item.name"
             />
 
             <ManageK8SWorkerDialog
-              v-if="dialog === item.deploymentName"
+              v-if="dialog === item.name"
               :data="item"
               @close="dialog = undefined"
               @update:k8s="item.workers = $event.workers"
@@ -349,8 +349,8 @@
         <strong>Delete the following deployments?</strong>
       </v-card-title>
       <v-card-text>
-        <v-chip class="ma-1" v-for="item in selectedItems" :key="item.deploymentName">
-          {{ item.deploymentName }}
+        <v-chip class="ma-1" v-for="item in selectedItems" :key="item.name">
+          {{ item.name }}
         </v-chip>
         <v-divider />
       </v-card-text>
@@ -421,12 +421,14 @@ async function onDelete(k8s = false) {
     for (const item of selectedItems.value) {
       try {
         await deleteDeployment(updateGrid(grid!, { projectName: item.projectName }), {
-          name: item.deploymentName,
+          deploymentName: item.deploymentName,
+          name: k8s ? item.deploymentName : item.name,
           projectName: item.projectName,
+          ip: item.interfaces?.[0]?.ip,
           k8s,
         });
       } catch (e: any) {
-        createCustomToast(`Failed to delete deployment with name: ${item.deploymentName}`, ToastType.danger);
+        createCustomToast(`Failed to delete deployment with name: ${item.name}`, ToastType.danger);
         console.log("Error while deleting deployment", e.message);
         continue;
       }


### PR DESCRIPTION
### Description
Fix manage multiple vms deployment

### Changes
- feat: Add filter to load deployment gateways method
- feat: Use load deployment gateways filter to avoid delete not related gateways
- feat: Add deploymentName option to allow deleting a single machine from deployment instead of the entire deployment
- feat: Use filter from loadDeploymentGateways in manage gateway dialog to show only machine owned gateways
- fix: Use 'item.name' instead of 'item.deployment' because deployment with multiple machines will have same deploymentName for all machines
- feat: Use ip to filter deployment gateways while deleting a deployment
- feat: Use deploymentName option to delete_machine instead of delete entire deployment

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2940

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
