### PR TITLE
fix: Removed the default ipV6 filter from the request in the node finder page.

### DIFF
--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -561,7 +561,7 @@ export default {
             numGpu: +filters.value.numGpu || undefined,
             rentable: filters.value.rentable && profileManager.profile ? filters.value.rentable : undefined,
             availableFor: filters.value.rentable && profileManager.profile ? profileManager.profile.twinId : undefined,
-            hasIPv6: filters.value.ipv6,
+            hasIPv6: filters.value.ipv6 ? filters.value.ipv6 : undefined,
           },
           { loadFarm: true },
         );


### PR DESCRIPTION
### Description

Removed the default ipV6 filter from the request in the node finder page.

### Changes

- Removed the default ipV6 filter from the request in the node finder page.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2952

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/f53708c8-9a11-47f7-9d89-19f96cea6400)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
