### PR TITLE
hide the unlock button on node contracts that on rented nodes

### DIFF
--- a/packages/playground/src/components/contracts_list/contracts_table.vue
+++ b/packages/playground/src/components/contracts_list/contracts_table.vue
@@ -342,11 +342,11 @@ const getAmountLocked = computed(() => {
 
 const isNodeInRentContracts = computed(() => {
   if (props.contractsType == ContractType.Node && selectedItem.value) {
-    const nodeIds = props.contracts.value
-      .map(contract => contract.details.nodeId)
-      .filter(nodeId => nodeId !== undefined) as number[];
+    const nodeIds = new Set(
+      props.contracts.value.map(contract => contract.details.nodeId).filter(nodeId => nodeId !== undefined) as number[],
+    );
     if (contractLocked.value && contractLocked.value.amountLocked === 0) {
-      return nodeIds.includes(selectedItem.value.details.nodeId);
+      return nodeIds.has(selectedItem.value.details.nodeId);
     }
   }
   return false;

--- a/packages/playground/src/components/contracts_list/contracts_table.vue
+++ b/packages/playground/src/components/contracts_list/contracts_table.vue
@@ -346,7 +346,7 @@ const isNodeInRentContracts = computed(() => {
       .map(contract => contract.details.nodeId)
       .filter(nodeId => nodeId !== undefined) as number[];
     if (contractLocked.value && contractLocked.value.amountLocked === 0) {
-      return nodeIds.includes(selectedItem.value.nodeId);
+      return nodeIds.includes(selectedItem.value.details.nodeId);
     }
   }
   return false;

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -310,7 +310,7 @@ async function loadContracts(type?: ContractType) {
         loadContractsByType(ContractType.Rent, rentContracts),
       ]);
     }
-
+    await getContractsLockDetails();
     contracts.value = [...nodeContracts.value, ...nameContracts.value, ...rentContracts.value];
 
     // Update the total cost of the contracts.


### PR DESCRIPTION
### Description

after changes that have been made in https://github.com/threefoldtech/tfgrid-sdk-ts/pull/2872 we can't access the nodeid directly so the value is undefined, then the condition is always false, This makes the  button appears 

### Changes

- Fix: update accessing the nodeId as it becomes of type `NormalizedContracts`
- Make the nodeIds as Set to avoid node ids redundancy

### Related Issues
 
- #2687 
![Screenshot from 2024-06-13 12-13-40](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/442c2d82-02a3-425b-aeb0-15e94cd0bf8c)

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
