### PR TITLE
Adding email validation to admin email field in discourse 

### DIFF
--- a/packages/playground/src/components/smtp_server.vue
+++ b/packages/playground/src/components/smtp_server.vue
@@ -21,6 +21,7 @@
         :value="$props.modelValue.username"
         :rules="[
           validators.required('Email is required.'),
+          validators.isEmail('Please provide a valid email address.'),
           v => {
             return isDiscourse ? undefined : validators.isEmail('Please provide a valid email address.')(v);
           },


### PR DESCRIPTION
### Description

Adding email validation to admin email field in discourse 

### Related Issues

- #2838
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
