### PR TITLE
Ensure Gateway IP Resides in the Same Subnet as Node's IP

### DIFF
--- a/packages/playground/src/dashboard/components/public_config.vue
+++ b/packages/playground/src/dashboard/components/public_config.vue
@@ -29,7 +29,7 @@
                 :rules="[
                   () => isPrivateIP('ipv4'),
                   validators.required('IPv4 is required.'),
-                  validators.isIPRange('IP is not valid.', 4),
+                  validators.isIPRange('IPv4 is not valid.', 4),
                 ]"
                 #="{ props }"
               >
@@ -105,9 +105,6 @@
                 </input-tooltip>
               </input-validator>
             </form-validator>
-            <v-alert type="error" v-if="errorMessage">
-              {{ errorMessage }}
-            </v-alert>
           </v-card-text>
           <v-card-actions class="justify-end my-1 mr-2">
             <!-- Remove and Generate Config Buttons -->
@@ -198,7 +195,6 @@ export default {
     const isConfigChanged = ref(false);
     const formRef = useFormRef();
     const grid = useGrid();
-    const errorMessage = ref<string | undefined>(undefined);
 
     const defualtNodeConfig = ref<PublicConfig>(publicConfigInitializer());
     const config = ref<PublicConfig>(publicConfigInitializer());
@@ -242,7 +238,6 @@ export default {
 
     async function AddConfig() {
       try {
-        errorMessage.value = undefined;
         isSaving.value = true;
         await grid.client.nodes.addNodePublicConfig({
           farmId: props.farmId,
@@ -264,9 +259,10 @@ export default {
         getPublicConfig();
         showDialogue.value = false;
       } catch (error) {
-        errorMessage.value =
-          "Failed to save the node public configuration. Please ensure that the configuration data you entered is valid.";
-        createCustomToast(errorMessage.value, ToastType.danger);
+        createCustomToast(
+          "Failed to save the node public configuration. Please ensure that the configuration data you entered is valid.",
+          ToastType.danger,
+        );
         console.error(`Failed to save config due: ${error}.`, ToastType.danger);
       } finally {
         isSaving.value = false;
@@ -344,7 +340,7 @@ export default {
 
       if (!isRange) {
         return {
-          message: "Gateway IP not in the provided IP range.",
+          message: "Gateway IP is not in the provided IP range.",
         };
       }
     };
@@ -359,7 +355,6 @@ export default {
       config,
       isConfigChanged,
       formRef,
-      errorMessage,
 
       AddConfig,
       removeConfig,


### PR DESCRIPTION
### Description

The gateway must reside within the same IP range (subnet) as the node's IP address to facilitate proper routing. This ensures that the node can effectively communicate and route its traffic through the designated gateway.

### Changes

- A new validation rule has been added to ensure that the gateway IP address is within the same subnet as the node's IP address. This validation is applied based on the IP version (IPv4 or IPv6).
- A new validation rule has been added to verify whether the provided IPv4 address is public or private.
- A new validation rule has been added to verify whether the provided IPv6 address is public or private.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2637

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/44e97231-a885-4634-be37-60109b199b1d)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/7192c533-a8f5-4e23-9d06-3c5d0cb6704e)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/f3f1d2f9-6036-4d17-aba5-c93280b219ff)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/0fe086ab-485e-4031-9132-90c95bd765dc)
- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/2087d489-3228-45b2-996b-822cc44926dd)


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
