### PR TITLE
Fix: reload gateway nodes button 

### DIFF
--- a/packages/playground/src/components/node_selector/TfDomainName.vue
+++ b/packages/playground/src/components/node_selector/TfDomainName.vue
@@ -52,7 +52,7 @@
               <template #append-item v-if="pagination.page !== -1">
                 <VContainer>
                   <VBtn
-                    @click="reloadDomains()"
+                    @click="loadDomains()"
                     block
                     color="secondary"
                     variant="tonal"
@@ -149,26 +149,28 @@ export default {
       farmId: enableCustomDomain.value ? props.farm?.farmId : undefined,
       availableFor: gridStore.client.twinId,
     }));
-
-    const reloadDomains = () => domainsTask.value.run(gridStore, filters.value);
-
-    useWatchDeep(
-      filters,
-      async filters => {
-        await pageCountTask.value.run(gridStore, filters);
-        pagination.value.reset(pageCountTask.value.data as number);
-        await nextTick();
-        loadedDomains.value = [];
-        return reloadDomains();
-      },
-      {
-        immediate: true,
-        deep: true,
-        ignoreFields: ["page"],
-      },
-    );
-    const customDomain = ref("");
     const selectedDomain = ref<NodeInfo | null>(null);
+    const loadDomains = () => domainsTask.value.run(gridStore, filters.value);
+
+    const reloadDomains = async (_filters: FilterOptions = filters.value) => {
+      if (selectedDomain.value) {
+        selectedDomain.value = null;
+        bindModelValue();
+        bindStatus();
+      }
+      await pageCountTask.value.run(gridStore, _filters);
+      pagination.value.reset(pageCountTask.value.data as number);
+      await nextTick();
+      loadedDomains.value = [];
+      return loadDomains();
+    };
+
+    useWatchDeep(filters, reloadDomains, {
+      immediate: true,
+      deep: true,
+      ignoreFields: ["page"],
+    });
+    const customDomain = ref("");
 
     const domainNameValid = ref<boolean | null>(null);
     watch(domainNameValid, valid => {
@@ -235,6 +237,7 @@ export default {
       domainsTask,
       loadedDomains,
       selectedDomain,
+      loadDomains,
       reloadDomains,
 
       disableSelectedDomain,


### PR DESCRIPTION
- add reload node logic, and reset the gateway field, separate from `loadDomains` logic that actually load more domains 

### Related Issues

 - #2947

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
