### PR TITLE
Node statistics UI

### DIFF
--- a/packages/playground/src/components/statistics_card.vue
+++ b/packages/playground/src/components/statistics_card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card color="primary" class="py-2 text-center">
+  <v-card color="primary" class="py-2 text-center flex-grow-1">
     <div class="font-weight-medium">
       <v-icon class="mr-2" size="small">{{ item.icon }} </v-icon>
       <span>

--- a/packages/playground/src/components/statistics_card.vue
+++ b/packages/playground/src/components/statistics_card.vue
@@ -1,22 +1,20 @@
 <template>
-  <div class="my-2 mx-2 text-center">
-    <v-card color="primary" class="py-2">
-      <div class="d-flex align-center justify-center items-center font-weight-medium">
-        <v-icon class="mr-2" size="small">{{ item.icon }} </v-icon>
-        <span>
-          {{ item.title }}
-        </span>
-      </div>
+  <v-card color="primary" class="py-2 text-center">
+    <div class="font-weight-medium">
+      <v-icon class="mr-2" size="small">{{ item.icon }} </v-icon>
+      <span>
+        {{ item.title }}
+      </span>
+    </div>
 
-      <v-divider class="mt-1" />
+    <v-divider class="mt-1" />
 
-      <v-card-text class="card-body"> {{ item.data }} </v-card-text>
-    </v-card>
-  </div>
+    <v-card-text class="card-body"> {{ item.data }} </v-card-text>
+  </v-card>
 </template>
 
 <script lang="ts" setup>
-import type { IStatistics as IStatistics } from "../types";
+import type { IStatistics } from "../types";
 
 defineProps<{
   item: IStatistics;

--- a/packages/playground/src/views/stats.vue
+++ b/packages/playground/src/views/stats.vue
@@ -14,8 +14,8 @@
           </v-col>
         </v-row>
       </div>
-      <v-card class="pa-5">
-        <v-row>
+      <v-card class="d-flex">
+        <v-row align="center" class="pa-5">
           <v-col color="red" v-if="failed">
             <v-alert type="error" variant="tonal">
               Failed to get stats data after 3 attempts, Feel free to contact the support team or try again later.
@@ -24,14 +24,15 @@
               </v-btn>
             </v-alert>
           </v-col>
-          <v-col xl="6" lg="6" md="12" cols="12" class="mx-auto mt-15 pr-2">
+          <v-col cols="12" sm="6">
             <tf-map r="125" g="227" b="200" :nodes="nodesDistribution" />
           </v-col>
-          <v-divider class="main_divider mx-1 my-4" vertical></v-divider>
-          <v-col v-if="Istats.length !== 0" class="d-flex flex-wrap justify-start">
-            <v-col v-for="item of Istats" :key="item.title" xl="4" lg="6" md="6" cols="12" class="px-0 py-0">
-              <StatisticsCard :item="item" />
-            </v-col>
+          <v-col v-if="Istats.length !== 0">
+            <v-row>
+              <v-col v-for="item of Istats" :key="item.title" cols="12" sm="6">
+                <StatisticsCard :item="item" />
+              </v-col>
+            </v-row>
           </v-col>
         </v-row>
       </v-card>

--- a/packages/playground/src/views/stats.vue
+++ b/packages/playground/src/views/stats.vue
@@ -24,12 +24,18 @@
               </v-btn>
             </v-alert>
           </v-col>
-          <v-col cols="12" sm="6">
+          <v-col cols="12" md="8">
             <tf-map r="125" g="227" b="200" :nodes="nodesDistribution" />
           </v-col>
-          <v-col v-if="Istats.length !== 0">
+          <v-col v-if="Istats.length !== 0" cols="12" md="4">
             <v-row>
-              <v-col v-for="item of Istats" :key="item.title" cols="12" sm="6">
+              <v-col
+                v-for="(item, index) of Istats"
+                :key="item.title"
+                :cols="index === Istats.length - 1 ? 12 : 6"
+                :md="index === Istats.length - 1 ? 12 : 6"
+                class="d-flex flex-grow-1"
+              >
                 <StatisticsCard :item="item" />
               </v-col>
             </v-row>


### PR DESCRIPTION
### Description

- Center all items vertically
- Remove vertical divider
- Let the last card take the full-width 
- Make all cards height equal on small screens 
- Adjust the statistics page grid

### Changes

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/11662805/2c4d3c43-9f3d-4462-9015-3f91ea8b8fdf)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2897
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
