### PR TITLE
Add auto generated tfchain types to tfchain_client

### DIFF
--- a/packages/tfchain_client/docs/generateTypes.md
+++ b/packages/tfchain_client/docs/generateTypes.md
@@ -7,7 +7,7 @@ This guide covers the steps to generate chain types using `@polkadot/typegen` an
 Inside tfchain_client directory run:
 
 ```bash
-yarn yarn generate-types -e <<CHAIN_URL>>
+yarn generate-types -e <<CHAIN_URL>>
 ```
 
 > replace `<<CHAIN_URL>>` with URL of the desired chain stack, e.g. `https://tfchain.dev.grid.tf/`

--- a/packages/tfchain_client/docs/generateTypes.md
+++ b/packages/tfchain_client/docs/generateTypes.md
@@ -1,0 +1,86 @@
+# Generating Chain Types
+
+This guide covers the steps to generate chain types using `@polkadot/typegen` and how to use these generated types in this project.
+
+## Process:
+
+Inside tfchain_client directory run:
+
+```bash
+yarn yarn generate-types -e <<CHAIN_URL>>
+```
+
+> replace `<<CHAIN_URL>>` with URL of the desired chain stack, e.g. `https://tfchain.dev.grid.tf/`
+> This will update the metadata file `chainMeta.json`, generate types inside `interfaces/chain` and adjust the created types to be compatible with TypeScript compiler.
+
+## Details:
+
+- Generate a chain types requires `@polkadot/typegen` package of the same version as `@polkadot/api`.
+
+### Generating
+
+First we need to have chain metadata, to generate types based on it, this is done by running the following command:
+
+```bash
+curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "state_getMetadata", "params":[]}' -o chainMeta.json <<CHAIN_URL>>
+```
+
+The result of this command will be `chainMeta.json` with a content like
+
+```json
+{ "jsonrpc": "2.0", "result": "0x6d6574610b6c185379737....", "id": 29 }
+```
+
+This file will be used in the following two commands:
+
+- Generate defined chain types and lookup files using `polkadot-types-from-defs `
+  ```bash
+  ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package @threefold/tfchain_client  --input ./src/interfaces/chain --endpoint ./chainMeta.json
+  ```
+  > Currently we don't have defined types but this command needed to crate the lookup files, for more details see the [documentation](https://polkadot.js.org/docs/api/start/typescript.user/#definitions)
+- Generate types from the chain using `polkadot-types-from-chain`
+  ```bash
+   ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --endpoint ./chainMeta.json --output ./src/interfaces/chain
+  ```
+
+Now types are generated, but we need to let the compiler aware of the generated types, we can do that by add the following paths to `tsconfig-*.json` inside compilerOptions.paths add those lines:
+
+```json
+ "@polkadot/types/lookup": ["src/interfaces/chain/types-lookup.ts"],
+ "@polkadot/api-augment*": ["src/interfaces/chain/augment-api.ts"]
+```
+
+Finally we need to export the generated types
+in `src/interfaces/index.ts`
+
+```ts
+export * from "./chain/augment-api";
+export * from "./chain/types-lookup";
+export * from "./chain/lookup";
+```
+
+### Usage
+
+We need to import the augmented definitions "somewhere" as documentation says, in our case we will import them in `src/client`.
+
+```ts
+import "./interfaces";
+import "@polkadot/api-augment";
+```
+
+Now we can import any type anywhere in the client as follows:
+
+```ts
+// e.g SpRuntimeModuleError
+import { SpRuntimeModuleError } from "@polkadot/types/lookup";
+```
+
+There are two blockers now from building the project:
+
+1. As we din't have any defined types `src/interfaces/chain/types` is empty and will gives an error while build, for now we just need to export an empty object on it so we add `export {}` to the file.
+2. Types with reserved names:
+   In `src/interfaces/chain/augment-api-tx.ts` we have `createFarmingPolicy` and `updateFarmingPolicy` functions in tfgridmodule each of them contains parameter named `default` this is not acceptable on Typescript as it is a reserved word, so we could replace it with `_default`.
+
+> All the previous steps are collected into `scripts/generateTypes.bash`
+
+Now everything is ready to go

--- a/packages/tfchain_client/docs/generateTypes.md
+++ b/packages/tfchain_client/docs/generateTypes.md
@@ -77,7 +77,7 @@ import { SpRuntimeModuleError } from "@polkadot/types/lookup";
 
 There are two blockers now from building the project:
 
-1. As we din't have any defined types `src/interfaces/chain/types` is empty and will gives an error while build, for now we just need to export an empty object on it so we add `export {}` to the file.
+1. As we don't have any defined types `src/interfaces/chain/types` is empty and will give an error while build, for now we just need to export an empty object on it so we add `export {}` to the file.
 2. Types with reserved names:
    In `src/interfaces/chain/augment-api-tx.ts` we have `createFarmingPolicy` and `updateFarmingPolicy` functions in tfgridmodule each of them contains parameter named `default` this is not acceptable on Typescript as it is a reserved word, so we could replace it with `_default`.
 

--- a/packages/tfchain_client/package.json
+++ b/packages/tfchain_client/package.json
@@ -12,7 +12,8 @@
     "node-build": "tsc --build tsconfig-node.json",
     "es6-build": "tsc --build tsconfig-es6.json",
     "generate-docs": "typedoc --tsconfig tsconfig-es6.json src/index.ts --out docs/api",
-    "serve-docs": "http-server docs/api"
+    "serve-docs": "http-server docs/api",
+    "generate-types" : "bash ./scripts/generateTypes.bash"
   },
   "repository": {
     "type": "git",
@@ -42,7 +43,8 @@
     "npm-run-all": "^4.1.5",
     "ts-node": "^10.9.1",
     "typedoc": "^0.23.28",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "@polkadot/typegen": "^8.9.1"
   },
   "dependencies": {
     "@polkadot/api": "^8.9.1",

--- a/packages/tfchain_client/scripts/generateTypes.bash
+++ b/packages/tfchain_client/scripts/generateTypes.bash
@@ -1,0 +1,49 @@
+set -e 
+while getopts e: flag
+do
+    case "${flag}" in
+        e) endpoint=${OPTARG};;
+    esac
+done
+
+if [ -n "$endpoint" ]; then 
+    echo "Generating meta data from $endpoint";
+else
+    echo "endpoint url is required, please use -e flag";
+    exit 1
+fi
+
+
+outputFile="chainMeta.json"
+echo "meta destination file: '$outputFile'"
+
+generateDefs="ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package @threefold/tfchain_client  --input ./src/interfaces/chain --endpoint ./chainMeta.json"
+generateMeta="ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --endpoint ./chainMeta.json --output ./src/interfaces/chain"
+
+err=$(curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "state_getMetadata", "params":[]}' -o $outputFile $endpoint 2>&1)
+
+if [[ $? -ne 0 ]]; then
+   echo "Failed to fetch chain metadata due to error: '$err'"
+fi
+
+echo "updating node modules.."
+yarn
+
+echo "Generating chain types.."
+${generateDefs} && ${generateMeta}
+
+
+echo "Adjusting files..."
+
+if [ -f "./src/interfaces/chain/types.ts" ] && ! grep -q export "./src/interfaces/chain/types.ts"; then
+    echo "export {}" >> ./src/interfaces/chain/types.ts
+fi
+
+stringToReplace="default: bool | boolean | Uint8Array,"
+stringToBeReplaced="_default: bool | boolean | Uint8Array,"
+if [ -f "./src/interfaces/chain/augment-api-tx.ts" ]; then
+    sed -i "s#$stringToReplace#$stringToBeReplaced#g" src/interfaces/chain/augment-api-tx.ts
+fi
+
+echo "Success!"
+exit 0

--- a/packages/tfchain_client/src/client.ts
+++ b/packages/tfchain_client/src/client.ts
@@ -1,3 +1,6 @@
+import "./interfaces";
+import "@polkadot/api-augment";
+
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import { Signer } from "@polkadot/api/types";
 import { SubmittableExtrinsic } from "@polkadot/api-base/types";

--- a/packages/tfchain_client/src/interfaces/chain/augment-api-consts.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api-consts.ts
@@ -1,0 +1,212 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/api-base/types/consts";
+
+import type { ApiTypes, AugmentedConst } from "@polkadot/api-base/types";
+import type { u128, u16, u32, u64, u8 } from "@polkadot/types-codec";
+import type { Codec } from "@polkadot/types-codec/types";
+import type {
+  FrameSystemLimitsBlockLength,
+  FrameSystemLimitsBlockWeights,
+  SpVersionRuntimeVersion,
+  SpWeightsRuntimeDbWeight,
+  SpWeightsWeightV2Weight,
+} from "@polkadot/types/lookup";
+
+export type __AugmentedConst<ApiType extends ApiTypes> = AugmentedConst<ApiType>;
+
+declare module "@polkadot/api-base/types/consts" {
+  interface AugmentedConsts<ApiType extends ApiTypes> {
+    balances: {
+      /**
+       * The minimum amount required to keep an account open. MUST BE GREATER THAN ZERO!
+       *
+       * If you *really* need it to be zero, you can enable the feature `insecure_zero_ed` for
+       * this pallet. However, you do so at your own risk: this will open up a major DoS vector.
+       * In case you have multiple sources of provider references, you may also get unexpected
+       * behaviour if you set this to zero.
+       *
+       * Bottom line: Do yourself a favour and make it at least one!
+       **/
+      existentialDeposit: u128 & AugmentedConst<ApiType>;
+      /**
+       * The maximum number of individual freeze locks that can exist on an account at any time.
+       **/
+      maxFreezes: u32 & AugmentedConst<ApiType>;
+      /**
+       * The maximum number of holds that can exist on an account at any time.
+       **/
+      maxHolds: u32 & AugmentedConst<ApiType>;
+      /**
+       * The maximum number of locks that should exist on an account.
+       * Not strictly enforced, but used for weight estimation.
+       **/
+      maxLocks: u32 & AugmentedConst<ApiType>;
+      /**
+       * The maximum number of named reserves that can exist on an account.
+       **/
+      maxReserves: u32 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    council: {
+      /**
+       * The maximum weight of a dispatch call that can be proposed and executed.
+       **/
+      maxProposalWeight: SpWeightsWeightV2Weight & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    grandpa: {
+      /**
+       * Max Authorities in use
+       **/
+      maxAuthorities: u32 & AugmentedConst<ApiType>;
+      /**
+       * The maximum number of entries to keep in the set id to session index mapping.
+       *
+       * Since the `SetIdSession` map is only used for validating equivocations this
+       * value should relate to the bonding duration of whatever staking system is
+       * being used (if any). If equivocation handling is not enabled then this value
+       * can be zero.
+       **/
+      maxSetIdSessionEntries: u64 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    scheduler: {
+      /**
+       * The maximum weight that may be scheduled per block for any dispatchables.
+       **/
+      maximumWeight: SpWeightsWeightV2Weight & AugmentedConst<ApiType>;
+      /**
+       * The maximum number of scheduled calls in the queue for a single block.
+       *
+       * NOTE:
+       * + Dependent pallets' benchmarks might require a higher limit for the setting. Set a
+       * higher limit under `runtime-benchmarks` feature.
+       **/
+      maxScheduledPerBlock: u32 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    smartContractModule: {
+      maxDeploymentDataLength: u32 & AugmentedConst<ApiType>;
+      maxNameContractNameLength: u32 & AugmentedConst<ApiType>;
+      maxNodeContractPublicIps: u32 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    system: {
+      /**
+       * Maximum number of block number to block hash mappings to keep (oldest pruned first).
+       **/
+      blockHashCount: u32 & AugmentedConst<ApiType>;
+      /**
+       * The maximum length of a block (in bytes).
+       **/
+      blockLength: FrameSystemLimitsBlockLength & AugmentedConst<ApiType>;
+      /**
+       * Block & extrinsics weights: base values and limits.
+       **/
+      blockWeights: FrameSystemLimitsBlockWeights & AugmentedConst<ApiType>;
+      /**
+       * The weight of runtime database operations the runtime can invoke.
+       **/
+      dbWeight: SpWeightsRuntimeDbWeight & AugmentedConst<ApiType>;
+      /**
+       * The designated SS58 prefix of this chain.
+       *
+       * This replaces the "ss58Format" property declared in the chain spec. Reason is
+       * that the runtime should know about the prefix in order to make use of it as
+       * an identifier of the chain.
+       **/
+      ss58Prefix: u16 & AugmentedConst<ApiType>;
+      /**
+       * Get the chain's current version.
+       **/
+      version: SpVersionRuntimeVersion & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    tfgridModule: {
+      maxFarmNameLength: u32 & AugmentedConst<ApiType>;
+      maxFarmPublicIps: u32 & AugmentedConst<ApiType>;
+      maxInterfaceIpsLength: u32 & AugmentedConst<ApiType>;
+      maxInterfacesLength: u32 & AugmentedConst<ApiType>;
+      timestampHintDrift: u64 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    timestamp: {
+      /**
+       * The minimum period between blocks. Beware that this is different to the *expected*
+       * period that the block production apparatus provides. Your chosen consensus system will
+       * generally work with this to determine a sensible block time. e.g. For Aura, it will be
+       * double this period on default settings.
+       **/
+      minimumPeriod: u64 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    transactionPayment: {
+      /**
+       * A fee mulitplier for `Operational` extrinsics to compute "virtual tip" to boost their
+       * `priority`
+       *
+       * This value is multipled by the `final_fee` to obtain a "virtual tip" that is later
+       * added to a tip component in regular `priority` calculations.
+       * It means that a `Normal` transaction can front-run a similarly-sized `Operational`
+       * extrinsic (with no tip), by including a tip value greater than the virtual tip.
+       *
+       * ```rust,ignore
+       * // For `Normal`
+       * let priority = priority_calc(tip);
+       *
+       * // For `Operational`
+       * let virtual_tip = (inclusion_fee + tip) * OperationalFeeMultiplier;
+       * let priority = priority_calc(tip + virtual_tip);
+       * ```
+       *
+       * Note that since we use `final_fee` the multiplier applies also to the regular `tip`
+       * sent with the transaction. So, not only does the transaction get a priority bump based
+       * on the `inclusion_fee`, but we also amplify the impact of tips applied to `Operational`
+       * transactions.
+       **/
+      operationalFeeMultiplier: u8 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    utility: {
+      /**
+       * The limit on the number of batched calls.
+       **/
+      batchedCallsLimit: u32 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+  } // AugmentedConsts
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/augment-api-errors.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api-errors.ts
@@ -1,0 +1,561 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/api-base/types/errors";
+
+import type { ApiTypes, AugmentedError } from "@polkadot/api-base/types";
+
+export type __AugmentedError<ApiType extends ApiTypes> = AugmentedError<ApiType>;
+
+declare module "@polkadot/api-base/types/errors" {
+  interface AugmentedErrors<ApiType extends ApiTypes> {
+    balances: {
+      /**
+       * Beneficiary account must pre-exist.
+       **/
+      DeadAccount: AugmentedError<ApiType>;
+      /**
+       * Value too low to create account due to existential deposit.
+       **/
+      ExistentialDeposit: AugmentedError<ApiType>;
+      /**
+       * A vesting schedule already exists for this account.
+       **/
+      ExistingVestingSchedule: AugmentedError<ApiType>;
+      /**
+       * Transfer/payment would kill account.
+       **/
+      Expendability: AugmentedError<ApiType>;
+      /**
+       * Balance too low to send value.
+       **/
+      InsufficientBalance: AugmentedError<ApiType>;
+      /**
+       * Account liquidity restrictions prevent withdrawal.
+       **/
+      LiquidityRestrictions: AugmentedError<ApiType>;
+      /**
+       * Number of freezes exceed `MaxFreezes`.
+       **/
+      TooManyFreezes: AugmentedError<ApiType>;
+      /**
+       * Number of holds exceed `MaxHolds`.
+       **/
+      TooManyHolds: AugmentedError<ApiType>;
+      /**
+       * Number of named reserves exceed `MaxReserves`.
+       **/
+      TooManyReserves: AugmentedError<ApiType>;
+      /**
+       * Vesting balance too high to send value.
+       **/
+      VestingBalance: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    burningModule: {
+      NotEnoughBalanceToBurn: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    council: {
+      /**
+       * Members are already initialized!
+       **/
+      AlreadyInitialized: AugmentedError<ApiType>;
+      /**
+       * Duplicate proposals not allowed
+       **/
+      DuplicateProposal: AugmentedError<ApiType>;
+      /**
+       * Duplicate vote ignored
+       **/
+      DuplicateVote: AugmentedError<ApiType>;
+      /**
+       * Account is not a member
+       **/
+      NotMember: AugmentedError<ApiType>;
+      /**
+       * Proposal must exist
+       **/
+      ProposalMissing: AugmentedError<ApiType>;
+      /**
+       * The close call was made too early, before the end of the voting.
+       **/
+      TooEarly: AugmentedError<ApiType>;
+      /**
+       * There can only be a maximum of `MaxProposals` active proposals.
+       **/
+      TooManyProposals: AugmentedError<ApiType>;
+      /**
+       * Mismatched index
+       **/
+      WrongIndex: AugmentedError<ApiType>;
+      /**
+       * The given length bound for the proposal was too low.
+       **/
+      WrongProposalLength: AugmentedError<ApiType>;
+      /**
+       * The given weight bound for the proposal was too low.
+       **/
+      WrongProposalWeight: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    councilMembership: {
+      /**
+       * Already a member.
+       **/
+      AlreadyMember: AugmentedError<ApiType>;
+      /**
+       * Not a member.
+       **/
+      NotMember: AugmentedError<ApiType>;
+      /**
+       * Too many members.
+       **/
+      TooManyMembers: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    dao: {
+      DuplicateProposal: AugmentedError<ApiType>;
+      DuplicateVeto: AugmentedError<ApiType>;
+      DuplicateVote: AugmentedError<ApiType>;
+      FarmHasNoNodes: AugmentedError<ApiType>;
+      FarmNotExists: AugmentedError<ApiType>;
+      InvalidProposalDuration: AugmentedError<ApiType>;
+      NoneValue: AugmentedError<ApiType>;
+      NotAuthorizedToVote: AugmentedError<ApiType>;
+      NotCouncilMember: AugmentedError<ApiType>;
+      OngoingVoteAndTresholdStillNotMet: AugmentedError<ApiType>;
+      ProposalMissing: AugmentedError<ApiType>;
+      StorageOverflow: AugmentedError<ApiType>;
+      ThresholdTooLow: AugmentedError<ApiType>;
+      TimeLimitReached: AugmentedError<ApiType>;
+      TooEarly: AugmentedError<ApiType>;
+      WrongIndex: AugmentedError<ApiType>;
+      WrongProposalLength: AugmentedError<ApiType>;
+      WrongProposalWeight: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    grandpa: {
+      /**
+       * Attempt to signal GRANDPA change with one already pending.
+       **/
+      ChangePending: AugmentedError<ApiType>;
+      /**
+       * A given equivocation report is valid but already previously reported.
+       **/
+      DuplicateOffenceReport: AugmentedError<ApiType>;
+      /**
+       * An equivocation proof provided as part of an equivocation report is invalid.
+       **/
+      InvalidEquivocationProof: AugmentedError<ApiType>;
+      /**
+       * A key ownership proof provided as part of an equivocation report is invalid.
+       **/
+      InvalidKeyOwnershipProof: AugmentedError<ApiType>;
+      /**
+       * Attempt to signal GRANDPA pause when the authority set isn't live
+       * (either paused or already pending pause).
+       **/
+      PauseFailed: AugmentedError<ApiType>;
+      /**
+       * Attempt to signal GRANDPA resume when the authority set isn't paused
+       * (either live or already pending resume).
+       **/
+      ResumeFailed: AugmentedError<ApiType>;
+      /**
+       * Cannot signal forced change so soon after last.
+       **/
+      TooSoon: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    scheduler: {
+      /**
+       * Failed to schedule a call
+       **/
+      FailedToSchedule: AugmentedError<ApiType>;
+      /**
+       * Attempt to use a non-named function on a named task.
+       **/
+      Named: AugmentedError<ApiType>;
+      /**
+       * Cannot find the scheduled call.
+       **/
+      NotFound: AugmentedError<ApiType>;
+      /**
+       * Reschedule failed because it does not change scheduled time.
+       **/
+      RescheduleNoChange: AugmentedError<ApiType>;
+      /**
+       * Given target block number is in the past.
+       **/
+      TargetBlockNumberInPast: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    session: {
+      /**
+       * Registered duplicate key.
+       **/
+      DuplicatedKey: AugmentedError<ApiType>;
+      /**
+       * Invalid ownership proof.
+       **/
+      InvalidProof: AugmentedError<ApiType>;
+      /**
+       * Key setting account is not live, so it's impossible to associate keys.
+       **/
+      NoAccount: AugmentedError<ApiType>;
+      /**
+       * No associated validator ID for account.
+       **/
+      NoAssociatedValidatorId: AugmentedError<ApiType>;
+      /**
+       * No keys are associated with this account.
+       **/
+      NoKeys: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    smartContractModule: {
+      CannotUpdateContractInGraceState: AugmentedError<ApiType>;
+      CanOnlyIncreaseFrequency: AugmentedError<ApiType>;
+      ContractIsNotUnique: AugmentedError<ApiType>;
+      ContractNotExists: AugmentedError<ApiType>;
+      ContractWrongBillingLoopIndex: AugmentedError<ApiType>;
+      FailedToFreeIPs: AugmentedError<ApiType>;
+      FailedToReserveIP: AugmentedError<ApiType>;
+      FarmHasNotEnoughPublicIPs: AugmentedError<ApiType>;
+      FarmHasNotEnoughPublicIPsFree: AugmentedError<ApiType>;
+      FarmIsNotDedicated: AugmentedError<ApiType>;
+      FarmNotExists: AugmentedError<ApiType>;
+      InvalidContractType: AugmentedError<ApiType>;
+      InvalidProviderConfiguration: AugmentedError<ApiType>;
+      IsNotAnAuthority: AugmentedError<ApiType>;
+      MethodIsDeprecated: AugmentedError<ApiType>;
+      NameContractNameTooLong: AugmentedError<ApiType>;
+      NameContractNameTooShort: AugmentedError<ApiType>;
+      NameExists: AugmentedError<ApiType>;
+      NameNotValid: AugmentedError<ApiType>;
+      NodeHasActiveContracts: AugmentedError<ApiType>;
+      NodeHasRentContract: AugmentedError<ApiType>;
+      NodeNotAuthorizedToComputeReport: AugmentedError<ApiType>;
+      NodeNotAuthorizedToDeployContract: AugmentedError<ApiType>;
+      NodeNotAuthorizedToReportResources: AugmentedError<ApiType>;
+      NodeNotAvailableToDeploy: AugmentedError<ApiType>;
+      NodeNotExists: AugmentedError<ApiType>;
+      NoSuchSolutionProvider: AugmentedError<ApiType>;
+      NotEnoughResourcesOnNode: AugmentedError<ApiType>;
+      NumOverflow: AugmentedError<ApiType>;
+      OffchainSignedTxAlreadySent: AugmentedError<ApiType>;
+      OffchainSignedTxCannotSign: AugmentedError<ApiType>;
+      OffchainSignedTxNoLocalAccountAvailable: AugmentedError<ApiType>;
+      PricingPolicyNotExists: AugmentedError<ApiType>;
+      ServiceContractApprovalNotAllowed: AugmentedError<ApiType>;
+      ServiceContractBillingNotApprovedByBoth: AugmentedError<ApiType>;
+      ServiceContractBillingVariableAmountTooHigh: AugmentedError<ApiType>;
+      ServiceContractBillMetadataTooLong: AugmentedError<ApiType>;
+      ServiceContractCreationNotAllowed: AugmentedError<ApiType>;
+      ServiceContractMetadataTooLong: AugmentedError<ApiType>;
+      ServiceContractModificationNotAllowed: AugmentedError<ApiType>;
+      ServiceContractNotEnoughFundsToPayBill: AugmentedError<ApiType>;
+      ServiceContractNotExists: AugmentedError<ApiType>;
+      ServiceContractRejectionNotAllowed: AugmentedError<ApiType>;
+      SolutionProviderNotApproved: AugmentedError<ApiType>;
+      TFTPriceValueError: AugmentedError<ApiType>;
+      TwinNotAuthorized: AugmentedError<ApiType>;
+      TwinNotAuthorizedToCancelContract: AugmentedError<ApiType>;
+      TwinNotAuthorizedToUpdateContract: AugmentedError<ApiType>;
+      TwinNotExists: AugmentedError<ApiType>;
+      UnauthorizedToChangeSolutionProviderId: AugmentedError<ApiType>;
+      UnauthorizedToSetExtraFee: AugmentedError<ApiType>;
+      WrongAuthority: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    system: {
+      /**
+       * The origin filter prevent the call to be dispatched.
+       **/
+      CallFiltered: AugmentedError<ApiType>;
+      /**
+       * Failed to extract the runtime version from the new runtime.
+       *
+       * Either calling `Core_version` or decoding `RuntimeVersion` failed.
+       **/
+      FailedToExtractRuntimeVersion: AugmentedError<ApiType>;
+      /**
+       * The name of specification does not match between the current runtime
+       * and the new runtime.
+       **/
+      InvalidSpecName: AugmentedError<ApiType>;
+      /**
+       * Suicide called when the account has non-default composite data.
+       **/
+      NonDefaultComposite: AugmentedError<ApiType>;
+      /**
+       * There is a non-zero reference count preventing the account from being purged.
+       **/
+      NonZeroRefCount: AugmentedError<ApiType>;
+      /**
+       * The specification version is not allowed to decrease between the current runtime
+       * and the new runtime.
+       **/
+      SpecVersionNeedsToIncrease: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    tfgridModule: {
+      AlreadyCertifier: AugmentedError<ApiType>;
+      CannotCreateFarmWrongTwin: AugmentedError<ApiType>;
+      CannotCreateNode: AugmentedError<ApiType>;
+      CannotCreateTwin: AugmentedError<ApiType>;
+      CannotDeleteEntity: AugmentedError<ApiType>;
+      CannotDeleteFarm: AugmentedError<ApiType>;
+      CannotDeleteFarmWithNodesAssigned: AugmentedError<ApiType>;
+      CannotDeleteFarmWithPublicIPs: AugmentedError<ApiType>;
+      CannotDeleteFarmWrongTwin: AugmentedError<ApiType>;
+      CannotDeleteNode: AugmentedError<ApiType>;
+      CannotUpdateEntity: AugmentedError<ApiType>;
+      CannotUpdateFarmWrongTwin: AugmentedError<ApiType>;
+      CertificationCodeExists: AugmentedError<ApiType>;
+      CityNameTooLong: AugmentedError<ApiType>;
+      CityNameTooShort: AugmentedError<ApiType>;
+      CountryNameTooLong: AugmentedError<ApiType>;
+      CountryNameTooShort: AugmentedError<ApiType>;
+      DocumentHashInputTooLong: AugmentedError<ApiType>;
+      DocumentHashInputTooShort: AugmentedError<ApiType>;
+      DocumentLinkInputTooLong: AugmentedError<ApiType>;
+      DocumentLinkInputTooShort: AugmentedError<ApiType>;
+      DomainTooLong: AugmentedError<ApiType>;
+      DomainTooShort: AugmentedError<ApiType>;
+      EntityNotExists: AugmentedError<ApiType>;
+      EntitySignatureDoesNotMatch: AugmentedError<ApiType>;
+      EntityWithNameExists: AugmentedError<ApiType>;
+      EntityWithPubkeyExists: AugmentedError<ApiType>;
+      EntityWithSignatureAlreadyExists: AugmentedError<ApiType>;
+      FarmerDidNotSignTermsAndConditions: AugmentedError<ApiType>;
+      FarmerDoesNotHaveEnoughFunds: AugmentedError<ApiType>;
+      FarmerNotAuthorized: AugmentedError<ApiType>;
+      FarmExists: AugmentedError<ApiType>;
+      FarmingPolicyAlreadyExists: AugmentedError<ApiType>;
+      FarmingPolicyExpired: AugmentedError<ApiType>;
+      FarmingPolicyNotExists: AugmentedError<ApiType>;
+      FarmNameTooLong: AugmentedError<ApiType>;
+      FarmNameTooShort: AugmentedError<ApiType>;
+      FarmNotExists: AugmentedError<ApiType>;
+      FarmPayoutAdressAlreadyRegistered: AugmentedError<ApiType>;
+      GatewayIPTooLong: AugmentedError<ApiType>;
+      GatewayIPTooShort: AugmentedError<ApiType>;
+      GW4TooLong: AugmentedError<ApiType>;
+      GW4TooShort: AugmentedError<ApiType>;
+      GW6TooLong: AugmentedError<ApiType>;
+      GW6TooShort: AugmentedError<ApiType>;
+      InterfaceIpTooLong: AugmentedError<ApiType>;
+      InterfaceIpTooShort: AugmentedError<ApiType>;
+      InterfaceMacTooLong: AugmentedError<ApiType>;
+      InterfaceMacTooShort: AugmentedError<ApiType>;
+      InterfaceNameTooLong: AugmentedError<ApiType>;
+      InterfaceNameTooShort: AugmentedError<ApiType>;
+      InvalidCityName: AugmentedError<ApiType>;
+      InvalidCountryCityPair: AugmentedError<ApiType>;
+      InvalidCountryName: AugmentedError<ApiType>;
+      InvalidCRUInput: AugmentedError<ApiType>;
+      InvalidDocumentHashInput: AugmentedError<ApiType>;
+      InvalidDocumentLinkInput: AugmentedError<ApiType>;
+      InvalidDomain: AugmentedError<ApiType>;
+      InvalidFarmName: AugmentedError<ApiType>;
+      InvalidGW4: AugmentedError<ApiType>;
+      InvalidGW6: AugmentedError<ApiType>;
+      InvalidHRUInput: AugmentedError<ApiType>;
+      InvalidInterfaceIP: AugmentedError<ApiType>;
+      InvalidInterfaceName: AugmentedError<ApiType>;
+      InvalidIP4: AugmentedError<ApiType>;
+      InvalidIP6: AugmentedError<ApiType>;
+      InvalidLatitudeInput: AugmentedError<ApiType>;
+      InvalidLongitudeInput: AugmentedError<ApiType>;
+      InvalidMacAddress: AugmentedError<ApiType>;
+      InvalidMRUInput: AugmentedError<ApiType>;
+      InvalidPublicConfig: AugmentedError<ApiType>;
+      InvalidPublicIP: AugmentedError<ApiType>;
+      InvalidRelay: AugmentedError<ApiType>;
+      InvalidRelayAddress: AugmentedError<ApiType>;
+      InvalidSerialNumber: AugmentedError<ApiType>;
+      InvalidSRUInput: AugmentedError<ApiType>;
+      InvalidStorageInput: AugmentedError<ApiType>;
+      InvalidTimestampHint: AugmentedError<ApiType>;
+      InvalidZosVersion: AugmentedError<ApiType>;
+      IP4TooLong: AugmentedError<ApiType>;
+      IP4TooShort: AugmentedError<ApiType>;
+      IP6TooLong: AugmentedError<ApiType>;
+      IP6TooShort: AugmentedError<ApiType>;
+      IpExists: AugmentedError<ApiType>;
+      IpNotExists: AugmentedError<ApiType>;
+      LatitudeInputTooLong: AugmentedError<ApiType>;
+      LatitudeInputTooShort: AugmentedError<ApiType>;
+      LongitudeInputTooLong: AugmentedError<ApiType>;
+      LongitudeInputTooShort: AugmentedError<ApiType>;
+      MethodIsDeprecated: AugmentedError<ApiType>;
+      NodeDeleteNotAuthorized: AugmentedError<ApiType>;
+      NodeHasActiveContracts: AugmentedError<ApiType>;
+      NodeNotExists: AugmentedError<ApiType>;
+      NodeUpdateNotAuthorized: AugmentedError<ApiType>;
+      NodeWithTwinIdExists: AugmentedError<ApiType>;
+      NoneValue: AugmentedError<ApiType>;
+      NotAllowedToCertifyNode: AugmentedError<ApiType>;
+      NotCertifier: AugmentedError<ApiType>;
+      PricingPolicyExists: AugmentedError<ApiType>;
+      PricingPolicyNotExists: AugmentedError<ApiType>;
+      PricingPolicyWithDifferentIdExists: AugmentedError<ApiType>;
+      PublicIPTooLong: AugmentedError<ApiType>;
+      PublicIPTooShort: AugmentedError<ApiType>;
+      RelayTooLong: AugmentedError<ApiType>;
+      RelayTooShort: AugmentedError<ApiType>;
+      SerialNumberTooLong: AugmentedError<ApiType>;
+      SerialNumberTooShort: AugmentedError<ApiType>;
+      SignatureLengthIsIncorrect: AugmentedError<ApiType>;
+      StorageOverflow: AugmentedError<ApiType>;
+      TwinCannotBoundToItself: AugmentedError<ApiType>;
+      TwinExists: AugmentedError<ApiType>;
+      TwinNotExists: AugmentedError<ApiType>;
+      TwinWithPubkeyExists: AugmentedError<ApiType>;
+      UnauthorizedToChangePowerTarget: AugmentedError<ApiType>;
+      UnauthorizedToUpdateTwin: AugmentedError<ApiType>;
+      UserDidNotSignTermsAndConditions: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    tfkvStore: {
+      KeyIsTooLarge: AugmentedError<ApiType>;
+      /**
+       * The requested user has not stored a value yet
+       **/
+      NoValueStored: AugmentedError<ApiType>;
+      ValueIsTooLarge: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    tftBridgeModule: {
+      AmountIsLessThanDepositFee: AugmentedError<ApiType>;
+      AmountIsLessThanWithdrawFee: AugmentedError<ApiType>;
+      BurnSignatureExists: AugmentedError<ApiType>;
+      BurnTransactionAlreadyExecuted: AugmentedError<ApiType>;
+      BurnTransactionExists: AugmentedError<ApiType>;
+      BurnTransactionNotExists: AugmentedError<ApiType>;
+      EnoughBurnSignaturesPresent: AugmentedError<ApiType>;
+      EnoughRefundSignaturesPresent: AugmentedError<ApiType>;
+      InvalidStellarPublicKey: AugmentedError<ApiType>;
+      MintTransactionAlreadyExecuted: AugmentedError<ApiType>;
+      MintTransactionExists: AugmentedError<ApiType>;
+      MintTransactionNotExists: AugmentedError<ApiType>;
+      NotEnoughBalanceToSwap: AugmentedError<ApiType>;
+      RefundSignatureExists: AugmentedError<ApiType>;
+      RefundTransactionAlreadyExecuted: AugmentedError<ApiType>;
+      RefundTransactionNotExists: AugmentedError<ApiType>;
+      TransactionValidatorExists: AugmentedError<ApiType>;
+      TransactionValidatorNotExists: AugmentedError<ApiType>;
+      ValidatorExists: AugmentedError<ApiType>;
+      ValidatorNotExists: AugmentedError<ApiType>;
+      WrongParametersProvided: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    tftPriceModule: {
+      AccountUnauthorizedToSetPrice: AugmentedError<ApiType>;
+      ErrFetchingPrice: AugmentedError<ApiType>;
+      IsNotAnAuthority: AugmentedError<ApiType>;
+      MaxPriceBelowMinPriceError: AugmentedError<ApiType>;
+      MinPriceAboveMaxPriceError: AugmentedError<ApiType>;
+      NoLocalAcctForSigning: AugmentedError<ApiType>;
+      OffchainSignedTxError: AugmentedError<ApiType>;
+      WrongAuthority: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    utility: {
+      /**
+       * Too many calls batched.
+       **/
+      TooManyCalls: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    validator: {
+      AlreadyBonded: AugmentedError<ApiType>;
+      BadOrigin: AugmentedError<ApiType>;
+      CannotBondWithSameAccount: AugmentedError<ApiType>;
+      DuplicateValidator: AugmentedError<ApiType>;
+      NotCouncilMember: AugmentedError<ApiType>;
+      StashBondedWithWrongValidator: AugmentedError<ApiType>;
+      StashNotBonded: AugmentedError<ApiType>;
+      UnauthorizedToActivateValidator: AugmentedError<ApiType>;
+      ValidatorNotApproved: AugmentedError<ApiType>;
+      ValidatorNotFound: AugmentedError<ApiType>;
+      ValidatorNotValidating: AugmentedError<ApiType>;
+      ValidatorValidatingAlready: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    validatorSet: {
+      /**
+       * Only the validator can add itself back after coming online.
+       **/
+      BadOrigin: AugmentedError<ApiType>;
+      /**
+       * Validator is already in the validator set.
+       **/
+      Duplicate: AugmentedError<ApiType>;
+      /**
+       * Target (post-removal) validator count is below the minimum.
+       **/
+      TooLowValidatorCount: AugmentedError<ApiType>;
+      /**
+       * Validator is not approved for re-addition.
+       **/
+      ValidatorNotApproved: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+  } // AugmentedErrors
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/augment-api-events.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api-events.ts
@@ -1,0 +1,725 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/api-base/types/events";
+
+import type { ApiTypes, AugmentedEvent } from "@polkadot/api-base/types";
+import type { Bytes, Null, Option, Result, U8aFixed, Vec, bool, u128, u32, u64 } from "@polkadot/types-codec";
+import type { ITuple } from "@polkadot/types-codec/types";
+import type { AccountId32, H256 } from "@polkadot/types/interfaces/runtime";
+import type {
+  FrameSupportDispatchDispatchInfo,
+  FrameSupportTokensMiscBalanceStatus,
+  PalletSmartContractCause,
+  PalletSmartContractConsumption,
+  PalletSmartContractContract,
+  PalletSmartContractContractBill,
+  PalletSmartContractContractResources,
+  PalletSmartContractNruConsumption,
+  PalletSmartContractServiceContract,
+  PalletSmartContractServiceContractBill,
+  PalletSmartContractSolutionProvider,
+  PalletTfgridEntity,
+  PalletTfgridFarmingPolicy,
+  PalletTfgridPricingPolicy,
+  PalletTfgridTwin,
+  PalletTftBridgeBurnTransaction,
+  PalletTftBridgeMintTransaction,
+  PalletTftBridgeRefundTransaction,
+  PalletTftBridgeStellarSignature,
+  PalletValidatorValidator,
+  SpConsensusGrandpaAppPublic,
+  SpRuntimeDispatchError,
+  TfchainSupportFarm,
+  TfchainSupportFarmCertification,
+  TfchainSupportFarmingPolicyLimit,
+  TfchainSupportNode,
+  TfchainSupportNodeCertification,
+  TfchainSupportPower,
+  TfchainSupportPowerState,
+  TfchainSupportPublicConfig,
+  TfchainSupportPublicIP,
+} from "@polkadot/types/lookup";
+
+export type __AugmentedEvent<ApiType extends ApiTypes> = AugmentedEvent<ApiType>;
+
+declare module "@polkadot/api-base/types/events" {
+  interface AugmentedEvents<ApiType extends ApiTypes> {
+    balances: {
+      /**
+       * A balance was set by root.
+       **/
+      BalanceSet: AugmentedEvent<ApiType, [who: AccountId32, free: u128], { who: AccountId32; free: u128 }>;
+      /**
+       * Some amount was burned from an account.
+       **/
+      Burned: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Some amount was deposited (e.g. for transaction fees).
+       **/
+      Deposit: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * An account was removed whose balance was non-zero but below ExistentialDeposit,
+       * resulting in an outright loss.
+       **/
+      DustLost: AugmentedEvent<ApiType, [account: AccountId32, amount: u128], { account: AccountId32; amount: u128 }>;
+      /**
+       * An account was created with some free balance.
+       **/
+      Endowed: AugmentedEvent<
+        ApiType,
+        [account: AccountId32, freeBalance: u128],
+        { account: AccountId32; freeBalance: u128 }
+      >;
+      /**
+       * Some balance was frozen.
+       **/
+      Frozen: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Total issuance was increased by `amount`, creating a credit to be balanced.
+       **/
+      Issued: AugmentedEvent<ApiType, [amount: u128], { amount: u128 }>;
+      /**
+       * Some balance was locked.
+       **/
+      Locked: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Some amount was minted into an account.
+       **/
+      Minted: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Total issuance was decreased by `amount`, creating a debt to be balanced.
+       **/
+      Rescinded: AugmentedEvent<ApiType, [amount: u128], { amount: u128 }>;
+      /**
+       * Some balance was reserved (moved from free to reserved).
+       **/
+      Reserved: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Some balance was moved from the reserve of the first account to the second account.
+       * Final argument indicates the destination balance type.
+       **/
+      ReserveRepatriated: AugmentedEvent<
+        ApiType,
+        [from: AccountId32, to: AccountId32, amount: u128, destinationStatus: FrameSupportTokensMiscBalanceStatus],
+        { from: AccountId32; to: AccountId32; amount: u128; destinationStatus: FrameSupportTokensMiscBalanceStatus }
+      >;
+      /**
+       * Some amount was restored into an account.
+       **/
+      Restored: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Some amount was removed from the account (e.g. for misbehavior).
+       **/
+      Slashed: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Some amount was suspended from an account (it can be restored later).
+       **/
+      Suspended: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Some balance was thawed.
+       **/
+      Thawed: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Transfer succeeded.
+       **/
+      Transfer: AugmentedEvent<
+        ApiType,
+        [from: AccountId32, to: AccountId32, amount: u128],
+        { from: AccountId32; to: AccountId32; amount: u128 }
+      >;
+      /**
+       * Some balance was unlocked.
+       **/
+      Unlocked: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Some balance was unreserved (moved from reserved to free).
+       **/
+      Unreserved: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * An account was upgraded.
+       **/
+      Upgraded: AugmentedEvent<ApiType, [who: AccountId32], { who: AccountId32 }>;
+      /**
+       * Some amount was withdrawn from the account (e.g. for transaction fees).
+       **/
+      Withdraw: AugmentedEvent<ApiType, [who: AccountId32, amount: u128], { who: AccountId32; amount: u128 }>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    burningModule: {
+      BurnTransactionCreated: AugmentedEvent<ApiType, [AccountId32, u128, u32, Bytes]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    council: {
+      /**
+       * A motion was approved by the required threshold.
+       **/
+      Approved: AugmentedEvent<ApiType, [proposalHash: H256], { proposalHash: H256 }>;
+      /**
+       * A proposal was closed because its threshold was reached or after its duration was up.
+       **/
+      Closed: AugmentedEvent<
+        ApiType,
+        [proposalHash: H256, yes: u32, no: u32],
+        { proposalHash: H256; yes: u32; no: u32 }
+      >;
+      /**
+       * A motion was not approved by the required threshold.
+       **/
+      Disapproved: AugmentedEvent<ApiType, [proposalHash: H256], { proposalHash: H256 }>;
+      /**
+       * A motion was executed; result will be `Ok` if it returned without error.
+       **/
+      Executed: AugmentedEvent<
+        ApiType,
+        [proposalHash: H256, result: Result<Null, SpRuntimeDispatchError>],
+        { proposalHash: H256; result: Result<Null, SpRuntimeDispatchError> }
+      >;
+      /**
+       * A single member did some action; result will be `Ok` if it returned without error.
+       **/
+      MemberExecuted: AugmentedEvent<
+        ApiType,
+        [proposalHash: H256, result: Result<Null, SpRuntimeDispatchError>],
+        { proposalHash: H256; result: Result<Null, SpRuntimeDispatchError> }
+      >;
+      /**
+       * A motion (given hash) has been proposed (by given account) with a threshold (given
+       * `MemberCount`).
+       **/
+      Proposed: AugmentedEvent<
+        ApiType,
+        [account: AccountId32, proposalIndex: u32, proposalHash: H256, threshold: u32],
+        { account: AccountId32; proposalIndex: u32; proposalHash: H256; threshold: u32 }
+      >;
+      /**
+       * A motion (given hash) has been voted on by given account, leaving
+       * a tally (yes votes and no votes given respectively as `MemberCount`).
+       **/
+      Voted: AugmentedEvent<
+        ApiType,
+        [account: AccountId32, proposalHash: H256, voted: bool, yes: u32, no: u32],
+        { account: AccountId32; proposalHash: H256; voted: bool; yes: u32; no: u32 }
+      >;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    councilMembership: {
+      /**
+       * Phantom member, never used.
+       **/
+      Dummy: AugmentedEvent<ApiType, []>;
+      /**
+       * One of the members' keys changed.
+       **/
+      KeyChanged: AugmentedEvent<ApiType, []>;
+      /**
+       * The given member was added; see the transaction for who.
+       **/
+      MemberAdded: AugmentedEvent<ApiType, []>;
+      /**
+       * The given member was removed; see the transaction for who.
+       **/
+      MemberRemoved: AugmentedEvent<ApiType, []>;
+      /**
+       * The membership was reset; see the transaction for who the new set is.
+       **/
+      MembersReset: AugmentedEvent<ApiType, []>;
+      /**
+       * Two members were swapped; see the transaction for who.
+       **/
+      MembersSwapped: AugmentedEvent<ApiType, []>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    dao: {
+      /**
+       * A motion was approved by the required threshold.
+       **/
+      Approved: AugmentedEvent<ApiType, [proposalHash: H256], { proposalHash: H256 }>;
+      /**
+       * A proposal_hash was closed because its threshold was reached or after its duration was up.
+       **/
+      Closed: AugmentedEvent<
+        ApiType,
+        [proposalHash: H256, yes: u32, yesWeight: u64, no: u32, noWeight: u64],
+        { proposalHash: H256; yes: u32; yesWeight: u64; no: u32; noWeight: u64 }
+      >;
+      ClosedByCouncil: AugmentedEvent<
+        ApiType,
+        [proposalHash: H256, vetos: Vec<AccountId32>],
+        { proposalHash: H256; vetos: Vec<AccountId32> }
+      >;
+      CouncilMemberVeto: AugmentedEvent<
+        ApiType,
+        [proposalHash: H256, who: AccountId32],
+        { proposalHash: H256; who: AccountId32 }
+      >;
+      /**
+       * A motion was not approved by the required threshold.
+       **/
+      Disapproved: AugmentedEvent<ApiType, [proposalHash: H256], { proposalHash: H256 }>;
+      /**
+       * A motion was executed; result will be `Ok` if it returned without error.
+       **/
+      Executed: AugmentedEvent<
+        ApiType,
+        [proposalHash: H256, result: Result<Null, SpRuntimeDispatchError>],
+        { proposalHash: H256; result: Result<Null, SpRuntimeDispatchError> }
+      >;
+      /**
+       * A motion (given hash) has been proposed (by given account) with a threshold (given
+       * `MemberCount`).
+       **/
+      Proposed: AugmentedEvent<
+        ApiType,
+        [account: AccountId32, proposalIndex: u32, proposalHash: H256, threshold: u32],
+        { account: AccountId32; proposalIndex: u32; proposalHash: H256; threshold: u32 }
+      >;
+      Voted: AugmentedEvent<
+        ApiType,
+        [account: AccountId32, proposalHash: H256, voted: bool, yes: u32, no: u32],
+        { account: AccountId32; proposalHash: H256; voted: bool; yes: u32; no: u32 }
+      >;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    grandpa: {
+      /**
+       * New authority set has been applied.
+       **/
+      NewAuthorities: AugmentedEvent<
+        ApiType,
+        [authoritySet: Vec<ITuple<[SpConsensusGrandpaAppPublic, u64]>>],
+        { authoritySet: Vec<ITuple<[SpConsensusGrandpaAppPublic, u64]>> }
+      >;
+      /**
+       * Current authority set has been paused.
+       **/
+      Paused: AugmentedEvent<ApiType, []>;
+      /**
+       * Current authority set has been resumed.
+       **/
+      Resumed: AugmentedEvent<ApiType, []>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    scheduler: {
+      /**
+       * The call for the provided hash was not found so the task has been aborted.
+       **/
+      CallUnavailable: AugmentedEvent<
+        ApiType,
+        [task: ITuple<[u32, u32]>, id: Option<U8aFixed>],
+        { task: ITuple<[u32, u32]>; id: Option<U8aFixed> }
+      >;
+      /**
+       * Canceled some task.
+       **/
+      Canceled: AugmentedEvent<ApiType, [when: u32, index: u32], { when: u32; index: u32 }>;
+      /**
+       * Dispatched some task.
+       **/
+      Dispatched: AugmentedEvent<
+        ApiType,
+        [task: ITuple<[u32, u32]>, id: Option<U8aFixed>, result: Result<Null, SpRuntimeDispatchError>],
+        { task: ITuple<[u32, u32]>; id: Option<U8aFixed>; result: Result<Null, SpRuntimeDispatchError> }
+      >;
+      /**
+       * The given task was unable to be renewed since the agenda is full at that block.
+       **/
+      PeriodicFailed: AugmentedEvent<
+        ApiType,
+        [task: ITuple<[u32, u32]>, id: Option<U8aFixed>],
+        { task: ITuple<[u32, u32]>; id: Option<U8aFixed> }
+      >;
+      /**
+       * The given task can never be executed since it is overweight.
+       **/
+      PermanentlyOverweight: AugmentedEvent<
+        ApiType,
+        [task: ITuple<[u32, u32]>, id: Option<U8aFixed>],
+        { task: ITuple<[u32, u32]>; id: Option<U8aFixed> }
+      >;
+      /**
+       * Scheduled some task.
+       **/
+      Scheduled: AugmentedEvent<ApiType, [when: u32, index: u32], { when: u32; index: u32 }>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    session: {
+      /**
+       * New session has happened. Note that the argument is the session index, not the
+       * block number as the type might suggest.
+       **/
+      NewSession: AugmentedEvent<ApiType, [sessionIndex: u32], { sessionIndex: u32 }>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    smartContractModule: {
+      BillingFrequencyChanged: AugmentedEvent<ApiType, [u64]>;
+      /**
+       * Deprecated event
+       **/
+      ConsumptionReportReceived: AugmentedEvent<ApiType, [PalletSmartContractConsumption]>;
+      ContractBilled: AugmentedEvent<ApiType, [PalletSmartContractContractBill]>;
+      /**
+       * A contract got created
+       **/
+      ContractCreated: AugmentedEvent<ApiType, [PalletSmartContractContract]>;
+      /**
+       * Deprecated event
+       **/
+      ContractDeployed: AugmentedEvent<ApiType, [u64, AccountId32]>;
+      /**
+       * A Contract grace period was ended
+       **/
+      ContractGracePeriodEnded: AugmentedEvent<
+        ApiType,
+        [contractId: u64, nodeId: u32, twinId: u32],
+        { contractId: u64; nodeId: u32; twinId: u32 }
+      >;
+      /**
+       * A Contract grace period is triggered
+       **/
+      ContractGracePeriodStarted: AugmentedEvent<
+        ApiType,
+        [contractId: u64, nodeId: u32, twinId: u32, blockNumber: u64],
+        { contractId: u64; nodeId: u32; twinId: u32; blockNumber: u64 }
+      >;
+      /**
+       * A contract was updated
+       **/
+      ContractUpdated: AugmentedEvent<ApiType, [PalletSmartContractContract]>;
+      /**
+       * IP got freed by a Node contract
+       **/
+      IPsFreed: AugmentedEvent<
+        ApiType,
+        [contractId: u64, publicIps: Vec<TfchainSupportPublicIP>],
+        { contractId: u64; publicIps: Vec<TfchainSupportPublicIP> }
+      >;
+      /**
+       * IP got reserved by a Node contract
+       **/
+      IPsReserved: AugmentedEvent<
+        ApiType,
+        [contractId: u64, publicIps: Vec<TfchainSupportPublicIP>],
+        { contractId: u64; publicIps: Vec<TfchainSupportPublicIP> }
+      >;
+      /**
+       * A Name contract is canceled
+       **/
+      NameContractCanceled: AugmentedEvent<ApiType, [contractId: u64], { contractId: u64 }>;
+      /**
+       * A Node contract is canceled
+       **/
+      NodeContractCanceled: AugmentedEvent<
+        ApiType,
+        [contractId: u64, nodeId: u32, twinId: u32],
+        { contractId: u64; nodeId: u32; twinId: u32 }
+      >;
+      NodeExtraFeeSet: AugmentedEvent<ApiType, [nodeId: u32, extraFee: u64], { nodeId: u32; extraFee: u64 }>;
+      /**
+       * Network resources report received for contract
+       **/
+      NruConsumptionReportReceived: AugmentedEvent<ApiType, [PalletSmartContractNruConsumption]>;
+      /**
+       * a Rent contract is canceled
+       **/
+      RentContractCanceled: AugmentedEvent<ApiType, [contractId: u64], { contractId: u64 }>;
+      /**
+       * A Service contract is approved
+       **/
+      ServiceContractApproved: AugmentedEvent<ApiType, [PalletSmartContractServiceContract]>;
+      /**
+       * A Service contract is billed
+       **/
+      ServiceContractBilled: AugmentedEvent<
+        ApiType,
+        [
+          serviceContract: PalletSmartContractServiceContract,
+          bill: PalletSmartContractServiceContractBill,
+          amount: u128,
+        ],
+        {
+          serviceContract: PalletSmartContractServiceContract;
+          bill: PalletSmartContractServiceContractBill;
+          amount: u128;
+        }
+      >;
+      /**
+       * A Service contract is canceled
+       **/
+      ServiceContractCanceled: AugmentedEvent<
+        ApiType,
+        [serviceContractId: u64, cause: PalletSmartContractCause],
+        { serviceContractId: u64; cause: PalletSmartContractCause }
+      >;
+      /**
+       * A Service contract is created
+       **/
+      ServiceContractCreated: AugmentedEvent<ApiType, [PalletSmartContractServiceContract]>;
+      /**
+       * A Service contract fees are set
+       **/
+      ServiceContractFeesSet: AugmentedEvent<ApiType, [PalletSmartContractServiceContract]>;
+      /**
+       * A Service contract metadata is set
+       **/
+      ServiceContractMetadataSet: AugmentedEvent<ApiType, [PalletSmartContractServiceContract]>;
+      SolutionProviderApproved: AugmentedEvent<ApiType, [u64, bool]>;
+      SolutionProviderCreated: AugmentedEvent<ApiType, [PalletSmartContractSolutionProvider]>;
+      /**
+       * A certain amount of tokens got burned by a contract
+       **/
+      TokensBurned: AugmentedEvent<ApiType, [contractId: u64, amount: u128], { contractId: u64; amount: u128 }>;
+      /**
+       * Contract resources got updated
+       **/
+      UpdatedUsedResources: AugmentedEvent<ApiType, [PalletSmartContractContractResources]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    system: {
+      /**
+       * `:code` was updated.
+       **/
+      CodeUpdated: AugmentedEvent<ApiType, []>;
+      /**
+       * An extrinsic failed.
+       **/
+      ExtrinsicFailed: AugmentedEvent<
+        ApiType,
+        [dispatchError: SpRuntimeDispatchError, dispatchInfo: FrameSupportDispatchDispatchInfo],
+        { dispatchError: SpRuntimeDispatchError; dispatchInfo: FrameSupportDispatchDispatchInfo }
+      >;
+      /**
+       * An extrinsic completed successfully.
+       **/
+      ExtrinsicSuccess: AugmentedEvent<
+        ApiType,
+        [dispatchInfo: FrameSupportDispatchDispatchInfo],
+        { dispatchInfo: FrameSupportDispatchDispatchInfo }
+      >;
+      /**
+       * An account was reaped.
+       **/
+      KilledAccount: AugmentedEvent<ApiType, [account: AccountId32], { account: AccountId32 }>;
+      /**
+       * A new account was created.
+       **/
+      NewAccount: AugmentedEvent<ApiType, [account: AccountId32], { account: AccountId32 }>;
+      /**
+       * On on-chain remark happened.
+       **/
+      Remarked: AugmentedEvent<ApiType, [sender: AccountId32, hash_: H256], { sender: AccountId32; hash_: H256 }>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    tfgridModule: {
+      ConnectionPriceSet: AugmentedEvent<ApiType, [u32]>;
+      EntityDeleted: AugmentedEvent<ApiType, [u32]>;
+      EntityStored: AugmentedEvent<ApiType, [PalletTfgridEntity]>;
+      EntityUpdated: AugmentedEvent<ApiType, [PalletTfgridEntity]>;
+      FarmCertificationSet: AugmentedEvent<ApiType, [u32, TfchainSupportFarmCertification]>;
+      FarmDeleted: AugmentedEvent<ApiType, [u32]>;
+      FarmingPolicySet: AugmentedEvent<ApiType, [u32, Option<TfchainSupportFarmingPolicyLimit>]>;
+      FarmingPolicyStored: AugmentedEvent<ApiType, [PalletTfgridFarmingPolicy]>;
+      FarmingPolicyUpdated: AugmentedEvent<ApiType, [PalletTfgridFarmingPolicy]>;
+      FarmMarkedAsDedicated: AugmentedEvent<ApiType, [u32]>;
+      FarmPayoutV2AddressRegistered: AugmentedEvent<ApiType, [u32, Bytes]>;
+      FarmStored: AugmentedEvent<ApiType, [TfchainSupportFarm]>;
+      FarmUpdated: AugmentedEvent<ApiType, [TfchainSupportFarm]>;
+      NodeCertificationSet: AugmentedEvent<ApiType, [u32, TfchainSupportNodeCertification]>;
+      NodeCertifierAdded: AugmentedEvent<ApiType, [AccountId32]>;
+      NodeCertifierRemoved: AugmentedEvent<ApiType, [AccountId32]>;
+      NodeDeleted: AugmentedEvent<ApiType, [u32]>;
+      NodePublicConfigStored: AugmentedEvent<ApiType, [u32, Option<TfchainSupportPublicConfig>]>;
+      NodeStored: AugmentedEvent<ApiType, [TfchainSupportNode]>;
+      NodeUpdated: AugmentedEvent<ApiType, [TfchainSupportNode]>;
+      NodeUptimeReported: AugmentedEvent<ApiType, [u32, u64, u64]>;
+      PowerStateChanged: AugmentedEvent<
+        ApiType,
+        [farmId: u32, nodeId: u32, powerState: TfchainSupportPowerState],
+        { farmId: u32; nodeId: u32; powerState: TfchainSupportPowerState }
+      >;
+      /**
+       * Send an event to zero os to change its state
+       **/
+      PowerTargetChanged: AugmentedEvent<
+        ApiType,
+        [farmId: u32, nodeId: u32, powerTarget: TfchainSupportPower],
+        { farmId: u32; nodeId: u32; powerTarget: TfchainSupportPower }
+      >;
+      PricingPolicyStored: AugmentedEvent<ApiType, [PalletTfgridPricingPolicy]>;
+      TwinAccountBounded: AugmentedEvent<ApiType, [u32, AccountId32]>;
+      TwinDeleted: AugmentedEvent<ApiType, [u32]>;
+      TwinEntityRemoved: AugmentedEvent<ApiType, [u32, u32]>;
+      TwinEntityStored: AugmentedEvent<ApiType, [u32, u32, Bytes]>;
+      TwinStored: AugmentedEvent<ApiType, [PalletTfgridTwin]>;
+      TwinUpdated: AugmentedEvent<ApiType, [PalletTfgridTwin]>;
+      ZosVersionUpdated: AugmentedEvent<ApiType, [Bytes]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    tfkvStore: {
+      /**
+       * A user has read their entry, leaving it in storage
+       **/
+      EntryGot: AugmentedEvent<ApiType, [AccountId32, Bytes, Bytes]>;
+      /**
+       * A user has set their entry
+       **/
+      EntrySet: AugmentedEvent<ApiType, [AccountId32, Bytes, Bytes]>;
+      /**
+       * A user has read their entry, removing it from storage
+       **/
+      EntryTaken: AugmentedEvent<ApiType, [AccountId32, Bytes, Bytes]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    tftBridgeModule: {
+      BurnTransactionCreated: AugmentedEvent<ApiType, [u64, AccountId32, Bytes, u64]>;
+      BurnTransactionExpired: AugmentedEvent<ApiType, [u64, Option<AccountId32>, Bytes, u64]>;
+      BurnTransactionProcessed: AugmentedEvent<ApiType, [PalletTftBridgeBurnTransaction]>;
+      BurnTransactionProposed: AugmentedEvent<ApiType, [u64, Bytes, u64]>;
+      BurnTransactionReady: AugmentedEvent<ApiType, [u64]>;
+      BurnTransactionSignatureAdded: AugmentedEvent<ApiType, [u64, PalletTftBridgeStellarSignature]>;
+      MintCompleted: AugmentedEvent<ApiType, [PalletTftBridgeMintTransaction, Bytes]>;
+      MintTransactionExpired: AugmentedEvent<ApiType, [Bytes, u64, AccountId32]>;
+      MintTransactionProposed: AugmentedEvent<ApiType, [Bytes, AccountId32, u64]>;
+      MintTransactionVoted: AugmentedEvent<ApiType, [Bytes]>;
+      RefundTransactionCreated: AugmentedEvent<ApiType, [Bytes, Bytes, u64]>;
+      RefundTransactionExpired: AugmentedEvent<ApiType, [Bytes, Bytes, u64]>;
+      RefundTransactionProcessed: AugmentedEvent<ApiType, [PalletTftBridgeRefundTransaction]>;
+      RefundTransactionReady: AugmentedEvent<ApiType, [Bytes]>;
+      RefundTransactionsignatureAdded: AugmentedEvent<ApiType, [Bytes, PalletTftBridgeStellarSignature]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    tftPriceModule: {
+      AveragePriceIsAboveMaxPrice: AugmentedEvent<ApiType, [u32, u32]>;
+      AveragePriceIsBelowMinPrice: AugmentedEvent<ApiType, [u32, u32]>;
+      AveragePriceStored: AugmentedEvent<ApiType, [u32]>;
+      OffchainWorkerExecuted: AugmentedEvent<ApiType, [AccountId32]>;
+      PriceStored: AugmentedEvent<ApiType, [u32]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    transactionPayment: {
+      /**
+       * A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,
+       * has been paid by `who`.
+       **/
+      TransactionFeePaid: AugmentedEvent<
+        ApiType,
+        [who: AccountId32, actualFee: u128, tip: u128],
+        { who: AccountId32; actualFee: u128; tip: u128 }
+      >;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    utility: {
+      /**
+       * Batch of dispatches completed fully with no error.
+       **/
+      BatchCompleted: AugmentedEvent<ApiType, []>;
+      /**
+       * Batch of dispatches completed but has errors.
+       **/
+      BatchCompletedWithErrors: AugmentedEvent<ApiType, []>;
+      /**
+       * Batch of dispatches did not complete fully. Index of first failing dispatch given, as
+       * well as the error.
+       **/
+      BatchInterrupted: AugmentedEvent<
+        ApiType,
+        [index: u32, error: SpRuntimeDispatchError],
+        { index: u32; error: SpRuntimeDispatchError }
+      >;
+      /**
+       * A call was dispatched.
+       **/
+      DispatchedAs: AugmentedEvent<
+        ApiType,
+        [result: Result<Null, SpRuntimeDispatchError>],
+        { result: Result<Null, SpRuntimeDispatchError> }
+      >;
+      /**
+       * A single item within a Batch of dispatches has completed with no error.
+       **/
+      ItemCompleted: AugmentedEvent<ApiType, []>;
+      /**
+       * A single item within a Batch of dispatches has completed with error.
+       **/
+      ItemFailed: AugmentedEvent<ApiType, [error: SpRuntimeDispatchError], { error: SpRuntimeDispatchError }>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    validator: {
+      Bonded: AugmentedEvent<ApiType, [AccountId32]>;
+      NodeValidatorChanged: AugmentedEvent<ApiType, [AccountId32]>;
+      NodeValidatorRemoved: AugmentedEvent<ApiType, [AccountId32]>;
+      ValidatorActivated: AugmentedEvent<ApiType, [PalletValidatorValidator]>;
+      ValidatorRemoved: AugmentedEvent<ApiType, [PalletValidatorValidator]>;
+      ValidatorRequestApproved: AugmentedEvent<ApiType, [PalletValidatorValidator]>;
+      ValidatorRequestCreated: AugmentedEvent<ApiType, [AccountId32, PalletValidatorValidator]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    validatorSet: {
+      /**
+       * New validator addition initiated. Effective in ~2 sessions.
+       **/
+      ValidatorAdditionInitiated: AugmentedEvent<ApiType, [AccountId32]>;
+      /**
+       * Validator removal initiated. Effective in ~2 sessions.
+       **/
+      ValidatorRemovalInitiated: AugmentedEvent<ApiType, [AccountId32]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+  } // AugmentedEvents
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/augment-api-query.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api-query.ts
@@ -1,0 +1,808 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/api-base/types/storage";
+
+import type { ApiTypes, AugmentedQuery, QueryableStorageEntry } from "@polkadot/api-base/types";
+import type { Bytes, Option, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from "@polkadot/types-codec";
+import type { AnyNumber, ITuple } from "@polkadot/types-codec/types";
+import type { AccountId32, Call, H256 } from "@polkadot/types/interfaces/runtime";
+import type {
+  FrameSupportDispatchPerDispatchClassWeight,
+  FrameSystemAccountInfo,
+  FrameSystemEventRecord,
+  FrameSystemLastRuntimeUpgradeInfo,
+  FrameSystemPhase,
+  PalletBalancesAccountData,
+  PalletBalancesBalanceLock,
+  PalletBalancesIdAmount,
+  PalletBalancesReserveData,
+  PalletBurningBurn,
+  PalletCollectiveVotes,
+  PalletDaoProposalDaoProposal,
+  PalletDaoProposalDaoVotes,
+  PalletGrandpaStoredPendingChange,
+  PalletGrandpaStoredState,
+  PalletSchedulerScheduled,
+  PalletSmartContractContract,
+  PalletSmartContractContractBillingInformation,
+  PalletSmartContractContractLock,
+  PalletSmartContractContractResources,
+  PalletSmartContractServiceContract,
+  PalletSmartContractSolutionProvider,
+  PalletSmartContractStorageVersion,
+  PalletTfgridEntity,
+  PalletTfgridFarmingPolicy,
+  PalletTfgridPricingPolicy,
+  PalletTfgridStorageVersion,
+  PalletTfgridTermsCondTermsAndConditions,
+  PalletTfgridTwin,
+  PalletTftBridgeBurnTransaction,
+  PalletTftBridgeMintTransaction,
+  PalletTftBridgeRefundTransaction,
+  PalletTftBridgeStorageVersion,
+  PalletTransactionPaymentReleases,
+  PalletValidatorValidator,
+  SpConsensusAuraSr25519AppSr25519Public,
+  SpCoreCryptoKeyTypeId,
+  SpRuntimeDigest,
+  TfchainRuntimeOpaqueSessionKeys,
+  TfchainSupportFarm,
+  TfchainSupportNode,
+  TfchainSupportNodePower,
+} from "@polkadot/types/lookup";
+import type { Observable } from "@polkadot/types/types";
+
+export type __AugmentedQuery<ApiType extends ApiTypes> = AugmentedQuery<ApiType, () => unknown>;
+export type __QueryableStorageEntry<ApiType extends ApiTypes> = QueryableStorageEntry<ApiType>;
+
+declare module "@polkadot/api-base/types/storage" {
+  interface AugmentedQueries<ApiType extends ApiTypes> {
+    aura: {
+      /**
+       * The current authority set.
+       **/
+      authorities: AugmentedQuery<ApiType, () => Observable<Vec<SpConsensusAuraSr25519AppSr25519Public>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * The current slot of this block.
+       *
+       * This will be set in `on_initialize`.
+       **/
+      currentSlot: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    authorship: {
+      /**
+       * Author of current block.
+       **/
+      author: AugmentedQuery<ApiType, () => Observable<Option<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    balances: {
+      /**
+       * The Balances pallet example of storing the balance of an account.
+       *
+       * # Example
+       *
+       * ```nocompile
+       * impl pallet_balances::Config for Runtime {
+       * type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>
+       * }
+       * ```
+       *
+       * You can also store the balance of an account in the `System` pallet.
+       *
+       * # Example
+       *
+       * ```nocompile
+       * impl pallet_balances::Config for Runtime {
+       * type AccountStore = System
+       * }
+       * ```
+       *
+       * But this comes with tradeoffs, storing account balances in the system pallet stores
+       * `frame_system` data alongside the account data contrary to storing account balances in the
+       * `Balances` pallet, which uses a `StorageMap` to store balances data only.
+       * NOTE: This is only used in the case that this pallet is used to store balances.
+       **/
+      account: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<PalletBalancesAccountData>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * Freeze locks on account balances.
+       **/
+      freezes: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Vec<PalletBalancesIdAmount>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * Holds on account balances.
+       **/
+      holds: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Vec<PalletBalancesIdAmount>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * The total units of outstanding deactivated balance in the system.
+       **/
+      inactiveIssuance: AugmentedQuery<ApiType, () => Observable<u128>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Any liquidity locks on some account balances.
+       * NOTE: Should only be accessed when setting, changing and freeing a lock.
+       **/
+      locks: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Vec<PalletBalancesBalanceLock>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * Named reserves on some account balances.
+       **/
+      reserves: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Vec<PalletBalancesReserveData>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * The total units issued in the system.
+       **/
+      totalIssuance: AugmentedQuery<ApiType, () => Observable<u128>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    burningModule: {
+      burns: AugmentedQuery<ApiType, () => Observable<Option<Vec<PalletBurningBurn>>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    council: {
+      /**
+       * The current members of the collective. This is stored sorted (just by value).
+       **/
+      members: AugmentedQuery<ApiType, () => Observable<Vec<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * The prime member that helps determine the default vote behavior in case of absentations.
+       **/
+      prime: AugmentedQuery<ApiType, () => Observable<Option<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Proposals so far.
+       **/
+      proposalCount: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Actual proposal for a given hash, if it's current.
+       **/
+      proposalOf: AugmentedQuery<ApiType, (arg: H256 | string | Uint8Array) => Observable<Option<Call>>, [H256]> &
+        QueryableStorageEntry<ApiType, [H256]>;
+      /**
+       * The hashes of the active proposals.
+       **/
+      proposals: AugmentedQuery<ApiType, () => Observable<Vec<H256>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Votes on a given proposal, if it is ongoing.
+       **/
+      voting: AugmentedQuery<
+        ApiType,
+        (arg: H256 | string | Uint8Array) => Observable<Option<PalletCollectiveVotes>>,
+        [H256]
+      > &
+        QueryableStorageEntry<ApiType, [H256]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    councilMembership: {
+      /**
+       * The current membership, stored as an ordered Vec.
+       **/
+      members: AugmentedQuery<ApiType, () => Observable<Vec<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * The current prime member, if one exists.
+       **/
+      prime: AugmentedQuery<ApiType, () => Observable<Option<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    dao: {
+      farmWeight: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<u64>, [u32]> &
+        QueryableStorageEntry<ApiType, [u32]>;
+      /**
+       * Proposals so far.
+       **/
+      proposalCount: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * The hashes of the active proposals.
+       **/
+      proposalList: AugmentedQuery<ApiType, () => Observable<Vec<H256>>, []> & QueryableStorageEntry<ApiType, []>;
+      proposalOf: AugmentedQuery<ApiType, (arg: H256 | string | Uint8Array) => Observable<Option<Call>>, [H256]> &
+        QueryableStorageEntry<ApiType, [H256]>;
+      /**
+       * A map that indexes a hash to an active proposal object.
+       **/
+      proposals: AugmentedQuery<
+        ApiType,
+        (arg: H256 | string | Uint8Array) => Observable<Option<PalletDaoProposalDaoProposal>>,
+        [H256]
+      > &
+        QueryableStorageEntry<ApiType, [H256]>;
+      /**
+       * Votes on a given proposal, if it is ongoing.
+       **/
+      voting: AugmentedQuery<
+        ApiType,
+        (arg: H256 | string | Uint8Array) => Observable<Option<PalletDaoProposalDaoVotes>>,
+        [H256]
+      > &
+        QueryableStorageEntry<ApiType, [H256]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    grandpa: {
+      /**
+       * The number of changes (both in terms of keys and underlying economic responsibilities)
+       * in the "set" of Grandpa validators from genesis.
+       **/
+      currentSetId: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * next block number where we can force a change.
+       **/
+      nextForced: AugmentedQuery<ApiType, () => Observable<Option<u32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Pending change: (signaled at, scheduled change).
+       **/
+      pendingChange: AugmentedQuery<ApiType, () => Observable<Option<PalletGrandpaStoredPendingChange>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * A mapping from grandpa set ID to the index of the *most recent* session for which its
+       * members were responsible.
+       *
+       * This is only used for validating equivocation proofs. An equivocation proof must
+       * contains a key-ownership proof for a given session, therefore we need a way to tie
+       * together sessions and GRANDPA set ids, i.e. we need to validate that a validator
+       * was the owner of a given key on a given session, and what the active set ID was
+       * during that session.
+       *
+       * TWOX-NOTE: `SetId` is not under user control.
+       **/
+      setIdSession: AugmentedQuery<ApiType, (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<u32>>, [u64]> &
+        QueryableStorageEntry<ApiType, [u64]>;
+      /**
+       * `true` if we are currently stalled.
+       **/
+      stalled: AugmentedQuery<ApiType, () => Observable<Option<ITuple<[u32, u32]>>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * State of the current authority set.
+       **/
+      state: AugmentedQuery<ApiType, () => Observable<PalletGrandpaStoredState>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    scheduler: {
+      /**
+       * Items to be executed, indexed by the block number that they should be executed on.
+       **/
+      agenda: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Vec<Option<PalletSchedulerScheduled>>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      incompleteSince: AugmentedQuery<ApiType, () => Observable<Option<u32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Lookup from a name to the block number and index of the task.
+       *
+       * For v3 -> v4 the previously unbounded identities are Blake2-256 hashed to form the v4
+       * identities.
+       **/
+      lookup: AugmentedQuery<
+        ApiType,
+        (arg: U8aFixed | string | Uint8Array) => Observable<Option<ITuple<[u32, u32]>>>,
+        [U8aFixed]
+      > &
+        QueryableStorageEntry<ApiType, [U8aFixed]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    session: {
+      /**
+       * Current index of the session.
+       **/
+      currentIndex: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Indices of disabled validators.
+       *
+       * The vec is always kept sorted so that we can find whether a given validator is
+       * disabled using binary search. It gets cleared when `on_session_ending` returns
+       * a new set of identities.
+       **/
+      disabledValidators: AugmentedQuery<ApiType, () => Observable<Vec<u32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * The owner of a key. The key is the `KeyTypeId` + the encoded key.
+       **/
+      keyOwner: AugmentedQuery<
+        ApiType,
+        (
+          arg:
+            | ITuple<[SpCoreCryptoKeyTypeId, Bytes]>
+            | [SpCoreCryptoKeyTypeId | string | Uint8Array, Bytes | string | Uint8Array],
+        ) => Observable<Option<AccountId32>>,
+        [ITuple<[SpCoreCryptoKeyTypeId, Bytes]>]
+      > &
+        QueryableStorageEntry<ApiType, [ITuple<[SpCoreCryptoKeyTypeId, Bytes]>]>;
+      /**
+       * The next session keys for a validator.
+       **/
+      nextKeys: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Option<TfchainRuntimeOpaqueSessionKeys>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * True if the underlying economic identities or weighting behind the validators
+       * has changed in the queued validator set.
+       **/
+      queuedChanged: AugmentedQuery<ApiType, () => Observable<bool>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * The queued keys for the next session. When the next session begins, these keys
+       * will be used to determine the validator's session keys.
+       **/
+      queuedKeys: AugmentedQuery<
+        ApiType,
+        () => Observable<Vec<ITuple<[AccountId32, TfchainRuntimeOpaqueSessionKeys]>>>,
+        []
+      > &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * The current set of validators.
+       **/
+      validators: AugmentedQuery<ApiType, () => Observable<Vec<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    smartContractModule: {
+      activeNodeContracts: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<Vec<u64>>, [u32]> &
+        QueryableStorageEntry<ApiType, [u32]>;
+      activeRentContractForNode: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<u64>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      billingFrequency: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      contractBillingInformationByID: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<PalletSmartContractContractBillingInformation>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      contractID: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      contractIDByNameRegistration: AugmentedQuery<
+        ApiType,
+        (arg: Bytes | string | Uint8Array) => Observable<u64>,
+        [Bytes]
+      > &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      contractIDByNodeIDAndHash: AugmentedQuery<
+        ApiType,
+        (arg1: u32 | AnyNumber | Uint8Array, arg2: U8aFixed | string | Uint8Array) => Observable<u64>,
+        [u32, U8aFixed]
+      > &
+        QueryableStorageEntry<ApiType, [u32, U8aFixed]>;
+      contractLock: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<PalletSmartContractContractLock>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      contracts: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<PalletSmartContractContract>>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      contractsToBillAt: AugmentedQuery<ApiType, (arg: u64 | AnyNumber | Uint8Array) => Observable<Vec<u64>>, [u64]> &
+        QueryableStorageEntry<ApiType, [u64]>;
+      /**
+       * The current migration's stage, if any.
+       **/
+      currentMigrationStage: AugmentedQuery<ApiType, () => Observable<Option<u8>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      dedicatedNodesExtraFee: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<u64>, [u32]> &
+        QueryableStorageEntry<ApiType, [u32]>;
+      nodeContractResources: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<PalletSmartContractContractResources>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      palletVersion: AugmentedQuery<ApiType, () => Observable<PalletSmartContractStorageVersion>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      serviceContractID: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      serviceContracts: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<PalletSmartContractServiceContract>>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      solutionProviderID: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      solutionProviders: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<PalletSmartContractSolutionProvider>>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    system: {
+      /**
+       * The full account information for a particular account ID.
+       **/
+      account: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<FrameSystemAccountInfo>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * Total length (in bytes) for all extrinsics put together, for the current block.
+       **/
+      allExtrinsicsLen: AugmentedQuery<ApiType, () => Observable<Option<u32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Map of block numbers to block hashes.
+       **/
+      blockHash: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<H256>, [u32]> &
+        QueryableStorageEntry<ApiType, [u32]>;
+      /**
+       * The current weight for the block.
+       **/
+      blockWeight: AugmentedQuery<ApiType, () => Observable<FrameSupportDispatchPerDispatchClassWeight>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * Digest of the current block, also part of the block header.
+       **/
+      digest: AugmentedQuery<ApiType, () => Observable<SpRuntimeDigest>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * The number of events in the `Events<T>` list.
+       **/
+      eventCount: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Events deposited for the current block.
+       *
+       * NOTE: The item is unbound and should therefore never be read on chain.
+       * It could otherwise inflate the PoV size of a block.
+       *
+       * Events have a large in-memory size. Box the events to not go out-of-memory
+       * just in case someone still reads them from within the runtime.
+       **/
+      events: AugmentedQuery<ApiType, () => Observable<Vec<FrameSystemEventRecord>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * Mapping between a topic (represented by T::Hash) and a vector of indexes
+       * of events in the `<Events<T>>` list.
+       *
+       * All topic vectors have deterministic storage locations depending on the topic. This
+       * allows light-clients to leverage the changes trie storage tracking mechanism and
+       * in case of changes fetch the list of events of interest.
+       *
+       * The value has the type `(BlockNumberFor<T>, EventIndex)` because if we used only just
+       * the `EventIndex` then in case if the topic has the same contents on the next block
+       * no notification will be triggered thus the event might be lost.
+       **/
+      eventTopics: AugmentedQuery<
+        ApiType,
+        (arg: H256 | string | Uint8Array) => Observable<Vec<ITuple<[u32, u32]>>>,
+        [H256]
+      > &
+        QueryableStorageEntry<ApiType, [H256]>;
+      /**
+       * The execution phase of the block.
+       **/
+      executionPhase: AugmentedQuery<ApiType, () => Observable<Option<FrameSystemPhase>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * Total extrinsics count for the current block.
+       **/
+      extrinsicCount: AugmentedQuery<ApiType, () => Observable<Option<u32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Extrinsics data for the current block (maps an extrinsic's index to its data).
+       **/
+      extrinsicData: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<Bytes>, [u32]> &
+        QueryableStorageEntry<ApiType, [u32]>;
+      /**
+       * Stores the `spec_version` and `spec_name` of when the last runtime upgrade happened.
+       **/
+      lastRuntimeUpgrade: AugmentedQuery<ApiType, () => Observable<Option<FrameSystemLastRuntimeUpgradeInfo>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * The current block number being processed. Set by `execute_block`.
+       **/
+      number: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Hash of the previous block.
+       **/
+      parentHash: AugmentedQuery<ApiType, () => Observable<H256>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * True if we have upgraded so that AccountInfo contains three types of `RefCount`. False
+       * (default) if not.
+       **/
+      upgradedToTripleRefCount: AugmentedQuery<ApiType, () => Observable<bool>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * True if we have upgraded so that `type RefCount` is `u32`. False (default) if not.
+       **/
+      upgradedToU32RefCount: AugmentedQuery<ApiType, () => Observable<bool>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    tfgridModule: {
+      allowedNodeCertifiers: AugmentedQuery<ApiType, () => Observable<Option<Vec<AccountId32>>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      connectionPrice: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      entities: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<PalletTfgridEntity>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      entityID: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      entityIdByAccountID: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Option<u32>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      entityIdByName: AugmentedQuery<ApiType, (arg: Bytes | string | Uint8Array) => Observable<u32>, [Bytes]> &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      farmID: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      farmIdByName: AugmentedQuery<ApiType, (arg: Bytes | string | Uint8Array) => Observable<u32>, [Bytes]> &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      farmingPoliciesMap: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<PalletTfgridFarmingPolicy>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      farmingPolicyID: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      farmPayoutV2AddressByFarmID: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Bytes>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      farms: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<TfchainSupportFarm>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      nodeID: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      nodeIdByTwinID: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<u32>, [u32]> &
+        QueryableStorageEntry<ApiType, [u32]>;
+      nodePower: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<TfchainSupportNodePower>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      nodes: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<TfchainSupportNode>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      nodesByFarmID: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<Vec<u32>>, [u32]> &
+        QueryableStorageEntry<ApiType, [u32]>;
+      palletVersion: AugmentedQuery<ApiType, () => Observable<PalletTfgridStorageVersion>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      pricingPolicies: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<PalletTfgridPricingPolicy>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      pricingPolicyID: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      pricingPolicyIdByName: AugmentedQuery<ApiType, (arg: Bytes | string | Uint8Array) => Observable<u32>, [Bytes]> &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      twinBoundedAccountID: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<AccountId32>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      twinID: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      twinIdByAccountID: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Option<u32>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      twins: AugmentedQuery<
+        ApiType,
+        (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<PalletTfgridTwin>>,
+        [u32]
+      > &
+        QueryableStorageEntry<ApiType, [u32]>;
+      usersTermsAndConditions: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Option<Vec<PalletTfgridTermsCondTermsAndConditions>>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      zosVersion: AugmentedQuery<ApiType, () => Observable<Bytes>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    tfkvStore: {
+      tfkvStore: AugmentedQuery<
+        ApiType,
+        (arg1: AccountId32 | string | Uint8Array, arg2: Bytes | string | Uint8Array) => Observable<Bytes>,
+        [AccountId32, Bytes]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32, Bytes]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    tftBridgeModule: {
+      burnTransactionID: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      burnTransactions: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<PalletTftBridgeBurnTransaction>>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      depositFee: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      executedBurnTransactions: AugmentedQuery<
+        ApiType,
+        (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<PalletTftBridgeBurnTransaction>>,
+        [u64]
+      > &
+        QueryableStorageEntry<ApiType, [u64]>;
+      executedMintTransactions: AugmentedQuery<
+        ApiType,
+        (arg: Bytes | string | Uint8Array) => Observable<Option<PalletTftBridgeMintTransaction>>,
+        [Bytes]
+      > &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      executedRefundTransactions: AugmentedQuery<
+        ApiType,
+        (arg: Bytes | string | Uint8Array) => Observable<PalletTftBridgeRefundTransaction>,
+        [Bytes]
+      > &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      feeAccount: AugmentedQuery<ApiType, () => Observable<Option<AccountId32>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      mintTransactions: AugmentedQuery<
+        ApiType,
+        (arg: Bytes | string | Uint8Array) => Observable<Option<PalletTftBridgeMintTransaction>>,
+        [Bytes]
+      > &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      palletVersion: AugmentedQuery<ApiType, () => Observable<PalletTftBridgeStorageVersion>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      refundTransactions: AugmentedQuery<
+        ApiType,
+        (arg: Bytes | string | Uint8Array) => Observable<PalletTftBridgeRefundTransaction>,
+        [Bytes]
+      > &
+        QueryableStorageEntry<ApiType, [Bytes]>;
+      validators: AugmentedQuery<ApiType, () => Observable<Vec<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      withdrawFee: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    tftPriceModule: {
+      averageTftPrice: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      bufferRange: AugmentedQuery<ApiType, () => Observable<ITuple<[u16, u16]>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      lastBlockSet: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      maxTftPrice: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      minTftPrice: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      tftPrice: AugmentedQuery<ApiType, () => Observable<u32>, []> & QueryableStorageEntry<ApiType, []>;
+      tftPriceHistory: AugmentedQuery<ApiType, (arg: u16 | AnyNumber | Uint8Array) => Observable<u32>, [u16]> &
+        QueryableStorageEntry<ApiType, [u16]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    timestamp: {
+      /**
+       * Did the timestamp get updated in this block?
+       **/
+      didUpdate: AugmentedQuery<ApiType, () => Observable<bool>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Current time for the current block.
+       **/
+      now: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    transactionPayment: {
+      nextFeeMultiplier: AugmentedQuery<ApiType, () => Observable<u128>, []> & QueryableStorageEntry<ApiType, []>;
+      storageVersion: AugmentedQuery<ApiType, () => Observable<PalletTransactionPaymentReleases>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    validator: {
+      bonded: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Option<AccountId32>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      validator: AugmentedQuery<
+        ApiType,
+        (arg: AccountId32 | string | Uint8Array) => Observable<Option<PalletValidatorValidator>>,
+        [AccountId32]
+      > &
+        QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    validatorSet: {
+      approvedValidators: AugmentedQuery<ApiType, () => Observable<Vec<AccountId32>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      offlineValidators: AugmentedQuery<ApiType, () => Observable<Vec<AccountId32>>, []> &
+        QueryableStorageEntry<ApiType, []>;
+      validators: AugmentedQuery<ApiType, () => Observable<Vec<AccountId32>>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+  } // AugmentedQueries
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/augment-api-rpc.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api-rpc.ts
@@ -1,0 +1,990 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/rpc-core/types/jsonrpc";
+
+import type { AugmentedRpc } from "@polkadot/rpc-core/types";
+import type { Metadata, StorageKey } from "@polkadot/types";
+import type {
+  Bytes,
+  HashMap,
+  Json,
+  Null,
+  Option,
+  Text,
+  U256,
+  U64,
+  Vec,
+  bool,
+  f64,
+  u32,
+  u64,
+} from "@polkadot/types-codec";
+import type { AnyNumber, Codec } from "@polkadot/types-codec/types";
+import type { ExtrinsicOrHash, ExtrinsicStatus } from "@polkadot/types/interfaces/author";
+import type { EpochAuthorship } from "@polkadot/types/interfaces/babe";
+import type { BeefySignedCommitment } from "@polkadot/types/interfaces/beefy";
+import type { BlockHash } from "@polkadot/types/interfaces/chain";
+import type { PrefixedStorageKey } from "@polkadot/types/interfaces/childstate";
+import type { AuthorityId } from "@polkadot/types/interfaces/consensus";
+import type {
+  CodeUploadRequest,
+  CodeUploadResult,
+  ContractCallRequest,
+  ContractExecResult,
+  ContractInstantiateResult,
+  InstantiateRequest,
+} from "@polkadot/types/interfaces/contracts";
+import type { BlockStats } from "@polkadot/types/interfaces/dev";
+import type { CreatedBlock } from "@polkadot/types/interfaces/engine";
+import type {
+  EthAccount,
+  EthCallRequest,
+  EthFeeHistory,
+  EthFilter,
+  EthFilterChanges,
+  EthLog,
+  EthReceipt,
+  EthRichBlock,
+  EthSubKind,
+  EthSubParams,
+  EthSyncStatus,
+  EthTransaction,
+  EthTransactionRequest,
+  EthWork,
+} from "@polkadot/types/interfaces/eth";
+import type { Extrinsic } from "@polkadot/types/interfaces/extrinsics";
+import type {
+  EncodedFinalityProofs,
+  JustificationNotification,
+  ReportedRoundStates,
+} from "@polkadot/types/interfaces/grandpa";
+import type { MmrLeafBatchProof, MmrLeafProof } from "@polkadot/types/interfaces/mmr";
+import type { StorageKind } from "@polkadot/types/interfaces/offchain";
+import type { FeeDetails, RuntimeDispatchInfo } from "@polkadot/types/interfaces/payment";
+import type { RpcMethods } from "@polkadot/types/interfaces/rpc";
+import type {
+  AccountId,
+  BlockNumber,
+  H160,
+  H256,
+  H64,
+  Hash,
+  Header,
+  Index,
+  Justification,
+  KeyValue,
+  SignedBlock,
+  StorageData,
+} from "@polkadot/types/interfaces/runtime";
+import type {
+  MigrationStatusResult,
+  ReadProof,
+  RuntimeVersion,
+  TraceBlockResponse,
+} from "@polkadot/types/interfaces/state";
+import type {
+  ApplyExtrinsicResult,
+  ChainProperties,
+  ChainType,
+  Health,
+  NetworkState,
+  NodeRole,
+  PeerInfo,
+  SyncState,
+} from "@polkadot/types/interfaces/system";
+import type { IExtrinsic, Observable } from "@polkadot/types/types";
+
+export type __AugmentedRpc = AugmentedRpc<() => unknown>;
+
+declare module "@polkadot/rpc-core/types/jsonrpc" {
+  interface RpcInterface {
+    author: {
+      /**
+       * Returns true if the keystore has private keys for the given public key and key type.
+       **/
+      hasKey: AugmentedRpc<(publicKey: Bytes | string | Uint8Array, keyType: Text | string) => Observable<bool>>;
+      /**
+       * Returns true if the keystore has private keys for the given session public keys.
+       **/
+      hasSessionKeys: AugmentedRpc<(sessionKeys: Bytes | string | Uint8Array) => Observable<bool>>;
+      /**
+       * Insert a key into the keystore.
+       **/
+      insertKey: AugmentedRpc<
+        (keyType: Text | string, suri: Text | string, publicKey: Bytes | string | Uint8Array) => Observable<Bytes>
+      >;
+      /**
+       * Returns all pending extrinsics, potentially grouped by sender
+       **/
+      pendingExtrinsics: AugmentedRpc<() => Observable<Vec<Extrinsic>>>;
+      /**
+       * Remove given extrinsic from the pool and temporarily ban it to prevent reimporting
+       **/
+      removeExtrinsic: AugmentedRpc<
+        (
+          bytesOrHash:
+            | Vec<ExtrinsicOrHash>
+            | (ExtrinsicOrHash | { Hash: any } | { Extrinsic: any } | string | Uint8Array)[],
+        ) => Observable<Vec<Hash>>
+      >;
+      /**
+       * Generate new session keys and returns the corresponding public keys
+       **/
+      rotateKeys: AugmentedRpc<() => Observable<Bytes>>;
+      /**
+       * Submit and subscribe to watch an extrinsic until unsubscribed
+       **/
+      submitAndWatchExtrinsic: AugmentedRpc<
+        (extrinsic: Extrinsic | IExtrinsic | string | Uint8Array) => Observable<ExtrinsicStatus>
+      >;
+      /**
+       * Submit a fully formatted extrinsic for block inclusion
+       **/
+      submitExtrinsic: AugmentedRpc<(extrinsic: Extrinsic | IExtrinsic | string | Uint8Array) => Observable<Hash>>;
+    };
+    babe: {
+      /**
+       * Returns data about which slots (primary or secondary) can be claimed in the current epoch with the keys in the keystore
+       **/
+      epochAuthorship: AugmentedRpc<() => Observable<HashMap<AuthorityId, EpochAuthorship>>>;
+    };
+    beefy: {
+      /**
+       * Returns hash of the latest BEEFY finalized block as seen by this client.
+       **/
+      getFinalizedHead: AugmentedRpc<() => Observable<H256>>;
+      /**
+       * Returns the block most recently finalized by BEEFY, alongside side its justification.
+       **/
+      subscribeJustifications: AugmentedRpc<() => Observable<BeefySignedCommitment>>;
+    };
+    chain: {
+      /**
+       * Get header and body of a relay chain block
+       **/
+      getBlock: AugmentedRpc<(hash?: BlockHash | string | Uint8Array) => Observable<SignedBlock>>;
+      /**
+       * Get the block hash for a specific block
+       **/
+      getBlockHash: AugmentedRpc<(blockNumber?: BlockNumber | AnyNumber | Uint8Array) => Observable<BlockHash>>;
+      /**
+       * Get hash of the last finalized block in the canon chain
+       **/
+      getFinalizedHead: AugmentedRpc<() => Observable<BlockHash>>;
+      /**
+       * Retrieves the header for a specific block
+       **/
+      getHeader: AugmentedRpc<(hash?: BlockHash | string | Uint8Array) => Observable<Header>>;
+      /**
+       * Retrieves the newest header via subscription
+       **/
+      subscribeAllHeads: AugmentedRpc<() => Observable<Header>>;
+      /**
+       * Retrieves the best finalized header via subscription
+       **/
+      subscribeFinalizedHeads: AugmentedRpc<() => Observable<Header>>;
+      /**
+       * Retrieves the best header via subscription
+       **/
+      subscribeNewHeads: AugmentedRpc<() => Observable<Header>>;
+    };
+    childstate: {
+      /**
+       * Returns the keys with prefix from a child storage, leave empty to get all the keys
+       **/
+      getKeys: AugmentedRpc<
+        (
+          childKey: PrefixedStorageKey | string | Uint8Array,
+          prefix: StorageKey | string | Uint8Array | any,
+          at?: Hash | string | Uint8Array,
+        ) => Observable<Vec<StorageKey>>
+      >;
+      /**
+       * Returns the keys with prefix from a child storage with pagination support
+       **/
+      getKeysPaged: AugmentedRpc<
+        (
+          childKey: PrefixedStorageKey | string | Uint8Array,
+          prefix: StorageKey | string | Uint8Array | any,
+          count: u32 | AnyNumber | Uint8Array,
+          startKey?: StorageKey | string | Uint8Array | any,
+          at?: Hash | string | Uint8Array,
+        ) => Observable<Vec<StorageKey>>
+      >;
+      /**
+       * Returns a child storage entry at a specific block state
+       **/
+      getStorage: AugmentedRpc<
+        (
+          childKey: PrefixedStorageKey | string | Uint8Array,
+          key: StorageKey | string | Uint8Array | any,
+          at?: Hash | string | Uint8Array,
+        ) => Observable<Option<StorageData>>
+      >;
+      /**
+       * Returns child storage entries for multiple keys at a specific block state
+       **/
+      getStorageEntries: AugmentedRpc<
+        (
+          childKey: PrefixedStorageKey | string | Uint8Array,
+          keys: Vec<StorageKey> | (StorageKey | string | Uint8Array | any)[],
+          at?: Hash | string | Uint8Array,
+        ) => Observable<Vec<Option<StorageData>>>
+      >;
+      /**
+       * Returns the hash of a child storage entry at a block state
+       **/
+      getStorageHash: AugmentedRpc<
+        (
+          childKey: PrefixedStorageKey | string | Uint8Array,
+          key: StorageKey | string | Uint8Array | any,
+          at?: Hash | string | Uint8Array,
+        ) => Observable<Option<Hash>>
+      >;
+      /**
+       * Returns the size of a child storage entry at a block state
+       **/
+      getStorageSize: AugmentedRpc<
+        (
+          childKey: PrefixedStorageKey | string | Uint8Array,
+          key: StorageKey | string | Uint8Array | any,
+          at?: Hash | string | Uint8Array,
+        ) => Observable<Option<u64>>
+      >;
+    };
+    contracts: {
+      /**
+       * Executes a call to a contract
+       **/
+      call: AugmentedRpc<
+        (
+          callRequest:
+            | ContractCallRequest
+            | { origin?: any; dest?: any; value?: any; gasLimit?: any; storageDepositLimit?: any; inputData?: any }
+            | string
+            | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<ContractExecResult>
+      >;
+      /**
+       * Returns the value under a specified storage key in a contract
+       **/
+      getStorage: AugmentedRpc<
+        (
+          address: AccountId | string | Uint8Array,
+          key: H256 | string | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Option<Bytes>>
+      >;
+      /**
+       * Instantiate a new contract
+       **/
+      instantiate: AugmentedRpc<
+        (
+          request:
+            | InstantiateRequest
+            | {
+                origin?: any;
+                value?: any;
+                gasLimit?: any;
+                storageDepositLimit?: any;
+                code?: any;
+                data?: any;
+                salt?: any;
+              }
+            | string
+            | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<ContractInstantiateResult>
+      >;
+      /**
+       * Returns the projected time a given contract will be able to sustain paying its rent
+       **/
+      rentProjection: AugmentedRpc<
+        (
+          address: AccountId | string | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Option<BlockNumber>>
+      >;
+      /**
+       * Upload new code without instantiating a contract from it
+       **/
+      uploadCode: AugmentedRpc<
+        (
+          uploadRequest:
+            | CodeUploadRequest
+            | { origin?: any; code?: any; storageDepositLimit?: any }
+            | string
+            | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<CodeUploadResult>
+      >;
+    };
+    dev: {
+      /**
+       * Reexecute the specified `block_hash` and gather statistics while doing so
+       **/
+      getBlockStats: AugmentedRpc<(at: Hash | string | Uint8Array) => Observable<Option<BlockStats>>>;
+    };
+    engine: {
+      /**
+       * Instructs the manual-seal authorship task to create a new block
+       **/
+      createBlock: AugmentedRpc<
+        (
+          createEmpty: bool | boolean | Uint8Array,
+          finalize: bool | boolean | Uint8Array,
+          parentHash?: BlockHash | string | Uint8Array,
+        ) => Observable<CreatedBlock>
+      >;
+      /**
+       * Instructs the manual-seal authorship task to finalize a block
+       **/
+      finalizeBlock: AugmentedRpc<
+        (hash: BlockHash | string | Uint8Array, justification?: Justification) => Observable<bool>
+      >;
+    };
+    eth: {
+      /**
+       * Returns accounts list.
+       **/
+      accounts: AugmentedRpc<() => Observable<Vec<H160>>>;
+      /**
+       * Returns the blockNumber
+       **/
+      blockNumber: AugmentedRpc<() => Observable<U256>>;
+      /**
+       * Call contract, returning the output data.
+       **/
+      call: AugmentedRpc<
+        (
+          request:
+            | EthCallRequest
+            | { from?: any; to?: any; gasPrice?: any; gas?: any; value?: any; data?: any; nonce?: any }
+            | string
+            | Uint8Array,
+          number?: BlockNumber | AnyNumber | Uint8Array,
+        ) => Observable<Bytes>
+      >;
+      /**
+       * Returns the chain ID used for transaction signing at the current best block. None is returned if not available.
+       **/
+      chainId: AugmentedRpc<() => Observable<U64>>;
+      /**
+       * Returns block author.
+       **/
+      coinbase: AugmentedRpc<() => Observable<H160>>;
+      /**
+       * Estimate gas needed for execution of given contract.
+       **/
+      estimateGas: AugmentedRpc<
+        (
+          request:
+            | EthCallRequest
+            | { from?: any; to?: any; gasPrice?: any; gas?: any; value?: any; data?: any; nonce?: any }
+            | string
+            | Uint8Array,
+          number?: BlockNumber | AnyNumber | Uint8Array,
+        ) => Observable<U256>
+      >;
+      /**
+       * Returns fee history for given block count & reward percentiles
+       **/
+      feeHistory: AugmentedRpc<
+        (
+          blockCount: U256 | AnyNumber | Uint8Array,
+          newestBlock: BlockNumber | AnyNumber | Uint8Array,
+          rewardPercentiles: Option<Vec<f64>> | null | Uint8Array | Vec<f64> | f64[],
+        ) => Observable<EthFeeHistory>
+      >;
+      /**
+       * Returns current gas price.
+       **/
+      gasPrice: AugmentedRpc<() => Observable<U256>>;
+      /**
+       * Returns balance of the given account.
+       **/
+      getBalance: AugmentedRpc<
+        (address: H160 | string | Uint8Array, number?: BlockNumber | AnyNumber | Uint8Array) => Observable<U256>
+      >;
+      /**
+       * Returns block with given hash.
+       **/
+      getBlockByHash: AugmentedRpc<
+        (hash: H256 | string | Uint8Array, full: bool | boolean | Uint8Array) => Observable<Option<EthRichBlock>>
+      >;
+      /**
+       * Returns block with given number.
+       **/
+      getBlockByNumber: AugmentedRpc<
+        (
+          block: BlockNumber | AnyNumber | Uint8Array,
+          full: bool | boolean | Uint8Array,
+        ) => Observable<Option<EthRichBlock>>
+      >;
+      /**
+       * Returns the number of transactions in a block with given hash.
+       **/
+      getBlockTransactionCountByHash: AugmentedRpc<(hash: H256 | string | Uint8Array) => Observable<U256>>;
+      /**
+       * Returns the number of transactions in a block with given block number.
+       **/
+      getBlockTransactionCountByNumber: AugmentedRpc<(block: BlockNumber | AnyNumber | Uint8Array) => Observable<U256>>;
+      /**
+       * Returns the code at given address at given time (block number).
+       **/
+      getCode: AugmentedRpc<
+        (address: H160 | string | Uint8Array, number?: BlockNumber | AnyNumber | Uint8Array) => Observable<Bytes>
+      >;
+      /**
+       * Returns filter changes since last poll.
+       **/
+      getFilterChanges: AugmentedRpc<(index: U256 | AnyNumber | Uint8Array) => Observable<EthFilterChanges>>;
+      /**
+       * Returns all logs matching given filter (in a range 'from' - 'to').
+       **/
+      getFilterLogs: AugmentedRpc<(index: U256 | AnyNumber | Uint8Array) => Observable<Vec<EthLog>>>;
+      /**
+       * Returns logs matching given filter object.
+       **/
+      getLogs: AugmentedRpc<
+        (
+          filter:
+            | EthFilter
+            | { fromBlock?: any; toBlock?: any; blockHash?: any; address?: any; topics?: any }
+            | string
+            | Uint8Array,
+        ) => Observable<Vec<EthLog>>
+      >;
+      /**
+       * Returns proof for account and storage.
+       **/
+      getProof: AugmentedRpc<
+        (
+          address: H160 | string | Uint8Array,
+          storageKeys: Vec<H256> | (H256 | string | Uint8Array)[],
+          number: BlockNumber | AnyNumber | Uint8Array,
+        ) => Observable<EthAccount>
+      >;
+      /**
+       * Returns content of the storage at given address.
+       **/
+      getStorageAt: AugmentedRpc<
+        (
+          address: H160 | string | Uint8Array,
+          index: U256 | AnyNumber | Uint8Array,
+          number?: BlockNumber | AnyNumber | Uint8Array,
+        ) => Observable<H256>
+      >;
+      /**
+       * Returns transaction at given block hash and index.
+       **/
+      getTransactionByBlockHashAndIndex: AugmentedRpc<
+        (hash: H256 | string | Uint8Array, index: U256 | AnyNumber | Uint8Array) => Observable<EthTransaction>
+      >;
+      /**
+       * Returns transaction by given block number and index.
+       **/
+      getTransactionByBlockNumberAndIndex: AugmentedRpc<
+        (
+          number: BlockNumber | AnyNumber | Uint8Array,
+          index: U256 | AnyNumber | Uint8Array,
+        ) => Observable<EthTransaction>
+      >;
+      /**
+       * Get transaction by its hash.
+       **/
+      getTransactionByHash: AugmentedRpc<(hash: H256 | string | Uint8Array) => Observable<EthTransaction>>;
+      /**
+       * Returns the number of transactions sent from given address at given time (block number).
+       **/
+      getTransactionCount: AugmentedRpc<
+        (hash: H256 | string | Uint8Array, number?: BlockNumber | AnyNumber | Uint8Array) => Observable<U256>
+      >;
+      /**
+       * Returns transaction receipt by transaction hash.
+       **/
+      getTransactionReceipt: AugmentedRpc<(hash: H256 | string | Uint8Array) => Observable<EthReceipt>>;
+      /**
+       * Returns an uncles at given block and index.
+       **/
+      getUncleByBlockHashAndIndex: AugmentedRpc<
+        (hash: H256 | string | Uint8Array, index: U256 | AnyNumber | Uint8Array) => Observable<EthRichBlock>
+      >;
+      /**
+       * Returns an uncles at given block and index.
+       **/
+      getUncleByBlockNumberAndIndex: AugmentedRpc<
+        (number: BlockNumber | AnyNumber | Uint8Array, index: U256 | AnyNumber | Uint8Array) => Observable<EthRichBlock>
+      >;
+      /**
+       * Returns the number of uncles in a block with given hash.
+       **/
+      getUncleCountByBlockHash: AugmentedRpc<(hash: H256 | string | Uint8Array) => Observable<U256>>;
+      /**
+       * Returns the number of uncles in a block with given block number.
+       **/
+      getUncleCountByBlockNumber: AugmentedRpc<(number: BlockNumber | AnyNumber | Uint8Array) => Observable<U256>>;
+      /**
+       * Returns the hash of the current block, the seedHash, and the boundary condition to be met.
+       **/
+      getWork: AugmentedRpc<() => Observable<EthWork>>;
+      /**
+       * Returns the number of hashes per second that the node is mining with.
+       **/
+      hashrate: AugmentedRpc<() => Observable<U256>>;
+      /**
+       * Returns max priority fee per gas
+       **/
+      maxPriorityFeePerGas: AugmentedRpc<() => Observable<U256>>;
+      /**
+       * Returns true if client is actively mining new blocks.
+       **/
+      mining: AugmentedRpc<() => Observable<bool>>;
+      /**
+       * Returns id of new block filter.
+       **/
+      newBlockFilter: AugmentedRpc<() => Observable<U256>>;
+      /**
+       * Returns id of new filter.
+       **/
+      newFilter: AugmentedRpc<
+        (
+          filter:
+            | EthFilter
+            | { fromBlock?: any; toBlock?: any; blockHash?: any; address?: any; topics?: any }
+            | string
+            | Uint8Array,
+        ) => Observable<U256>
+      >;
+      /**
+       * Returns id of new block filter.
+       **/
+      newPendingTransactionFilter: AugmentedRpc<() => Observable<U256>>;
+      /**
+       * Returns protocol version encoded as a string (quotes are necessary).
+       **/
+      protocolVersion: AugmentedRpc<() => Observable<u64>>;
+      /**
+       * Sends signed transaction, returning its hash.
+       **/
+      sendRawTransaction: AugmentedRpc<(bytes: Bytes | string | Uint8Array) => Observable<H256>>;
+      /**
+       * Sends transaction; will block waiting for signer to return the transaction hash
+       **/
+      sendTransaction: AugmentedRpc<
+        (
+          tx:
+            | EthTransactionRequest
+            | { from?: any; to?: any; gasPrice?: any; gas?: any; value?: any; data?: any; nonce?: any }
+            | string
+            | Uint8Array,
+        ) => Observable<H256>
+      >;
+      /**
+       * Used for submitting mining hashrate.
+       **/
+      submitHashrate: AugmentedRpc<
+        (index: U256 | AnyNumber | Uint8Array, hash: H256 | string | Uint8Array) => Observable<bool>
+      >;
+      /**
+       * Used for submitting a proof-of-work solution.
+       **/
+      submitWork: AugmentedRpc<
+        (
+          nonce: H64 | string | Uint8Array,
+          headerHash: H256 | string | Uint8Array,
+          mixDigest: H256 | string | Uint8Array,
+        ) => Observable<bool>
+      >;
+      /**
+       * Subscribe to Eth subscription.
+       **/
+      subscribe: AugmentedRpc<
+        (
+          kind: EthSubKind | "newHeads" | "logs" | "newPendingTransactions" | "syncing" | number | Uint8Array,
+          params?: EthSubParams | { None: any } | { Logs: any } | string | Uint8Array,
+        ) => Observable<Null>
+      >;
+      /**
+       * Returns an object with data about the sync status or false.
+       **/
+      syncing: AugmentedRpc<() => Observable<EthSyncStatus>>;
+      /**
+       * Uninstalls filter.
+       **/
+      uninstallFilter: AugmentedRpc<(index: U256 | AnyNumber | Uint8Array) => Observable<bool>>;
+    };
+    grandpa: {
+      /**
+       * Prove finality for the given block number, returning the Justification for the last block in the set.
+       **/
+      proveFinality: AugmentedRpc<
+        (blockNumber: BlockNumber | AnyNumber | Uint8Array) => Observable<Option<EncodedFinalityProofs>>
+      >;
+      /**
+       * Returns the state of the current best round state as well as the ongoing background rounds
+       **/
+      roundState: AugmentedRpc<() => Observable<ReportedRoundStates>>;
+      /**
+       * Subscribes to grandpa justifications
+       **/
+      subscribeJustifications: AugmentedRpc<() => Observable<JustificationNotification>>;
+    };
+    mmr: {
+      /**
+       * Generate MMR proof for the given leaf indices.
+       **/
+      generateBatchProof: AugmentedRpc<
+        (
+          leafIndices: Vec<u64> | (u64 | AnyNumber | Uint8Array)[],
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<MmrLeafProof>
+      >;
+      /**
+       * Generate MMR proof for given leaf index.
+       **/
+      generateProof: AugmentedRpc<
+        (leafIndex: u64 | AnyNumber | Uint8Array, at?: BlockHash | string | Uint8Array) => Observable<MmrLeafBatchProof>
+      >;
+    };
+    net: {
+      /**
+       * Returns true if client is actively listening for network connections. Otherwise false.
+       **/
+      listening: AugmentedRpc<() => Observable<bool>>;
+      /**
+       * Returns number of peers connected to node.
+       **/
+      peerCount: AugmentedRpc<() => Observable<Text>>;
+      /**
+       * Returns protocol version.
+       **/
+      version: AugmentedRpc<() => Observable<Text>>;
+    };
+    offchain: {
+      /**
+       * Get offchain local storage under given key and prefix
+       **/
+      localStorageGet: AugmentedRpc<
+        (
+          kind: StorageKind | "PERSISTENT" | "LOCAL" | number | Uint8Array,
+          key: Bytes | string | Uint8Array,
+        ) => Observable<Option<Bytes>>
+      >;
+      /**
+       * Set offchain local storage under given key and prefix
+       **/
+      localStorageSet: AugmentedRpc<
+        (
+          kind: StorageKind | "PERSISTENT" | "LOCAL" | number | Uint8Array,
+          key: Bytes | string | Uint8Array,
+          value: Bytes | string | Uint8Array,
+        ) => Observable<Null>
+      >;
+    };
+    payment: {
+      /**
+       * Query the detailed fee of a given encoded extrinsic
+       **/
+      queryFeeDetails: AugmentedRpc<
+        (extrinsic: Bytes | string | Uint8Array, at?: BlockHash | string | Uint8Array) => Observable<FeeDetails>
+      >;
+      /**
+       * Retrieves the fee information for an encoded extrinsic
+       **/
+      queryInfo: AugmentedRpc<
+        (
+          extrinsic: Bytes | string | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<RuntimeDispatchInfo>
+      >;
+    };
+    rpc: {
+      /**
+       * Retrieves the list of RPC methods that are exposed by the node
+       **/
+      methods: AugmentedRpc<() => Observable<RpcMethods>>;
+    };
+    state: {
+      /**
+       * Perform a call to a builtin on the chain
+       **/
+      call: AugmentedRpc<
+        (
+          method: Text | string,
+          data: Bytes | string | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Bytes>
+      >;
+      /**
+       * Retrieves the keys with prefix of a specific child storage
+       **/
+      getChildKeys: AugmentedRpc<
+        (
+          childStorageKey: StorageKey | string | Uint8Array | any,
+          childDefinition: StorageKey | string | Uint8Array | any,
+          childType: u32 | AnyNumber | Uint8Array,
+          key: StorageKey | string | Uint8Array | any,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Vec<StorageKey>>
+      >;
+      /**
+       * Returns proof of storage for child key entries at a specific block state.
+       **/
+      getChildReadProof: AugmentedRpc<
+        (
+          childStorageKey: PrefixedStorageKey | string | Uint8Array,
+          keys: Vec<StorageKey> | (StorageKey | string | Uint8Array | any)[],
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<ReadProof>
+      >;
+      /**
+       * Retrieves the child storage for a key
+       **/
+      getChildStorage: AugmentedRpc<
+        (
+          childStorageKey: StorageKey | string | Uint8Array | any,
+          childDefinition: StorageKey | string | Uint8Array | any,
+          childType: u32 | AnyNumber | Uint8Array,
+          key: StorageKey | string | Uint8Array | any,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<StorageData>
+      >;
+      /**
+       * Retrieves the child storage hash
+       **/
+      getChildStorageHash: AugmentedRpc<
+        (
+          childStorageKey: StorageKey | string | Uint8Array | any,
+          childDefinition: StorageKey | string | Uint8Array | any,
+          childType: u32 | AnyNumber | Uint8Array,
+          key: StorageKey | string | Uint8Array | any,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Hash>
+      >;
+      /**
+       * Retrieves the child storage size
+       **/
+      getChildStorageSize: AugmentedRpc<
+        (
+          childStorageKey: StorageKey | string | Uint8Array | any,
+          childDefinition: StorageKey | string | Uint8Array | any,
+          childType: u32 | AnyNumber | Uint8Array,
+          key: StorageKey | string | Uint8Array | any,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<u64>
+      >;
+      /**
+       * Retrieves the keys with a certain prefix
+       **/
+      getKeys: AugmentedRpc<
+        (
+          key: StorageKey | string | Uint8Array | any,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Vec<StorageKey>>
+      >;
+      /**
+       * Returns the keys with prefix with pagination support.
+       **/
+      getKeysPaged: AugmentedRpc<
+        (
+          key: StorageKey | string | Uint8Array | any,
+          count: u32 | AnyNumber | Uint8Array,
+          startKey?: StorageKey | string | Uint8Array | any,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Vec<StorageKey>>
+      >;
+      /**
+       * Returns the runtime metadata
+       **/
+      getMetadata: AugmentedRpc<(at?: BlockHash | string | Uint8Array) => Observable<Metadata>>;
+      /**
+       * Returns the keys with prefix, leave empty to get all the keys (deprecated: Use getKeysPaged)
+       **/
+      getPairs: AugmentedRpc<
+        (
+          prefix: StorageKey | string | Uint8Array | any,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<Vec<KeyValue>>
+      >;
+      /**
+       * Returns proof of storage entries at a specific block state
+       **/
+      getReadProof: AugmentedRpc<
+        (
+          keys: Vec<StorageKey> | (StorageKey | string | Uint8Array | any)[],
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<ReadProof>
+      >;
+      /**
+       * Get the runtime version
+       **/
+      getRuntimeVersion: AugmentedRpc<(at?: BlockHash | string | Uint8Array) => Observable<RuntimeVersion>>;
+      /**
+       * Retrieves the storage for a key
+       **/
+      getStorage: AugmentedRpc<
+        <T = Codec>(key: StorageKey | string | Uint8Array | any, block?: Hash | Uint8Array | string) => Observable<T>
+      >;
+      /**
+       * Retrieves the storage hash
+       **/
+      getStorageHash: AugmentedRpc<
+        (key: StorageKey | string | Uint8Array | any, at?: BlockHash | string | Uint8Array) => Observable<Hash>
+      >;
+      /**
+       * Retrieves the storage size
+       **/
+      getStorageSize: AugmentedRpc<
+        (key: StorageKey | string | Uint8Array | any, at?: BlockHash | string | Uint8Array) => Observable<u64>
+      >;
+      /**
+       * Query historical storage entries (by key) starting from a start block
+       **/
+      queryStorage: AugmentedRpc<
+        <T = Codec[]>(
+          keys: Vec<StorageKey> | (StorageKey | string | Uint8Array | any)[],
+          fromBlock?: Hash | Uint8Array | string,
+          toBlock?: Hash | Uint8Array | string,
+        ) => Observable<[Hash, T][]>
+      >;
+      /**
+       * Query storage entries (by key) starting at block hash given as the second parameter
+       **/
+      queryStorageAt: AugmentedRpc<
+        <T = Codec[]>(
+          keys: Vec<StorageKey> | (StorageKey | string | Uint8Array | any)[],
+          at?: Hash | Uint8Array | string,
+        ) => Observable<T>
+      >;
+      /**
+       * Retrieves the runtime version via subscription
+       **/
+      subscribeRuntimeVersion: AugmentedRpc<() => Observable<RuntimeVersion>>;
+      /**
+       * Subscribes to storage changes for the provided keys
+       **/
+      subscribeStorage: AugmentedRpc<
+        <T = Codec[]>(keys?: Vec<StorageKey> | (StorageKey | string | Uint8Array | any)[]) => Observable<T>
+      >;
+      /**
+       * Provides a way to trace the re-execution of a single block
+       **/
+      traceBlock: AugmentedRpc<
+        (
+          block: Hash | string | Uint8Array,
+          targets: Option<Text> | null | Uint8Array | Text | string,
+          storageKeys: Option<Text> | null | Uint8Array | Text | string,
+          methods: Option<Text> | null | Uint8Array | Text | string,
+        ) => Observable<TraceBlockResponse>
+      >;
+      /**
+       * Check current migration state
+       **/
+      trieMigrationStatus: AugmentedRpc<(at?: BlockHash | string | Uint8Array) => Observable<MigrationStatusResult>>;
+    };
+    syncstate: {
+      /**
+       * Returns the json-serialized chainspec running the node, with a sync state.
+       **/
+      genSyncSpec: AugmentedRpc<(raw: bool | boolean | Uint8Array) => Observable<Json>>;
+    };
+    system: {
+      /**
+       * Retrieves the next accountIndex as available on the node
+       **/
+      accountNextIndex: AugmentedRpc<(accountId: AccountId | string | Uint8Array) => Observable<Index>>;
+      /**
+       * Adds the supplied directives to the current log filter
+       **/
+      addLogFilter: AugmentedRpc<(directives: Text | string) => Observable<Null>>;
+      /**
+       * Adds a reserved peer
+       **/
+      addReservedPeer: AugmentedRpc<(peer: Text | string) => Observable<Text>>;
+      /**
+       * Retrieves the chain
+       **/
+      chain: AugmentedRpc<() => Observable<Text>>;
+      /**
+       * Retrieves the chain type
+       **/
+      chainType: AugmentedRpc<() => Observable<ChainType>>;
+      /**
+       * Dry run an extrinsic at a given block
+       **/
+      dryRun: AugmentedRpc<
+        (
+          extrinsic: Bytes | string | Uint8Array,
+          at?: BlockHash | string | Uint8Array,
+        ) => Observable<ApplyExtrinsicResult>
+      >;
+      /**
+       * Return health status of the node
+       **/
+      health: AugmentedRpc<() => Observable<Health>>;
+      /**
+       * The addresses include a trailing /p2p/ with the local PeerId, and are thus suitable to be passed to addReservedPeer or as a bootnode address for example
+       **/
+      localListenAddresses: AugmentedRpc<() => Observable<Vec<Text>>>;
+      /**
+       * Returns the base58-encoded PeerId of the node
+       **/
+      localPeerId: AugmentedRpc<() => Observable<Text>>;
+      /**
+       * Retrieves the node name
+       **/
+      name: AugmentedRpc<() => Observable<Text>>;
+      /**
+       * Returns current state of the network
+       **/
+      networkState: AugmentedRpc<() => Observable<NetworkState>>;
+      /**
+       * Returns the roles the node is running as
+       **/
+      nodeRoles: AugmentedRpc<() => Observable<Vec<NodeRole>>>;
+      /**
+       * Returns the currently connected peers
+       **/
+      peers: AugmentedRpc<() => Observable<Vec<PeerInfo>>>;
+      /**
+       * Get a custom set of properties as a JSON object, defined in the chain spec
+       **/
+      properties: AugmentedRpc<() => Observable<ChainProperties>>;
+      /**
+       * Remove a reserved peer
+       **/
+      removeReservedPeer: AugmentedRpc<(peerId: Text | string) => Observable<Text>>;
+      /**
+       * Returns the list of reserved peers
+       **/
+      reservedPeers: AugmentedRpc<() => Observable<Vec<Text>>>;
+      /**
+       * Resets the log filter to Substrate defaults
+       **/
+      resetLogFilter: AugmentedRpc<() => Observable<Null>>;
+      /**
+       * Returns the state of the syncing of the node
+       **/
+      syncState: AugmentedRpc<() => Observable<SyncState>>;
+      /**
+       * Retrieves the version of the node
+       **/
+      version: AugmentedRpc<() => Observable<Text>>;
+    };
+    web3: {
+      /**
+       * Returns current client version.
+       **/
+      clientVersion: AugmentedRpc<() => Observable<Text>>;
+      /**
+       * Returns sha3 of the given data
+       **/
+      sha3: AugmentedRpc<(data: Bytes | string | Uint8Array) => Observable<H256>>;
+    };
+  } // RpcInterface
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/augment-api-runtime.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api-runtime.ts
@@ -1,0 +1,215 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/api-base/types/calls";
+
+import type { ApiTypes, AugmentedCall, DecoratedCallBase } from "@polkadot/api-base/types";
+import type { Bytes, Null, Option, Vec } from "@polkadot/types-codec";
+import type { AnyNumber, ITuple } from "@polkadot/types-codec/types";
+import type { OpaqueKeyOwnershipProof } from "@polkadot/types/interfaces/babe";
+import type { CheckInherentsResult, InherentData } from "@polkadot/types/interfaces/blockbuilder";
+import type { BlockHash } from "@polkadot/types/interfaces/chain";
+import type { AuthorityId } from "@polkadot/types/interfaces/consensus";
+import type { Extrinsic } from "@polkadot/types/interfaces/extrinsics";
+import type { AuthorityList, GrandpaEquivocationProof, SetId } from "@polkadot/types/interfaces/grandpa";
+import type { AccountId, Block, Header, Index, KeyTypeId, SlotDuration } from "@polkadot/types/interfaces/runtime";
+import type { RuntimeVersion } from "@polkadot/types/interfaces/state";
+import type { ApplyExtrinsicResult } from "@polkadot/types/interfaces/system";
+import type { TransactionSource, TransactionValidity } from "@polkadot/types/interfaces/txqueue";
+import type { IExtrinsic, Observable } from "@polkadot/types/types";
+
+export type __AugmentedCall<ApiType extends ApiTypes> = AugmentedCall<ApiType>;
+export type __DecoratedCallBase<ApiType extends ApiTypes> = DecoratedCallBase<ApiType>;
+
+declare module "@polkadot/api-base/types/calls" {
+  interface AugmentedCalls<ApiType extends ApiTypes> {
+    /** 0xbc9d89904f5b923f/1 */
+    accountNonceApi: {
+      /**
+       * The API to query account nonce (aka transaction index)
+       **/
+      accountNonce: AugmentedCall<ApiType, (accountId: AccountId | string | Uint8Array) => Observable<Index>>;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+    /** 0xdd718d5cc53262d4/1 */
+    auraApi: {
+      /**
+       * Return the current set of authorities.
+       **/
+      authorities: AugmentedCall<ApiType, () => Observable<Vec<AuthorityId>>>;
+      /**
+       * Returns the slot duration for Aura.
+       **/
+      slotDuration: AugmentedCall<ApiType, () => Observable<SlotDuration>>;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+    /** 0x40fe3ad401f8959a/6 */
+    blockBuilder: {
+      /**
+       * Apply the given extrinsic.
+       **/
+      applyExtrinsic: AugmentedCall<
+        ApiType,
+        (extrinsic: Extrinsic | IExtrinsic | string | Uint8Array) => Observable<ApplyExtrinsicResult>
+      >;
+      /**
+       * Check that the inherents are valid.
+       **/
+      checkInherents: AugmentedCall<
+        ApiType,
+        (
+          block: Block | { header?: any; extrinsics?: any } | string | Uint8Array,
+          data: InherentData | { data?: any } | string | Uint8Array,
+        ) => Observable<CheckInherentsResult>
+      >;
+      /**
+       * Finish the current block.
+       **/
+      finalizeBlock: AugmentedCall<ApiType, () => Observable<Header>>;
+      /**
+       * Generate inherent extrinsics.
+       **/
+      inherentExtrinsics: AugmentedCall<
+        ApiType,
+        (inherent: InherentData | { data?: any } | string | Uint8Array) => Observable<Vec<Extrinsic>>
+      >;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+    /** 0xdf6acb689907609b/4 */
+    core: {
+      /**
+       * Execute the given block.
+       **/
+      executeBlock: AugmentedCall<
+        ApiType,
+        (block: Block | { header?: any; extrinsics?: any } | string | Uint8Array) => Observable<Null>
+      >;
+      /**
+       * Initialize a block with the given header.
+       **/
+      initializeBlock: AugmentedCall<
+        ApiType,
+        (
+          header:
+            | Header
+            | { parentHash?: any; number?: any; stateRoot?: any; extrinsicsRoot?: any; digest?: any }
+            | string
+            | Uint8Array,
+        ) => Observable<Null>
+      >;
+      /**
+       * Returns the version of the runtime.
+       **/
+      version: AugmentedCall<ApiType, () => Observable<RuntimeVersion>>;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+    /** 0xed99c5acb25eedf5/3 */
+    grandpaApi: {
+      /**
+       * Get current GRANDPA authority set id.
+       **/
+      currentSetId: AugmentedCall<ApiType, () => Observable<SetId>>;
+      /**
+       * Generates a proof of key ownership for the given authority in the given set.
+       **/
+      generateKeyOwnershipProof: AugmentedCall<
+        ApiType,
+        (
+          setId: SetId | AnyNumber | Uint8Array,
+          authorityId: AuthorityId | string | Uint8Array,
+        ) => Observable<Option<OpaqueKeyOwnershipProof>>
+      >;
+      /**
+       * Get the current GRANDPA authorities and weights. This should not change except for when changes are scheduled and the corresponding delay has passed.
+       **/
+      grandpaAuthorities: AugmentedCall<ApiType, () => Observable<AuthorityList>>;
+      /**
+       * Submits an unsigned extrinsic to report an equivocation.
+       **/
+      submitReportEquivocationUnsignedExtrinsic: AugmentedCall<
+        ApiType,
+        (
+          equivocationProof: GrandpaEquivocationProof | { setId?: any; equivocation?: any } | string | Uint8Array,
+          keyOwnerProof: OpaqueKeyOwnershipProof | string | Uint8Array,
+        ) => Observable<Option<Null>>
+      >;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+    /** 0xf78b278be53f454c/2 */
+    offchainWorkerApi: {
+      /**
+       * Starts the off-chain task for given block header.
+       **/
+      offchainWorker: AugmentedCall<
+        ApiType,
+        (
+          header:
+            | Header
+            | { parentHash?: any; number?: any; stateRoot?: any; extrinsicsRoot?: any; digest?: any }
+            | string
+            | Uint8Array,
+        ) => Observable<Null>
+      >;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+    /** 0xab3c0572291feb8b/1 */
+    sessionKeys: {
+      /**
+       * Decode the given public session keys.
+       **/
+      decodeSessionKeys: AugmentedCall<
+        ApiType,
+        (encoded: Bytes | string | Uint8Array) => Observable<Option<Vec<ITuple<[Bytes, KeyTypeId]>>>>
+      >;
+      /**
+       * Generate a set of session keys with optionally using the given seed.
+       **/
+      generateSessionKeys: AugmentedCall<
+        ApiType,
+        (seed: Option<Bytes> | null | Uint8Array | Bytes | string) => Observable<Bytes>
+      >;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+    /** 0xd2bc9897eed08f15/3 */
+    taggedTransactionQueue: {
+      /**
+       * Validate the transaction.
+       **/
+      validateTransaction: AugmentedCall<
+        ApiType,
+        (
+          source: TransactionSource | "InBlock" | "Local" | "External" | number | Uint8Array,
+          tx: Extrinsic | IExtrinsic | string | Uint8Array,
+          blockHash: BlockHash | string | Uint8Array,
+        ) => Observable<TransactionValidity>
+      >;
+      /**
+       * Generic call
+       **/
+      [key: string]: DecoratedCallBase<ApiType>;
+    };
+  } // AugmentedCalls
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/augment-api-tx.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api-tx.ts
@@ -1,0 +1,1693 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/api-base/types/submittable";
+
+import type {
+  ApiTypes,
+  AugmentedSubmittable,
+  SubmittableExtrinsic,
+  SubmittableExtrinsicFunction,
+} from "@polkadot/api-base/types";
+import type { Bytes, Compact, Option, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from "@polkadot/types-codec";
+import type { AnyNumber, IMethod, ITuple } from "@polkadot/types-codec/types";
+import type { AccountId32, Call, H256, MultiAddress } from "@polkadot/types/interfaces/runtime";
+import type {
+  PalletSmartContractContractResources,
+  PalletSmartContractNruConsumption,
+  PalletSmartContractProvider,
+  PalletTfgridLocationInput,
+  PalletTfgridPolicy,
+  PalletTfgridStorageVersion,
+  SpConsensusGrandpaEquivocationProof,
+  SpCoreVoid,
+  SpWeightsWeightV2Weight,
+  TfchainRuntimeOpaqueSessionKeys,
+  TfchainRuntimeOriginCaller,
+  TfchainSupportFarmCertification,
+  TfchainSupportFarmingPolicyLimit,
+  TfchainSupportInterfaceBoundedVec,
+  TfchainSupportIp4,
+  TfchainSupportNodeCertification,
+  TfchainSupportPower,
+  TfchainSupportPublicConfig,
+  TfchainSupportResources,
+} from "@polkadot/types/lookup";
+
+export type __AugmentedSubmittable = AugmentedSubmittable<() => unknown>;
+export type __SubmittableExtrinsic<ApiType extends ApiTypes> = SubmittableExtrinsic<ApiType>;
+export type __SubmittableExtrinsicFunction<ApiType extends ApiTypes> = SubmittableExtrinsicFunction<ApiType>;
+
+declare module "@polkadot/api-base/types/submittable" {
+  interface AugmentedSubmittables<ApiType extends ApiTypes> {
+    balances: {
+      /**
+       * See [`Pallet::force_set_balance`].
+       **/
+      forceSetBalance: AugmentedSubmittable<
+        (
+          who:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          newFree: Compact<u128> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, Compact<u128>]
+      >;
+      /**
+       * See [`Pallet::force_transfer`].
+       **/
+      forceTransfer: AugmentedSubmittable<
+        (
+          source:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          dest:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          value: Compact<u128> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, MultiAddress, Compact<u128>]
+      >;
+      /**
+       * See [`Pallet::force_unreserve`].
+       **/
+      forceUnreserve: AugmentedSubmittable<
+        (
+          who:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          amount: u128 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, u128]
+      >;
+      /**
+       * See [`Pallet::set_balance_deprecated`].
+       **/
+      setBalanceDeprecated: AugmentedSubmittable<
+        (
+          who:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          newFree: Compact<u128> | AnyNumber | Uint8Array,
+          oldReserved: Compact<u128> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, Compact<u128>, Compact<u128>]
+      >;
+      /**
+       * See [`Pallet::transfer`].
+       **/
+      transfer: AugmentedSubmittable<
+        (
+          dest:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          value: Compact<u128> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, Compact<u128>]
+      >;
+      /**
+       * See [`Pallet::transfer_all`].
+       **/
+      transferAll: AugmentedSubmittable<
+        (
+          dest:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          keepAlive: bool | boolean | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, bool]
+      >;
+      /**
+       * See [`Pallet::transfer_allow_death`].
+       **/
+      transferAllowDeath: AugmentedSubmittable<
+        (
+          dest:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          value: Compact<u128> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, Compact<u128>]
+      >;
+      /**
+       * See [`Pallet::transfer_keep_alive`].
+       **/
+      transferKeepAlive: AugmentedSubmittable<
+        (
+          dest:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          value: Compact<u128> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, Compact<u128>]
+      >;
+      /**
+       * See [`Pallet::upgrade_accounts`].
+       **/
+      upgradeAccounts: AugmentedSubmittable<
+        (who: Vec<AccountId32> | (AccountId32 | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
+        [Vec<AccountId32>]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    burningModule: {
+      /**
+       * See [`Pallet::burn_tft`].
+       **/
+      burnTft: AugmentedSubmittable<
+        (amount: u128 | AnyNumber | Uint8Array, message: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u128, Bytes]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    council: {
+      /**
+       * See [`Pallet::close`].
+       **/
+      close: AugmentedSubmittable<
+        (
+          proposalHash: H256 | string | Uint8Array,
+          index: Compact<u32> | AnyNumber | Uint8Array,
+          proposalWeightBound: SpWeightsWeightV2Weight | { refTime?: any; proofSize?: any } | string | Uint8Array,
+          lengthBound: Compact<u32> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [H256, Compact<u32>, SpWeightsWeightV2Weight, Compact<u32>]
+      >;
+      /**
+       * See [`Pallet::disapprove_proposal`].
+       **/
+      disapproveProposal: AugmentedSubmittable<
+        (proposalHash: H256 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [H256]
+      >;
+      /**
+       * See [`Pallet::execute`].
+       **/
+      execute: AugmentedSubmittable<
+        (
+          proposal: Call | IMethod | string | Uint8Array,
+          lengthBound: Compact<u32> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Call, Compact<u32>]
+      >;
+      /**
+       * See [`Pallet::propose`].
+       **/
+      propose: AugmentedSubmittable<
+        (
+          threshold: Compact<u32> | AnyNumber | Uint8Array,
+          proposal: Call | IMethod | string | Uint8Array,
+          lengthBound: Compact<u32> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Compact<u32>, Call, Compact<u32>]
+      >;
+      /**
+       * See [`Pallet::set_members`].
+       **/
+      setMembers: AugmentedSubmittable<
+        (
+          newMembers: Vec<AccountId32> | (AccountId32 | string | Uint8Array)[],
+          prime: Option<AccountId32> | null | Uint8Array | AccountId32 | string,
+          oldCount: u32 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Vec<AccountId32>, Option<AccountId32>, u32]
+      >;
+      /**
+       * See [`Pallet::vote`].
+       **/
+      vote: AugmentedSubmittable<
+        (
+          proposal: H256 | string | Uint8Array,
+          index: Compact<u32> | AnyNumber | Uint8Array,
+          approve: bool | boolean | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [H256, Compact<u32>, bool]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    councilMembership: {
+      /**
+       * See [`Pallet::add_member`].
+       **/
+      addMember: AugmentedSubmittable<
+        (
+          who:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress]
+      >;
+      /**
+       * See [`Pallet::change_key`].
+       **/
+      changeKey: AugmentedSubmittable<
+        (
+          updated:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress]
+      >;
+      /**
+       * See [`Pallet::clear_prime`].
+       **/
+      clearPrime: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>, []>;
+      /**
+       * See [`Pallet::remove_member`].
+       **/
+      removeMember: AugmentedSubmittable<
+        (
+          who:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress]
+      >;
+      /**
+       * See [`Pallet::reset_members`].
+       **/
+      resetMembers: AugmentedSubmittable<
+        (members: Vec<AccountId32> | (AccountId32 | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
+        [Vec<AccountId32>]
+      >;
+      /**
+       * See [`Pallet::set_prime`].
+       **/
+      setPrime: AugmentedSubmittable<
+        (
+          who:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress]
+      >;
+      /**
+       * See [`Pallet::swap_member`].
+       **/
+      swapMember: AugmentedSubmittable<
+        (
+          remove:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+          add:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress, MultiAddress]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    dao: {
+      /**
+       * See [`Pallet::close`].
+       **/
+      close: AugmentedSubmittable<
+        (
+          proposalHash: H256 | string | Uint8Array,
+          proposalIndex: Compact<u32> | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [H256, Compact<u32>]
+      >;
+      /**
+       * See [`Pallet::propose`].
+       **/
+      propose: AugmentedSubmittable<
+        (
+          threshold: Compact<u32> | AnyNumber | Uint8Array,
+          action: Call | IMethod | string | Uint8Array,
+          description: Bytes | string | Uint8Array,
+          link: Bytes | string | Uint8Array,
+          duration: Option<u32> | null | Uint8Array | u32 | AnyNumber,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Compact<u32>, Call, Bytes, Bytes, Option<u32>]
+      >;
+      /**
+       * See [`Pallet::veto`].
+       **/
+      veto: AugmentedSubmittable<(proposalHash: H256 | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [H256]>;
+      /**
+       * See [`Pallet::vote`].
+       **/
+      vote: AugmentedSubmittable<
+        (
+          farmId: u32 | AnyNumber | Uint8Array,
+          proposalHash: H256 | string | Uint8Array,
+          approve: bool | boolean | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, H256, bool]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    grandpa: {
+      /**
+       * See [`Pallet::note_stalled`].
+       **/
+      noteStalled: AugmentedSubmittable<
+        (
+          delay: u32 | AnyNumber | Uint8Array,
+          bestFinalizedBlockNumber: u32 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, u32]
+      >;
+      /**
+       * See [`Pallet::report_equivocation`].
+       **/
+      reportEquivocation: AugmentedSubmittable<
+        (
+          equivocationProof:
+            | SpConsensusGrandpaEquivocationProof
+            | { setId?: any; equivocation?: any }
+            | string
+            | Uint8Array,
+          keyOwnerProof: SpCoreVoid | null,
+        ) => SubmittableExtrinsic<ApiType>,
+        [SpConsensusGrandpaEquivocationProof, SpCoreVoid]
+      >;
+      /**
+       * See [`Pallet::report_equivocation_unsigned`].
+       **/
+      reportEquivocationUnsigned: AugmentedSubmittable<
+        (
+          equivocationProof:
+            | SpConsensusGrandpaEquivocationProof
+            | { setId?: any; equivocation?: any }
+            | string
+            | Uint8Array,
+          keyOwnerProof: SpCoreVoid | null,
+        ) => SubmittableExtrinsic<ApiType>,
+        [SpConsensusGrandpaEquivocationProof, SpCoreVoid]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    runtimeUpgrade: {
+      /**
+       * See [`Pallet::set_code`].
+       **/
+      setCode: AugmentedSubmittable<(code: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [Bytes]>;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    scheduler: {
+      /**
+       * See [`Pallet::cancel`].
+       **/
+      cancel: AugmentedSubmittable<
+        (when: u32 | AnyNumber | Uint8Array, index: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32, u32]
+      >;
+      /**
+       * See [`Pallet::cancel_named`].
+       **/
+      cancelNamed: AugmentedSubmittable<
+        (id: U8aFixed | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [U8aFixed]
+      >;
+      /**
+       * See [`Pallet::schedule`].
+       **/
+      schedule: AugmentedSubmittable<
+        (
+          when: u32 | AnyNumber | Uint8Array,
+          maybePeriodic:
+            | Option<ITuple<[u32, u32]>>
+            | null
+            | Uint8Array
+            | ITuple<[u32, u32]>
+            | [u32 | AnyNumber | Uint8Array, u32 | AnyNumber | Uint8Array],
+          priority: u8 | AnyNumber | Uint8Array,
+          call: Call | IMethod | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, Option<ITuple<[u32, u32]>>, u8, Call]
+      >;
+      /**
+       * See [`Pallet::schedule_after`].
+       **/
+      scheduleAfter: AugmentedSubmittable<
+        (
+          after: u32 | AnyNumber | Uint8Array,
+          maybePeriodic:
+            | Option<ITuple<[u32, u32]>>
+            | null
+            | Uint8Array
+            | ITuple<[u32, u32]>
+            | [u32 | AnyNumber | Uint8Array, u32 | AnyNumber | Uint8Array],
+          priority: u8 | AnyNumber | Uint8Array,
+          call: Call | IMethod | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, Option<ITuple<[u32, u32]>>, u8, Call]
+      >;
+      /**
+       * See [`Pallet::schedule_named`].
+       **/
+      scheduleNamed: AugmentedSubmittable<
+        (
+          id: U8aFixed | string | Uint8Array,
+          when: u32 | AnyNumber | Uint8Array,
+          maybePeriodic:
+            | Option<ITuple<[u32, u32]>>
+            | null
+            | Uint8Array
+            | ITuple<[u32, u32]>
+            | [u32 | AnyNumber | Uint8Array, u32 | AnyNumber | Uint8Array],
+          priority: u8 | AnyNumber | Uint8Array,
+          call: Call | IMethod | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [U8aFixed, u32, Option<ITuple<[u32, u32]>>, u8, Call]
+      >;
+      /**
+       * See [`Pallet::schedule_named_after`].
+       **/
+      scheduleNamedAfter: AugmentedSubmittable<
+        (
+          id: U8aFixed | string | Uint8Array,
+          after: u32 | AnyNumber | Uint8Array,
+          maybePeriodic:
+            | Option<ITuple<[u32, u32]>>
+            | null
+            | Uint8Array
+            | ITuple<[u32, u32]>
+            | [u32 | AnyNumber | Uint8Array, u32 | AnyNumber | Uint8Array],
+          priority: u8 | AnyNumber | Uint8Array,
+          call: Call | IMethod | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [U8aFixed, u32, Option<ITuple<[u32, u32]>>, u8, Call]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    session: {
+      /**
+       * See [`Pallet::purge_keys`].
+       **/
+      purgeKeys: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>, []>;
+      /**
+       * See [`Pallet::set_keys`].
+       **/
+      setKeys: AugmentedSubmittable<
+        (
+          keys: TfchainRuntimeOpaqueSessionKeys | { aura?: any; grandpa?: any } | string | Uint8Array,
+          proof: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [TfchainRuntimeOpaqueSessionKeys, Bytes]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    smartContractModule: {
+      /**
+       * See [`Pallet::add_nru_reports`].
+       **/
+      addNruReports: AugmentedSubmittable<
+        (
+          reports:
+            | Vec<PalletSmartContractNruConsumption>
+            | (
+                | PalletSmartContractNruConsumption
+                | { contractId?: any; timestamp?: any; window?: any; nru?: any }
+                | string
+                | Uint8Array
+              )[],
+        ) => SubmittableExtrinsic<ApiType>,
+        [Vec<PalletSmartContractNruConsumption>]
+      >;
+      /**
+       * See [`Pallet::approve_solution_provider`].
+       **/
+      approveSolutionProvider: AugmentedSubmittable<
+        (
+          solutionProviderId: u64 | AnyNumber | Uint8Array,
+          approve: bool | boolean | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, bool]
+      >;
+      /**
+       * See [`Pallet::attach_solution_provider_id`].
+       **/
+      attachSolutionProviderId: AugmentedSubmittable<
+        (
+          contractId: u64 | AnyNumber | Uint8Array,
+          solutionProviderId: u64 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, u64]
+      >;
+      /**
+       * See [`Pallet::bill_contract_for_block`].
+       **/
+      billContractForBlock: AugmentedSubmittable<
+        (contractId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::cancel_contract`].
+       **/
+      cancelContract: AugmentedSubmittable<
+        (contractId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::cancel_contract_collective`].
+       **/
+      cancelContractCollective: AugmentedSubmittable<
+        (contractId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::change_billing_frequency`].
+       **/
+      changeBillingFrequency: AugmentedSubmittable<
+        (frequency: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::create_name_contract`].
+       **/
+      createNameContract: AugmentedSubmittable<
+        (name: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Bytes]
+      >;
+      /**
+       * See [`Pallet::create_node_contract`].
+       **/
+      createNodeContract: AugmentedSubmittable<
+        (
+          nodeId: u32 | AnyNumber | Uint8Array,
+          deploymentHash: U8aFixed | string | Uint8Array,
+          deploymentData: Bytes | string | Uint8Array,
+          publicIps: u32 | AnyNumber | Uint8Array,
+          solutionProviderId: Option<u64> | null | Uint8Array | u64 | AnyNumber,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, U8aFixed, Bytes, u32, Option<u64>]
+      >;
+      /**
+       * See [`Pallet::create_rent_contract`].
+       **/
+      createRentContract: AugmentedSubmittable<
+        (
+          nodeId: u32 | AnyNumber | Uint8Array,
+          solutionProviderId: Option<u64> | null | Uint8Array | u64 | AnyNumber,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, Option<u64>]
+      >;
+      /**
+       * See [`Pallet::create_solution_provider`].
+       **/
+      createSolutionProvider: AugmentedSubmittable<
+        (
+          description: Bytes | string | Uint8Array,
+          link: Bytes | string | Uint8Array,
+          providers:
+            | Vec<PalletSmartContractProvider>
+            | (PalletSmartContractProvider | { who?: any; take?: any } | string | Uint8Array)[],
+        ) => SubmittableExtrinsic<ApiType>,
+        [Bytes, Bytes, Vec<PalletSmartContractProvider>]
+      >;
+      /**
+       * See [`Pallet::report_contract_resources`].
+       **/
+      reportContractResources: AugmentedSubmittable<
+        (
+          contractResources:
+            | Vec<PalletSmartContractContractResources>
+            | (PalletSmartContractContractResources | { contractId?: any; used?: any } | string | Uint8Array)[],
+        ) => SubmittableExtrinsic<ApiType>,
+        [Vec<PalletSmartContractContractResources>]
+      >;
+      /**
+       * See [`Pallet::service_contract_approve`].
+       **/
+      serviceContractApprove: AugmentedSubmittable<
+        (serviceContractId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::service_contract_bill`].
+       **/
+      serviceContractBill: AugmentedSubmittable<
+        (
+          serviceContractId: u64 | AnyNumber | Uint8Array,
+          variableAmount: u64 | AnyNumber | Uint8Array,
+          metadata: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, u64, Bytes]
+      >;
+      /**
+       * See [`Pallet::service_contract_cancel`].
+       **/
+      serviceContractCancel: AugmentedSubmittable<
+        (serviceContractId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::service_contract_create`].
+       **/
+      serviceContractCreate: AugmentedSubmittable<
+        (
+          serviceAccount: AccountId32 | string | Uint8Array,
+          consumerAccount: AccountId32 | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [AccountId32, AccountId32]
+      >;
+      /**
+       * See [`Pallet::service_contract_reject`].
+       **/
+      serviceContractReject: AugmentedSubmittable<
+        (serviceContractId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::service_contract_set_fees`].
+       **/
+      serviceContractSetFees: AugmentedSubmittable<
+        (
+          serviceContractId: u64 | AnyNumber | Uint8Array,
+          baseFee: u64 | AnyNumber | Uint8Array,
+          variableFee: u64 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, u64, u64]
+      >;
+      /**
+       * See [`Pallet::service_contract_set_metadata`].
+       **/
+      serviceContractSetMetadata: AugmentedSubmittable<
+        (
+          serviceContractId: u64 | AnyNumber | Uint8Array,
+          metadata: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, Bytes]
+      >;
+      /**
+       * See [`Pallet::set_dedicated_node_extra_fee`].
+       **/
+      setDedicatedNodeExtraFee: AugmentedSubmittable<
+        (nodeId: u32 | AnyNumber | Uint8Array, extraFee: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32, u64]
+      >;
+      /**
+       * See [`Pallet::update_node_contract`].
+       **/
+      updateNodeContract: AugmentedSubmittable<
+        (
+          contractId: u64 | AnyNumber | Uint8Array,
+          deploymentHash: U8aFixed | string | Uint8Array,
+          deploymentData: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, U8aFixed, Bytes]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    system: {
+      /**
+       * See [`Pallet::kill_prefix`].
+       **/
+      killPrefix: AugmentedSubmittable<
+        (prefix: Bytes | string | Uint8Array, subkeys: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Bytes, u32]
+      >;
+      /**
+       * See [`Pallet::kill_storage`].
+       **/
+      killStorage: AugmentedSubmittable<
+        (keys: Vec<Bytes> | (Bytes | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
+        [Vec<Bytes>]
+      >;
+      /**
+       * See [`Pallet::remark`].
+       **/
+      remark: AugmentedSubmittable<(remark: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [Bytes]>;
+      /**
+       * See [`Pallet::remark_with_event`].
+       **/
+      remarkWithEvent: AugmentedSubmittable<
+        (remark: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Bytes]
+      >;
+      /**
+       * See [`Pallet::set_code`].
+       **/
+      setCode: AugmentedSubmittable<(code: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [Bytes]>;
+      /**
+       * See [`Pallet::set_code_without_checks`].
+       **/
+      setCodeWithoutChecks: AugmentedSubmittable<
+        (code: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Bytes]
+      >;
+      /**
+       * See [`Pallet::set_heap_pages`].
+       **/
+      setHeapPages: AugmentedSubmittable<(pages: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [u64]>;
+      /**
+       * See [`Pallet::set_storage`].
+       **/
+      setStorage: AugmentedSubmittable<
+        (
+          items: Vec<ITuple<[Bytes, Bytes]>> | [Bytes | string | Uint8Array, Bytes | string | Uint8Array][],
+        ) => SubmittableExtrinsic<ApiType>,
+        [Vec<ITuple<[Bytes, Bytes]>>]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    tfgridModule: {
+      /**
+       * See [`Pallet::add_farm_ip`].
+       **/
+      addFarmIp: AugmentedSubmittable<
+        (
+          farmId: u32 | AnyNumber | Uint8Array,
+          ip: Bytes | string | Uint8Array,
+          gw: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, Bytes, Bytes]
+      >;
+      /**
+       * See [`Pallet::add_node_certifier`].
+       **/
+      addNodeCertifier: AugmentedSubmittable<
+        (certifier: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::add_node_public_config`].
+       **/
+      addNodePublicConfig: AugmentedSubmittable<
+        (
+          farmId: u32 | AnyNumber | Uint8Array,
+          nodeId: u32 | AnyNumber | Uint8Array,
+          publicConfig:
+            | Option<TfchainSupportPublicConfig>
+            | null
+            | Uint8Array
+            | TfchainSupportPublicConfig
+            | { ip4?: any; ip6?: any; domain?: any }
+            | string,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, u32, Option<TfchainSupportPublicConfig>]
+      >;
+      /**
+       * See [`Pallet::add_stellar_payout_v2address`].
+       **/
+      addStellarPayoutV2address: AugmentedSubmittable<
+        (
+          farmId: u32 | AnyNumber | Uint8Array,
+          stellarAddress: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, Bytes]
+      >;
+      /**
+       * See [`Pallet::add_twin_entity`].
+       **/
+      addTwinEntity: AugmentedSubmittable<
+        (
+          twinId: u32 | AnyNumber | Uint8Array,
+          entityId: u32 | AnyNumber | Uint8Array,
+          signature: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, u32, Bytes]
+      >;
+      /**
+       * See [`Pallet::attach_policy_to_farm`].
+       **/
+      attachPolicyToFarm: AugmentedSubmittable<
+        (
+          farmId: u32 | AnyNumber | Uint8Array,
+          limits:
+            | Option<TfchainSupportFarmingPolicyLimit>
+            | null
+            | Uint8Array
+            | TfchainSupportFarmingPolicyLimit
+            | { farmingPolicyId?: any; cu?: any; su?: any; end?: any; nodeCount?: any; nodeCertification?: any }
+            | string,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, Option<TfchainSupportFarmingPolicyLimit>]
+      >;
+      /**
+       * See [`Pallet::bond_twin_account`].
+       **/
+      bondTwinAccount: AugmentedSubmittable<
+        (twinId: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32]
+      >;
+      /**
+       * See [`Pallet::change_power_state`].
+       **/
+      changePowerState: AugmentedSubmittable<
+        (powerState: TfchainSupportPower | "Up" | "Down" | number | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [TfchainSupportPower]
+      >;
+      /**
+       * See [`Pallet::change_power_target`].
+       **/
+      changePowerTarget: AugmentedSubmittable<
+        (
+          nodeId: u32 | AnyNumber | Uint8Array,
+          powerTarget: TfchainSupportPower | "Up" | "Down" | number | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, TfchainSupportPower]
+      >;
+      /**
+       * See [`Pallet::create_entity`].
+       **/
+      createEntity: AugmentedSubmittable<
+        (
+          target: AccountId32 | string | Uint8Array,
+          name: Bytes | string | Uint8Array,
+          country: Bytes | string | Uint8Array,
+          city: Bytes | string | Uint8Array,
+          signature: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [AccountId32, Bytes, Bytes, Bytes, Bytes]
+      >;
+      /**
+       * See [`Pallet::create_farm`].
+       **/
+      createFarm: AugmentedSubmittable<
+        (
+          name: Bytes | string | Uint8Array,
+          publicIps: Vec<TfchainSupportIp4> | (TfchainSupportIp4 | { ip?: any; gw?: any } | string | Uint8Array)[],
+        ) => SubmittableExtrinsic<ApiType>,
+        [Bytes, Vec<TfchainSupportIp4>]
+      >;
+      /**
+       * See [`Pallet::create_farming_policy`].
+       **/
+      createFarmingPolicy: AugmentedSubmittable<
+        (
+          name: Bytes | string | Uint8Array,
+          su: u32 | AnyNumber | Uint8Array,
+          cu: u32 | AnyNumber | Uint8Array,
+          nu: u32 | AnyNumber | Uint8Array,
+          ipv4: u32 | AnyNumber | Uint8Array,
+          minimalUptime: u16 | AnyNumber | Uint8Array,
+          policyEnd: u32 | AnyNumber | Uint8Array,
+          immutable: bool | boolean | Uint8Array,
+          _default: bool | boolean | Uint8Array,
+          nodeCertification: TfchainSupportNodeCertification | "Diy" | "Certified" | number | Uint8Array,
+          farmCertification: TfchainSupportFarmCertification | "NotCertified" | "Gold" | number | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [
+          Bytes,
+          u32,
+          u32,
+          u32,
+          u32,
+          u16,
+          u32,
+          bool,
+          bool,
+          TfchainSupportNodeCertification,
+          TfchainSupportFarmCertification,
+        ]
+      >;
+      /**
+       * See [`Pallet::create_node`].
+       **/
+      createNode: AugmentedSubmittable<
+        (
+          farmId: u32 | AnyNumber | Uint8Array,
+          resources: TfchainSupportResources | { hru?: any; sru?: any; cru?: any; mru?: any } | string | Uint8Array,
+          location:
+            | PalletTfgridLocationInput
+            | { city?: any; country?: any; latitude?: any; longitude?: any }
+            | string
+            | Uint8Array,
+          interfaces:
+            | Vec<TfchainSupportInterfaceBoundedVec>
+            | (TfchainSupportInterfaceBoundedVec | { name?: any; mac?: any; ips?: any } | string | Uint8Array)[],
+          secureBoot: bool | boolean | Uint8Array,
+          virtualized: bool | boolean | Uint8Array,
+          serialNumber: Option<Bytes> | null | Uint8Array | Bytes | string,
+        ) => SubmittableExtrinsic<ApiType>,
+        [
+          u32,
+          TfchainSupportResources,
+          PalletTfgridLocationInput,
+          Vec<TfchainSupportInterfaceBoundedVec>,
+          bool,
+          bool,
+          Option<Bytes>,
+        ]
+      >;
+      /**
+       * See [`Pallet::create_pricing_policy`].
+       **/
+      createPricingPolicy: AugmentedSubmittable<
+        (
+          name: Bytes | string | Uint8Array,
+          su: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          cu: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          nu: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          ipu: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          uniqueName: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          domainName: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          foundationAccount: AccountId32 | string | Uint8Array,
+          certifiedSalesAccount: AccountId32 | string | Uint8Array,
+          discountForDedicationNodes: u8 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [
+          Bytes,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          AccountId32,
+          AccountId32,
+          u8,
+        ]
+      >;
+      /**
+       * See [`Pallet::create_twin`].
+       **/
+      createTwin: AugmentedSubmittable<
+        (
+          relay: Option<Bytes> | null | Uint8Array | Bytes | string,
+          pk: Option<Bytes> | null | Uint8Array | Bytes | string,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Option<Bytes>, Option<Bytes>]
+      >;
+      /**
+       * See [`Pallet::delete_entity`].
+       **/
+      deleteEntity: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>, []>;
+      /**
+       * See [`Pallet::delete_node`].
+       **/
+      deleteNode: AugmentedSubmittable<(nodeId: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [u32]>;
+      /**
+       * See [`Pallet::delete_node_farm`].
+       **/
+      deleteNodeFarm: AugmentedSubmittable<
+        (nodeId: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32]
+      >;
+      /**
+       * See [`Pallet::delete_twin_entity`].
+       **/
+      deleteTwinEntity: AugmentedSubmittable<
+        (twinId: u32 | AnyNumber | Uint8Array, entityId: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32, u32]
+      >;
+      /**
+       * See [`Pallet::force_reset_farm_ip`].
+       **/
+      forceResetFarmIp: AugmentedSubmittable<
+        (farmId: u32 | AnyNumber | Uint8Array, ip: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32, Bytes]
+      >;
+      /**
+       * See [`Pallet::remove_farm_ip`].
+       **/
+      removeFarmIp: AugmentedSubmittable<
+        (farmId: u32 | AnyNumber | Uint8Array, ip: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32, Bytes]
+      >;
+      /**
+       * See [`Pallet::remove_node_certifier`].
+       **/
+      removeNodeCertifier: AugmentedSubmittable<
+        (certifier: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::report_uptime`].
+       **/
+      reportUptime: AugmentedSubmittable<
+        (uptime: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::report_uptime_v2`].
+       **/
+      reportUptimeV2: AugmentedSubmittable<
+        (
+          uptime: u64 | AnyNumber | Uint8Array,
+          timestampHint: u64 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, u64]
+      >;
+      /**
+       * See [`Pallet::set_connection_price`].
+       **/
+      setConnectionPrice: AugmentedSubmittable<
+        (price: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32]
+      >;
+      /**
+       * See [`Pallet::set_farm_certification`].
+       **/
+      setFarmCertification: AugmentedSubmittable<
+        (
+          farmId: u32 | AnyNumber | Uint8Array,
+          certification: TfchainSupportFarmCertification | "NotCertified" | "Gold" | number | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, TfchainSupportFarmCertification]
+      >;
+      /**
+       * See [`Pallet::set_farm_dedicated`].
+       **/
+      setFarmDedicated: AugmentedSubmittable<
+        (farmId: u32 | AnyNumber | Uint8Array, dedicated: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32, bool]
+      >;
+      /**
+       * See [`Pallet::set_node_certification`].
+       **/
+      setNodeCertification: AugmentedSubmittable<
+        (
+          nodeId: u32 | AnyNumber | Uint8Array,
+          nodeCertification: TfchainSupportNodeCertification | "Diy" | "Certified" | number | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, TfchainSupportNodeCertification]
+      >;
+      /**
+       * See [`Pallet::set_storage_version`].
+       **/
+      setStorageVersion: AugmentedSubmittable<
+        (
+          version:
+            | PalletTfgridStorageVersion
+            | "V1Struct"
+            | "V2Struct"
+            | "V3Struct"
+            | "V4Struct"
+            | "V5Struct"
+            | "V6Struct"
+            | "V7Struct"
+            | "V8Struct"
+            | "V9Struct"
+            | "V10Struct"
+            | "V11Struct"
+            | "V12Struct"
+            | "V13Struct"
+            | "V14Struct"
+            | "V15Struct"
+            | "V16Struct"
+            | "V17Struct"
+            | number
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [PalletTfgridStorageVersion]
+      >;
+      /**
+       * See [`Pallet::set_zos_version`].
+       **/
+      setZosVersion: AugmentedSubmittable<
+        (zosVersion: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Bytes]
+      >;
+      /**
+       * See [`Pallet::update_entity`].
+       **/
+      updateEntity: AugmentedSubmittable<
+        (
+          name: Bytes | string | Uint8Array,
+          country: Bytes | string | Uint8Array,
+          city: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Bytes, Bytes, Bytes]
+      >;
+      /**
+       * See [`Pallet::update_farm`].
+       **/
+      updateFarm: AugmentedSubmittable<
+        (farmId: u32 | AnyNumber | Uint8Array, name: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32, Bytes]
+      >;
+      /**
+       * See [`Pallet::update_farming_policy`].
+       **/
+      updateFarmingPolicy: AugmentedSubmittable<
+        (
+          farmingPolicyId: u32 | AnyNumber | Uint8Array,
+          name: Bytes | string | Uint8Array,
+          su: u32 | AnyNumber | Uint8Array,
+          cu: u32 | AnyNumber | Uint8Array,
+          nu: u32 | AnyNumber | Uint8Array,
+          ipv4: u32 | AnyNumber | Uint8Array,
+          minimalUptime: u16 | AnyNumber | Uint8Array,
+          policyEnd: u32 | AnyNumber | Uint8Array,
+          _default: bool | boolean | Uint8Array,
+          nodeCertification: TfchainSupportNodeCertification | "Diy" | "Certified" | number | Uint8Array,
+          farmCertification: TfchainSupportFarmCertification | "NotCertified" | "Gold" | number | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [
+          u32,
+          Bytes,
+          u32,
+          u32,
+          u32,
+          u32,
+          u16,
+          u32,
+          bool,
+          TfchainSupportNodeCertification,
+          TfchainSupportFarmCertification,
+        ]
+      >;
+      /**
+       * See [`Pallet::update_node`].
+       **/
+      updateNode: AugmentedSubmittable<
+        (
+          nodeId: u32 | AnyNumber | Uint8Array,
+          farmId: u32 | AnyNumber | Uint8Array,
+          resources: TfchainSupportResources | { hru?: any; sru?: any; cru?: any; mru?: any } | string | Uint8Array,
+          location:
+            | PalletTfgridLocationInput
+            | { city?: any; country?: any; latitude?: any; longitude?: any }
+            | string
+            | Uint8Array,
+          interfaces:
+            | Vec<TfchainSupportInterfaceBoundedVec>
+            | (TfchainSupportInterfaceBoundedVec | { name?: any; mac?: any; ips?: any } | string | Uint8Array)[],
+          secureBoot: bool | boolean | Uint8Array,
+          virtualized: bool | boolean | Uint8Array,
+          serialNumber: Option<Bytes> | null | Uint8Array | Bytes | string,
+        ) => SubmittableExtrinsic<ApiType>,
+        [
+          u32,
+          u32,
+          TfchainSupportResources,
+          PalletTfgridLocationInput,
+          Vec<TfchainSupportInterfaceBoundedVec>,
+          bool,
+          bool,
+          Option<Bytes>,
+        ]
+      >;
+      /**
+       * See [`Pallet::update_pricing_policy`].
+       **/
+      updatePricingPolicy: AugmentedSubmittable<
+        (
+          pricingPolicyId: u32 | AnyNumber | Uint8Array,
+          name: Bytes | string | Uint8Array,
+          su: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          cu: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          nu: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          ipu: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          uniqueName: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          domainName: PalletTfgridPolicy | { value?: any; unit?: any } | string | Uint8Array,
+          foundationAccount: AccountId32 | string | Uint8Array,
+          certifiedSalesAccount: AccountId32 | string | Uint8Array,
+          discountForDedicationNodes: u8 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [
+          u32,
+          Bytes,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          PalletTfgridPolicy,
+          AccountId32,
+          AccountId32,
+          u8,
+        ]
+      >;
+      /**
+       * See [`Pallet::update_twin`].
+       **/
+      updateTwin: AugmentedSubmittable<
+        (
+          relay: Option<Bytes> | null | Uint8Array | Bytes | string,
+          pk: Option<Bytes> | null | Uint8Array | Bytes | string,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Option<Bytes>, Option<Bytes>]
+      >;
+      /**
+       * See [`Pallet::user_accept_tc`].
+       **/
+      userAcceptTc: AugmentedSubmittable<
+        (
+          documentLink: Bytes | string | Uint8Array,
+          documentHash: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Bytes, Bytes]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    tfkvStore: {
+      /**
+       * See [`Pallet::delete`].
+       **/
+      delete: AugmentedSubmittable<(key: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [Bytes]>;
+      /**
+       * See [`Pallet::set`].
+       **/
+      set: AugmentedSubmittable<
+        (key: Bytes | string | Uint8Array, value: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Bytes, Bytes]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    tftBridgeModule: {
+      /**
+       * See [`Pallet::add_bridge_validator`].
+       **/
+      addBridgeValidator: AugmentedSubmittable<
+        (target: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::create_refund_transaction_or_add_sig`].
+       **/
+      createRefundTransactionOrAddSig: AugmentedSubmittable<
+        (
+          txHash: Bytes | string | Uint8Array,
+          target: Bytes | string | Uint8Array,
+          amount: u64 | AnyNumber | Uint8Array,
+          signature: Bytes | string | Uint8Array,
+          stellarPubKey: Bytes | string | Uint8Array,
+          sequenceNumber: u64 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Bytes, Bytes, u64, Bytes, Bytes, u64]
+      >;
+      /**
+       * See [`Pallet::propose_burn_transaction_or_add_sig`].
+       **/
+      proposeBurnTransactionOrAddSig: AugmentedSubmittable<
+        (
+          transactionId: u64 | AnyNumber | Uint8Array,
+          target: Bytes | string | Uint8Array,
+          amount: u64 | AnyNumber | Uint8Array,
+          signature: Bytes | string | Uint8Array,
+          stellarPubKey: Bytes | string | Uint8Array,
+          sequenceNumber: u64 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, Bytes, u64, Bytes, Bytes, u64]
+      >;
+      /**
+       * See [`Pallet::propose_or_vote_mint_transaction`].
+       **/
+      proposeOrVoteMintTransaction: AugmentedSubmittable<
+        (
+          transaction: Bytes | string | Uint8Array,
+          target: AccountId32 | string | Uint8Array,
+          amount: u64 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Bytes, AccountId32, u64]
+      >;
+      /**
+       * See [`Pallet::remove_bridge_validator`].
+       **/
+      removeBridgeValidator: AugmentedSubmittable<
+        (target: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::set_burn_transaction_executed`].
+       **/
+      setBurnTransactionExecuted: AugmentedSubmittable<
+        (transactionId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::set_deposit_fee`].
+       **/
+      setDepositFee: AugmentedSubmittable<
+        (amount: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::set_fee_account`].
+       **/
+      setFeeAccount: AugmentedSubmittable<
+        (target: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::set_refund_transaction_executed`].
+       **/
+      setRefundTransactionExecuted: AugmentedSubmittable<
+        (txHash: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Bytes]
+      >;
+      /**
+       * See [`Pallet::set_withdraw_fee`].
+       **/
+      setWithdrawFee: AugmentedSubmittable<
+        (amount: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u64]
+      >;
+      /**
+       * See [`Pallet::swap_to_stellar`].
+       **/
+      swapToStellar: AugmentedSubmittable<
+        (
+          targetStellarAddress: Bytes | string | Uint8Array,
+          amount: u128 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Bytes, u128]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    tftPriceModule: {
+      /**
+       * See [`Pallet::set_max_tft_price`].
+       **/
+      setMaxTftPrice: AugmentedSubmittable<
+        (price: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32]
+      >;
+      /**
+       * See [`Pallet::set_min_tft_price`].
+       **/
+      setMinTftPrice: AugmentedSubmittable<
+        (price: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [u32]
+      >;
+      /**
+       * See [`Pallet::set_prices`].
+       **/
+      setPrices: AugmentedSubmittable<
+        (
+          price: u32 | AnyNumber | Uint8Array,
+          blockNumber: u32 | AnyNumber | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u32, u32]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    timestamp: {
+      /**
+       * See [`Pallet::set`].
+       **/
+      set: AugmentedSubmittable<
+        (now: Compact<u64> | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [Compact<u64>]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    utility: {
+      /**
+       * See [`Pallet::as_derivative`].
+       **/
+      asDerivative: AugmentedSubmittable<
+        (
+          index: u16 | AnyNumber | Uint8Array,
+          call: Call | IMethod | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [u16, Call]
+      >;
+      /**
+       * See [`Pallet::batch`].
+       **/
+      batch: AugmentedSubmittable<
+        (calls: Vec<Call> | (Call | IMethod | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
+        [Vec<Call>]
+      >;
+      /**
+       * See [`Pallet::batch_all`].
+       **/
+      batchAll: AugmentedSubmittable<
+        (calls: Vec<Call> | (Call | IMethod | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
+        [Vec<Call>]
+      >;
+      /**
+       * See [`Pallet::dispatch_as`].
+       **/
+      dispatchAs: AugmentedSubmittable<
+        (
+          asOrigin:
+            | TfchainRuntimeOriginCaller
+            | { system: any }
+            | { Void: any }
+            | { Council: any }
+            | string
+            | Uint8Array,
+          call: Call | IMethod | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [TfchainRuntimeOriginCaller, Call]
+      >;
+      /**
+       * See [`Pallet::force_batch`].
+       **/
+      forceBatch: AugmentedSubmittable<
+        (calls: Vec<Call> | (Call | IMethod | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>,
+        [Vec<Call>]
+      >;
+      /**
+       * See [`Pallet::with_weight`].
+       **/
+      withWeight: AugmentedSubmittable<
+        (
+          call: Call | IMethod | string | Uint8Array,
+          weight: SpWeightsWeightV2Weight | { refTime?: any; proofSize?: any } | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [Call, SpWeightsWeightV2Weight]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    validator: {
+      /**
+       * See [`Pallet::activate_validator_node`].
+       **/
+      activateValidatorNode: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>, []>;
+      /**
+       * See [`Pallet::approve_validator`].
+       **/
+      approveValidator: AugmentedSubmittable<
+        (
+          validatorAccount:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress]
+      >;
+      /**
+       * See [`Pallet::bond`].
+       **/
+      bond: AugmentedSubmittable<
+        (
+          validator:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress]
+      >;
+      /**
+       * See [`Pallet::change_validator_node_account`].
+       **/
+      changeValidatorNodeAccount: AugmentedSubmittable<
+        (newNodeValidatorAccount: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::create_validator_request`].
+       **/
+      createValidatorRequest: AugmentedSubmittable<
+        (
+          validatorNodeAccount: AccountId32 | string | Uint8Array,
+          stashAccount: AccountId32 | string | Uint8Array,
+          description: Bytes | string | Uint8Array,
+          tfConnectId: Bytes | string | Uint8Array,
+          info: Bytes | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [AccountId32, AccountId32, Bytes, Bytes, Bytes]
+      >;
+      /**
+       * See [`Pallet::remove_validator`].
+       **/
+      removeValidator: AugmentedSubmittable<
+        (
+          validatorAccount:
+            | MultiAddress
+            | { Id: any }
+            | { Index: any }
+            | { Raw: any }
+            | { Address32: any }
+            | { Address20: any }
+            | string
+            | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [MultiAddress]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    validatorSet: {
+      /**
+       * See [`Pallet::add_validator`].
+       **/
+      addValidator: AugmentedSubmittable<
+        (validatorId: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::add_validator_again`].
+       **/
+      addValidatorAgain: AugmentedSubmittable<
+        (validatorId: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * See [`Pallet::remove_validator`].
+       **/
+      removeValidator: AugmentedSubmittable<
+        (validatorId: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId32]
+      >;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+  } // AugmentedSubmittables
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/augment-api.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-api.ts
@@ -1,0 +1,10 @@
+// Auto-generated via `yarn polkadot-types-from-chain`, do not edit
+/* eslint-disable */
+
+import "./augment-api-consts";
+import "./augment-api-errors";
+import "./augment-api-events";
+import "./augment-api-query";
+import "./augment-api-tx";
+import "./augment-api-rpc";
+import "./augment-api-runtime";

--- a/packages/tfchain_client/src/interfaces/chain/augment-types.ts
+++ b/packages/tfchain_client/src/interfaces/chain/augment-types.ts
@@ -1,0 +1,2268 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/types/types/registry";
+
+import type { Data, StorageKey } from "@polkadot/types";
+import type {
+  BitVec,
+  Bool,
+  Bytes,
+  F32,
+  F64,
+  I128,
+  I16,
+  I256,
+  I32,
+  I64,
+  I8,
+  Json,
+  Null,
+  OptionBool,
+  Raw,
+  Text,
+  Type,
+  U128,
+  U16,
+  U256,
+  U32,
+  U64,
+  U8,
+  USize,
+  bool,
+  f32,
+  f64,
+  i128,
+  i16,
+  i256,
+  i32,
+  i64,
+  i8,
+  u128,
+  u16,
+  u256,
+  u32,
+  u64,
+  u8,
+  usize,
+} from "@polkadot/types-codec";
+import type {
+  AssetApproval,
+  AssetApprovalKey,
+  AssetBalance,
+  AssetDestroyWitness,
+  AssetDetails,
+  AssetMetadata,
+  TAssetBalance,
+  TAssetDepositBalance,
+} from "@polkadot/types/interfaces/assets";
+import type { BlockAttestations, IncludedBlocks, MoreAttestations } from "@polkadot/types/interfaces/attestations";
+import type { RawAuraPreDigest } from "@polkadot/types/interfaces/aura";
+import type { ExtrinsicOrHash, ExtrinsicStatus } from "@polkadot/types/interfaces/author";
+import type { UncleEntryItem } from "@polkadot/types/interfaces/authorship";
+import type {
+  AllowedSlots,
+  BabeAuthorityWeight,
+  BabeBlockWeight,
+  BabeEpochConfiguration,
+  BabeEquivocationProof,
+  BabeGenesisConfiguration,
+  BabeGenesisConfigurationV1,
+  BabeWeight,
+  Epoch,
+  EpochAuthorship,
+  MaybeRandomness,
+  MaybeVrf,
+  NextConfigDescriptor,
+  NextConfigDescriptorV1,
+  OpaqueKeyOwnershipProof,
+  Randomness,
+  RawBabePreDigest,
+  RawBabePreDigestCompat,
+  RawBabePreDigestPrimary,
+  RawBabePreDigestPrimaryTo159,
+  RawBabePreDigestSecondaryPlain,
+  RawBabePreDigestSecondaryTo159,
+  RawBabePreDigestSecondaryVRF,
+  RawBabePreDigestTo159,
+  SlotNumber,
+  VrfData,
+  VrfOutput,
+  VrfProof,
+} from "@polkadot/types/interfaces/babe";
+import type {
+  AccountData,
+  BalanceLock,
+  BalanceLockTo212,
+  BalanceStatus,
+  Reasons,
+  ReserveData,
+  ReserveIdentifier,
+  VestingSchedule,
+  WithdrawReasons,
+} from "@polkadot/types/interfaces/balances";
+import type {
+  BeefyAuthoritySet,
+  BeefyCommitment,
+  BeefyId,
+  BeefyNextAuthoritySet,
+  BeefyPayload,
+  BeefyPayloadId,
+  BeefySignedCommitment,
+  MmrRootHash,
+  ValidatorSet,
+  ValidatorSetId,
+} from "@polkadot/types/interfaces/beefy";
+import type {
+  BenchmarkConfig,
+  BenchmarkList,
+  BenchmarkMetadata,
+  BenchmarkParameter,
+} from "@polkadot/types/interfaces/benchmark";
+import type { CheckInherentsResult, InherentData, InherentIdentifier } from "@polkadot/types/interfaces/blockbuilder";
+import type {
+  BridgeMessageId,
+  BridgedBlockHash,
+  BridgedBlockNumber,
+  BridgedHeader,
+  CallOrigin,
+  ChainId,
+  DeliveredMessages,
+  DispatchFeePayment,
+  InboundLaneData,
+  InboundRelayer,
+  InitializationData,
+  LaneId,
+  MessageData,
+  MessageKey,
+  MessageNonce,
+  MessagesDeliveryProofOf,
+  MessagesProofOf,
+  OperatingMode,
+  OutboundLaneData,
+  OutboundMessageFee,
+  OutboundPayload,
+  Parameter,
+  RelayerId,
+  UnrewardedRelayer,
+  UnrewardedRelayersState,
+} from "@polkadot/types/interfaces/bridges";
+import type { BlockHash } from "@polkadot/types/interfaces/chain";
+import type { PrefixedStorageKey } from "@polkadot/types/interfaces/childstate";
+import type { StatementKind } from "@polkadot/types/interfaces/claims";
+import type {
+  CollectiveOrigin,
+  MemberCount,
+  ProposalIndex,
+  Votes,
+  VotesTo230,
+} from "@polkadot/types/interfaces/collective";
+import type { AuthorityId, RawVRFOutput } from "@polkadot/types/interfaces/consensus";
+import type {
+  AliveContractInfo,
+  CodeHash,
+  CodeSource,
+  CodeUploadRequest,
+  CodeUploadResult,
+  CodeUploadResultValue,
+  ContractCallFlags,
+  ContractCallRequest,
+  ContractExecResult,
+  ContractExecResultOk,
+  ContractExecResultResult,
+  ContractExecResultSuccessTo255,
+  ContractExecResultSuccessTo260,
+  ContractExecResultTo255,
+  ContractExecResultTo260,
+  ContractExecResultTo267,
+  ContractInfo,
+  ContractInstantiateResult,
+  ContractInstantiateResultTo267,
+  ContractInstantiateResultTo299,
+  ContractReturnFlags,
+  ContractStorageKey,
+  DeletedContract,
+  ExecReturnValue,
+  Gas,
+  HostFnWeights,
+  HostFnWeightsTo264,
+  InstantiateRequest,
+  InstantiateRequestV1,
+  InstantiateRequestV2,
+  InstantiateReturnValue,
+  InstantiateReturnValueOk,
+  InstantiateReturnValueTo267,
+  InstructionWeights,
+  Limits,
+  LimitsTo264,
+  PrefabWasmModule,
+  RentProjection,
+  Schedule,
+  ScheduleTo212,
+  ScheduleTo258,
+  ScheduleTo264,
+  SeedOf,
+  StorageDeposit,
+  TombstoneContractInfo,
+  TrieId,
+} from "@polkadot/types/interfaces/contracts";
+import type {
+  ContractConstructorSpecLatest,
+  ContractConstructorSpecV0,
+  ContractConstructorSpecV1,
+  ContractConstructorSpecV2,
+  ContractConstructorSpecV3,
+  ContractContractSpecV0,
+  ContractContractSpecV1,
+  ContractContractSpecV2,
+  ContractContractSpecV3,
+  ContractCryptoHasher,
+  ContractDiscriminant,
+  ContractDisplayName,
+  ContractEventParamSpecLatest,
+  ContractEventParamSpecV0,
+  ContractEventParamSpecV2,
+  ContractEventSpecLatest,
+  ContractEventSpecV0,
+  ContractEventSpecV1,
+  ContractEventSpecV2,
+  ContractLayoutArray,
+  ContractLayoutCell,
+  ContractLayoutEnum,
+  ContractLayoutHash,
+  ContractLayoutHashingStrategy,
+  ContractLayoutKey,
+  ContractLayoutStruct,
+  ContractLayoutStructField,
+  ContractMessageParamSpecLatest,
+  ContractMessageParamSpecV0,
+  ContractMessageParamSpecV2,
+  ContractMessageSpecLatest,
+  ContractMessageSpecV0,
+  ContractMessageSpecV1,
+  ContractMessageSpecV2,
+  ContractMetadata,
+  ContractMetadataLatest,
+  ContractMetadataV0,
+  ContractMetadataV1,
+  ContractMetadataV2,
+  ContractMetadataV3,
+  ContractProject,
+  ContractProjectContract,
+  ContractProjectInfo,
+  ContractProjectSource,
+  ContractProjectV0,
+  ContractSelector,
+  ContractStorageLayout,
+  ContractTypeSpec,
+} from "@polkadot/types/interfaces/contractsAbi";
+import type { FundIndex, FundInfo, LastContribution, TrieIndex } from "@polkadot/types/interfaces/crowdloan";
+import type {
+  CollationInfo,
+  CollationInfoV1,
+  ConfigData,
+  MessageId,
+  OverweightIndex,
+  PageCounter,
+  PageIndexData,
+} from "@polkadot/types/interfaces/cumulus";
+import type {
+  AccountVote,
+  AccountVoteSplit,
+  AccountVoteStandard,
+  Conviction,
+  Delegations,
+  PreimageStatus,
+  PreimageStatusAvailable,
+  PriorLock,
+  PropIndex,
+  Proposal,
+  ProxyState,
+  ReferendumIndex,
+  ReferendumInfo,
+  ReferendumInfoFinished,
+  ReferendumInfoTo239,
+  ReferendumStatus,
+  Tally,
+  Voting,
+  VotingDelegating,
+  VotingDirect,
+  VotingDirectVote,
+} from "@polkadot/types/interfaces/democracy";
+import type { BlockStats } from "@polkadot/types/interfaces/dev";
+import type {
+  ApprovalFlag,
+  DefunctVoter,
+  Renouncing,
+  SetIndex,
+  Vote,
+  VoteIndex,
+  VoteThreshold,
+  VoterInfo,
+} from "@polkadot/types/interfaces/elections";
+import type { CreatedBlock, ImportedAux } from "@polkadot/types/interfaces/engine";
+import type {
+  BlockV0,
+  BlockV1,
+  BlockV2,
+  EIP1559Transaction,
+  EIP2930Transaction,
+  EthAccessList,
+  EthAccessListItem,
+  EthAccount,
+  EthAddress,
+  EthBlock,
+  EthBloom,
+  EthCallRequest,
+  EthFeeHistory,
+  EthFilter,
+  EthFilterAddress,
+  EthFilterChanges,
+  EthFilterTopic,
+  EthFilterTopicEntry,
+  EthFilterTopicInner,
+  EthHeader,
+  EthLog,
+  EthReceipt,
+  EthReceiptV0,
+  EthReceiptV3,
+  EthRichBlock,
+  EthRichHeader,
+  EthStorageProof,
+  EthSubKind,
+  EthSubParams,
+  EthSubResult,
+  EthSyncInfo,
+  EthSyncStatus,
+  EthTransaction,
+  EthTransactionAction,
+  EthTransactionCondition,
+  EthTransactionRequest,
+  EthTransactionSignature,
+  EthTransactionStatus,
+  EthWork,
+  EthereumAccountId,
+  EthereumAddress,
+  EthereumLookupSource,
+  EthereumSignature,
+  LegacyTransaction,
+  TransactionV0,
+  TransactionV1,
+  TransactionV2,
+} from "@polkadot/types/interfaces/eth";
+import type {
+  EvmAccount,
+  EvmCallInfo,
+  EvmCreateInfo,
+  EvmLog,
+  EvmVicinity,
+  ExitError,
+  ExitFatal,
+  ExitReason,
+  ExitRevert,
+  ExitSucceed,
+} from "@polkadot/types/interfaces/evm";
+import type {
+  AnySignature,
+  EcdsaSignature,
+  Ed25519Signature,
+  Era,
+  Extrinsic,
+  ExtrinsicEra,
+  ExtrinsicPayload,
+  ExtrinsicPayloadUnknown,
+  ExtrinsicPayloadV4,
+  ExtrinsicSignature,
+  ExtrinsicSignatureV4,
+  ExtrinsicUnknown,
+  ExtrinsicV4,
+  ImmortalEra,
+  MortalEra,
+  MultiSignature,
+  Signature,
+  SignerPayload,
+  Sr25519Signature,
+} from "@polkadot/types/interfaces/extrinsics";
+import type {
+  AssetOptions,
+  Owner,
+  PermissionLatest,
+  PermissionVersions,
+  PermissionsV1,
+} from "@polkadot/types/interfaces/genericAsset";
+import type { ActiveGilt, ActiveGiltsTotal, ActiveIndex, GiltBid } from "@polkadot/types/interfaces/gilt";
+import type {
+  AuthorityIndex,
+  AuthorityList,
+  AuthoritySet,
+  AuthoritySetChange,
+  AuthoritySetChanges,
+  AuthorityWeight,
+  DelayKind,
+  DelayKindBest,
+  EncodedFinalityProofs,
+  ForkTreePendingChange,
+  ForkTreePendingChangeNode,
+  GrandpaCommit,
+  GrandpaEquivocation,
+  GrandpaEquivocationProof,
+  GrandpaEquivocationValue,
+  GrandpaJustification,
+  GrandpaPrecommit,
+  GrandpaPrevote,
+  GrandpaSignedPrecommit,
+  JustificationNotification,
+  KeyOwnerProof,
+  NextAuthority,
+  PendingChange,
+  PendingPause,
+  PendingResume,
+  Precommits,
+  Prevotes,
+  ReportedRoundStates,
+  RoundState,
+  SetId,
+  StoredPendingChange,
+  StoredState,
+} from "@polkadot/types/interfaces/grandpa";
+import type {
+  IdentityFields,
+  IdentityInfo,
+  IdentityInfoAdditional,
+  IdentityInfoTo198,
+  IdentityJudgement,
+  RegistrarIndex,
+  RegistrarInfo,
+  Registration,
+  RegistrationJudgement,
+  RegistrationTo198,
+} from "@polkadot/types/interfaces/identity";
+import type {
+  AuthIndex,
+  AuthoritySignature,
+  Heartbeat,
+  HeartbeatTo244,
+  OpaqueMultiaddr,
+  OpaqueNetworkState,
+  OpaquePeerId,
+} from "@polkadot/types/interfaces/imOnline";
+import type { CallIndex, LotteryConfig } from "@polkadot/types/interfaces/lottery";
+import type {
+  ErrorMetadataLatest,
+  ErrorMetadataV10,
+  ErrorMetadataV11,
+  ErrorMetadataV12,
+  ErrorMetadataV13,
+  ErrorMetadataV14,
+  ErrorMetadataV9,
+  EventMetadataLatest,
+  EventMetadataV10,
+  EventMetadataV11,
+  EventMetadataV12,
+  EventMetadataV13,
+  EventMetadataV14,
+  EventMetadataV9,
+  ExtrinsicMetadataLatest,
+  ExtrinsicMetadataV11,
+  ExtrinsicMetadataV12,
+  ExtrinsicMetadataV13,
+  ExtrinsicMetadataV14,
+  FunctionArgumentMetadataLatest,
+  FunctionArgumentMetadataV10,
+  FunctionArgumentMetadataV11,
+  FunctionArgumentMetadataV12,
+  FunctionArgumentMetadataV13,
+  FunctionArgumentMetadataV14,
+  FunctionArgumentMetadataV9,
+  FunctionMetadataLatest,
+  FunctionMetadataV10,
+  FunctionMetadataV11,
+  FunctionMetadataV12,
+  FunctionMetadataV13,
+  FunctionMetadataV14,
+  FunctionMetadataV9,
+  MetadataAll,
+  MetadataLatest,
+  MetadataV10,
+  MetadataV11,
+  MetadataV12,
+  MetadataV13,
+  MetadataV14,
+  MetadataV9,
+  ModuleConstantMetadataV10,
+  ModuleConstantMetadataV11,
+  ModuleConstantMetadataV12,
+  ModuleConstantMetadataV13,
+  ModuleConstantMetadataV9,
+  ModuleMetadataV10,
+  ModuleMetadataV11,
+  ModuleMetadataV12,
+  ModuleMetadataV13,
+  ModuleMetadataV9,
+  OpaqueMetadata,
+  PalletCallMetadataLatest,
+  PalletCallMetadataV14,
+  PalletConstantMetadataLatest,
+  PalletConstantMetadataV14,
+  PalletErrorMetadataLatest,
+  PalletErrorMetadataV14,
+  PalletEventMetadataLatest,
+  PalletEventMetadataV14,
+  PalletMetadataLatest,
+  PalletMetadataV14,
+  PalletStorageMetadataLatest,
+  PalletStorageMetadataV14,
+  PortableType,
+  PortableTypeV14,
+  SignedExtensionMetadataLatest,
+  SignedExtensionMetadataV14,
+  StorageEntryMetadataLatest,
+  StorageEntryMetadataV10,
+  StorageEntryMetadataV11,
+  StorageEntryMetadataV12,
+  StorageEntryMetadataV13,
+  StorageEntryMetadataV14,
+  StorageEntryMetadataV9,
+  StorageEntryModifierLatest,
+  StorageEntryModifierV10,
+  StorageEntryModifierV11,
+  StorageEntryModifierV12,
+  StorageEntryModifierV13,
+  StorageEntryModifierV14,
+  StorageEntryModifierV9,
+  StorageEntryTypeLatest,
+  StorageEntryTypeV10,
+  StorageEntryTypeV11,
+  StorageEntryTypeV12,
+  StorageEntryTypeV13,
+  StorageEntryTypeV14,
+  StorageEntryTypeV9,
+  StorageHasher,
+  StorageHasherV10,
+  StorageHasherV11,
+  StorageHasherV12,
+  StorageHasherV13,
+  StorageHasherV14,
+  StorageHasherV9,
+  StorageMetadataV10,
+  StorageMetadataV11,
+  StorageMetadataV12,
+  StorageMetadataV13,
+  StorageMetadataV9,
+} from "@polkadot/types/interfaces/metadata";
+import type {
+  MmrBatchProof,
+  MmrEncodableOpaqueLeaf,
+  MmrError,
+  MmrLeafBatchProof,
+  MmrLeafIndex,
+  MmrLeafProof,
+  MmrNodeIndex,
+  MmrProof,
+} from "@polkadot/types/interfaces/mmr";
+import type { NpApiError } from "@polkadot/types/interfaces/nompools";
+import type { StorageKind } from "@polkadot/types/interfaces/offchain";
+import type {
+  DeferredOffenceOf,
+  Kind,
+  OffenceDetails,
+  Offender,
+  OpaqueTimeSlot,
+  ReportIdOf,
+  Reporter,
+} from "@polkadot/types/interfaces/offences";
+import type {
+  AbridgedCandidateReceipt,
+  AbridgedHostConfiguration,
+  AbridgedHrmpChannel,
+  AssignmentId,
+  AssignmentKind,
+  AttestedCandidate,
+  AuctionIndex,
+  AuthorityDiscoveryId,
+  AvailabilityBitfield,
+  AvailabilityBitfieldRecord,
+  BackedCandidate,
+  Bidder,
+  BufferedSessionChange,
+  CandidateCommitments,
+  CandidateDescriptor,
+  CandidateEvent,
+  CandidateHash,
+  CandidateInfo,
+  CandidatePendingAvailability,
+  CandidateReceipt,
+  CollatorId,
+  CollatorSignature,
+  CommittedCandidateReceipt,
+  CoreAssignment,
+  CoreIndex,
+  CoreOccupied,
+  CoreState,
+  DisputeLocation,
+  DisputeResult,
+  DisputeState,
+  DisputeStatement,
+  DisputeStatementSet,
+  DoubleVoteReport,
+  DownwardMessage,
+  ExplicitDisputeStatement,
+  GlobalValidationData,
+  GlobalValidationSchedule,
+  GroupIndex,
+  GroupRotationInfo,
+  HeadData,
+  HostConfiguration,
+  HrmpChannel,
+  HrmpChannelId,
+  HrmpOpenChannelRequest,
+  InboundDownwardMessage,
+  InboundHrmpMessage,
+  InboundHrmpMessages,
+  IncomingParachain,
+  IncomingParachainDeploy,
+  IncomingParachainFixed,
+  InvalidDisputeStatementKind,
+  LeasePeriod,
+  LeasePeriodOf,
+  LocalValidationData,
+  MessageIngestionType,
+  MessageQueueChain,
+  MessagingStateSnapshot,
+  MessagingStateSnapshotEgressEntry,
+  MultiDisputeStatementSet,
+  NewBidder,
+  OccupiedCore,
+  OccupiedCoreAssumption,
+  OldV1SessionInfo,
+  OutboundHrmpMessage,
+  ParaGenesisArgs,
+  ParaId,
+  ParaInfo,
+  ParaLifecycle,
+  ParaPastCodeMeta,
+  ParaScheduling,
+  ParaValidatorIndex,
+  ParachainDispatchOrigin,
+  ParachainInherentData,
+  ParachainProposal,
+  ParachainsInherentData,
+  ParathreadClaim,
+  ParathreadClaimQueue,
+  ParathreadEntry,
+  PersistedValidationData,
+  PvfCheckStatement,
+  QueuedParathread,
+  RegisteredParachainInfo,
+  RelayBlockNumber,
+  RelayChainBlockNumber,
+  RelayChainHash,
+  RelayHash,
+  Remark,
+  ReplacementTimes,
+  Retriable,
+  ScheduledCore,
+  Scheduling,
+  ScrapedOnChainVotes,
+  ServiceQuality,
+  SessionInfo,
+  SessionInfoValidatorGroup,
+  SignedAvailabilityBitfield,
+  SignedAvailabilityBitfields,
+  SigningContext,
+  SlotRange,
+  SlotRange10,
+  Statement,
+  SubId,
+  SystemInherentData,
+  TransientValidationData,
+  UpgradeGoAhead,
+  UpgradeRestriction,
+  UpwardMessage,
+  ValidDisputeStatementKind,
+  ValidationCode,
+  ValidationCodeHash,
+  ValidationData,
+  ValidationDataType,
+  ValidationFunctionParams,
+  ValidatorSignature,
+  ValidityAttestation,
+  VecInboundHrmpMessage,
+  WinnersData,
+  WinnersData10,
+  WinnersDataTuple,
+  WinnersDataTuple10,
+  WinningData,
+  WinningData10,
+  WinningDataEntry,
+} from "@polkadot/types/interfaces/parachains";
+import type { FeeDetails, InclusionFee, RuntimeDispatchInfo } from "@polkadot/types/interfaces/payment";
+import type { Approvals } from "@polkadot/types/interfaces/poll";
+import type { ProxyAnnouncement, ProxyDefinition, ProxyType } from "@polkadot/types/interfaces/proxy";
+import type { AccountStatus, AccountValidity } from "@polkadot/types/interfaces/purchase";
+import type { ActiveRecovery, RecoveryConfig } from "@polkadot/types/interfaces/recovery";
+import type { RpcMethods } from "@polkadot/types/interfaces/rpc";
+import type {
+  AccountId,
+  AccountId20,
+  AccountId32,
+  AccountIdOf,
+  AccountIndex,
+  Address,
+  AssetId,
+  Balance,
+  BalanceOf,
+  Block,
+  BlockNumber,
+  BlockNumberFor,
+  BlockNumberOf,
+  Call,
+  CallHash,
+  CallHashOf,
+  ChangesTrieConfiguration,
+  ChangesTrieSignal,
+  CodecHash,
+  Consensus,
+  ConsensusEngineId,
+  CrateVersion,
+  Digest,
+  DigestItem,
+  EncodedJustification,
+  ExtrinsicsWeight,
+  Fixed128,
+  Fixed64,
+  FixedI128,
+  FixedI64,
+  FixedU128,
+  FixedU64,
+  H1024,
+  H128,
+  H160,
+  H2048,
+  H256,
+  H32,
+  H512,
+  H64,
+  Hash,
+  Header,
+  HeaderPartial,
+  I32F32,
+  Index,
+  IndicesLookupSource,
+  Justification,
+  Justifications,
+  KeyTypeId,
+  KeyValue,
+  LockIdentifier,
+  LookupSource,
+  LookupTarget,
+  ModuleId,
+  Moment,
+  MultiAddress,
+  MultiSigner,
+  OpaqueCall,
+  Origin,
+  OriginCaller,
+  PalletId,
+  PalletVersion,
+  PalletsOrigin,
+  Pays,
+  PerU16,
+  Perbill,
+  Percent,
+  Permill,
+  Perquintill,
+  Phantom,
+  PhantomData,
+  PreRuntime,
+  Releases,
+  RuntimeDbWeight,
+  Seal,
+  SealV0,
+  SignedBlock,
+  SignedBlockWithJustification,
+  SignedBlockWithJustifications,
+  Slot,
+  SlotDuration,
+  StorageData,
+  StorageInfo,
+  StorageProof,
+  TransactionInfo,
+  TransactionLongevity,
+  TransactionPriority,
+  TransactionStorageProof,
+  TransactionTag,
+  U32F32,
+  ValidatorId,
+  ValidatorIdOf,
+  Weight,
+  WeightMultiplier,
+} from "@polkadot/types/interfaces/runtime";
+import type {
+  Si0Field,
+  Si0LookupTypeId,
+  Si0Path,
+  Si0Type,
+  Si0TypeDef,
+  Si0TypeDefArray,
+  Si0TypeDefBitSequence,
+  Si0TypeDefCompact,
+  Si0TypeDefComposite,
+  Si0TypeDefPhantom,
+  Si0TypeDefPrimitive,
+  Si0TypeDefSequence,
+  Si0TypeDefTuple,
+  Si0TypeDefVariant,
+  Si0TypeParameter,
+  Si0Variant,
+  Si1Field,
+  Si1LookupTypeId,
+  Si1Path,
+  Si1Type,
+  Si1TypeDef,
+  Si1TypeDefArray,
+  Si1TypeDefBitSequence,
+  Si1TypeDefCompact,
+  Si1TypeDefComposite,
+  Si1TypeDefPrimitive,
+  Si1TypeDefSequence,
+  Si1TypeDefTuple,
+  Si1TypeDefVariant,
+  Si1TypeParameter,
+  Si1Variant,
+  SiField,
+  SiLookupTypeId,
+  SiPath,
+  SiType,
+  SiTypeDef,
+  SiTypeDefArray,
+  SiTypeDefBitSequence,
+  SiTypeDefCompact,
+  SiTypeDefComposite,
+  SiTypeDefPrimitive,
+  SiTypeDefSequence,
+  SiTypeDefTuple,
+  SiTypeDefVariant,
+  SiTypeParameter,
+  SiVariant,
+} from "@polkadot/types/interfaces/scaleInfo";
+import type {
+  Period,
+  Priority,
+  SchedulePeriod,
+  SchedulePriority,
+  Scheduled,
+  ScheduledTo254,
+  TaskAddress,
+} from "@polkadot/types/interfaces/scheduler";
+import type {
+  BeefyKey,
+  FullIdentification,
+  IdentificationTuple,
+  Keys,
+  MembershipProof,
+  SessionIndex,
+  SessionKeys1,
+  SessionKeys10,
+  SessionKeys10B,
+  SessionKeys2,
+  SessionKeys3,
+  SessionKeys4,
+  SessionKeys5,
+  SessionKeys6,
+  SessionKeys6B,
+  SessionKeys7,
+  SessionKeys7B,
+  SessionKeys8,
+  SessionKeys8B,
+  SessionKeys9,
+  SessionKeys9B,
+  ValidatorCount,
+} from "@polkadot/types/interfaces/session";
+import type {
+  Bid,
+  BidKind,
+  SocietyJudgement,
+  SocietyVote,
+  StrikeCount,
+  VouchingStatus,
+} from "@polkadot/types/interfaces/society";
+import type {
+  ActiveEraInfo,
+  CompactAssignments,
+  CompactAssignmentsTo257,
+  CompactAssignmentsTo265,
+  CompactAssignmentsWith16,
+  CompactAssignmentsWith24,
+  CompactScore,
+  CompactScoreCompact,
+  ElectionCompute,
+  ElectionPhase,
+  ElectionResult,
+  ElectionScore,
+  ElectionSize,
+  ElectionStatus,
+  EraIndex,
+  EraPoints,
+  EraRewardPoints,
+  EraRewards,
+  Exposure,
+  ExtendedBalance,
+  Forcing,
+  IndividualExposure,
+  KeyType,
+  MomentOf,
+  Nominations,
+  NominatorIndex,
+  NominatorIndexCompact,
+  OffchainAccuracy,
+  OffchainAccuracyCompact,
+  PhragmenScore,
+  Points,
+  RawSolution,
+  RawSolutionTo265,
+  RawSolutionWith16,
+  RawSolutionWith24,
+  ReadySolution,
+  RewardDestination,
+  RewardPoint,
+  RoundSnapshot,
+  SeatHolder,
+  SignedSubmission,
+  SignedSubmissionOf,
+  SignedSubmissionTo276,
+  SlashJournalEntry,
+  SlashingSpans,
+  SlashingSpansTo204,
+  SolutionOrSnapshotSize,
+  SolutionSupport,
+  SolutionSupports,
+  SpanIndex,
+  SpanRecord,
+  StakingLedger,
+  StakingLedgerTo223,
+  StakingLedgerTo240,
+  SubmissionIndicesOf,
+  Supports,
+  UnappliedSlash,
+  UnappliedSlashOther,
+  UnlockChunk,
+  ValidatorIndex,
+  ValidatorIndexCompact,
+  ValidatorPrefs,
+  ValidatorPrefsTo145,
+  ValidatorPrefsTo196,
+  ValidatorPrefsWithBlocked,
+  ValidatorPrefsWithCommission,
+  VoteWeight,
+  Voter,
+} from "@polkadot/types/interfaces/staking";
+import type {
+  ApiId,
+  BlockTrace,
+  BlockTraceEvent,
+  BlockTraceEventData,
+  BlockTraceSpan,
+  KeyValueOption,
+  MigrationStatusResult,
+  ReadProof,
+  RuntimeVersion,
+  RuntimeVersionApi,
+  RuntimeVersionPartial,
+  RuntimeVersionPre3,
+  RuntimeVersionPre4,
+  SpecVersion,
+  StorageChangeSet,
+  TraceBlockResponse,
+  TraceError,
+} from "@polkadot/types/interfaces/state";
+import type { WeightToFeeCoefficient } from "@polkadot/types/interfaces/support";
+import type {
+  AccountInfo,
+  AccountInfoWithDualRefCount,
+  AccountInfoWithProviders,
+  AccountInfoWithRefCount,
+  AccountInfoWithRefCountU8,
+  AccountInfoWithTripleRefCount,
+  ApplyExtrinsicResult,
+  ApplyExtrinsicResultPre6,
+  ArithmeticError,
+  BlockLength,
+  BlockWeights,
+  ChainProperties,
+  ChainType,
+  ConsumedWeight,
+  DigestOf,
+  DispatchClass,
+  DispatchError,
+  DispatchErrorModule,
+  DispatchErrorModulePre6,
+  DispatchErrorModuleU8,
+  DispatchErrorModuleU8a,
+  DispatchErrorPre6,
+  DispatchErrorPre6First,
+  DispatchErrorTo198,
+  DispatchInfo,
+  DispatchInfoTo190,
+  DispatchInfoTo244,
+  DispatchOutcome,
+  DispatchOutcomePre6,
+  DispatchResult,
+  DispatchResultOf,
+  DispatchResultTo198,
+  Event,
+  EventId,
+  EventIndex,
+  EventRecord,
+  Health,
+  InvalidTransaction,
+  Key,
+  LastRuntimeUpgradeInfo,
+  NetworkState,
+  NetworkStatePeerset,
+  NetworkStatePeersetInfo,
+  NodeRole,
+  NotConnectedPeer,
+  Peer,
+  PeerEndpoint,
+  PeerEndpointAddr,
+  PeerInfo,
+  PeerPing,
+  PerDispatchClassU32,
+  PerDispatchClassWeight,
+  PerDispatchClassWeightsPerClass,
+  Phase,
+  RawOrigin,
+  RefCount,
+  RefCountTo259,
+  SyncState,
+  SystemOrigin,
+  TokenError,
+  TransactionValidityError,
+  TransactionalError,
+  UnknownTransaction,
+  WeightPerClass,
+} from "@polkadot/types/interfaces/system";
+import type {
+  Bounty,
+  BountyIndex,
+  BountyStatus,
+  BountyStatusActive,
+  BountyStatusCuratorProposed,
+  BountyStatusPendingPayout,
+  OpenTip,
+  OpenTipFinderTo225,
+  OpenTipTip,
+  OpenTipTo225,
+  TreasuryProposal,
+} from "@polkadot/types/interfaces/treasury";
+import type { Multiplier } from "@polkadot/types/interfaces/txpayment";
+import type { TransactionSource, TransactionValidity, ValidTransaction } from "@polkadot/types/interfaces/txqueue";
+import type {
+  ClassDetails,
+  ClassId,
+  ClassMetadata,
+  DepositBalance,
+  DepositBalanceOf,
+  DestroyWitness,
+  InstanceDetails,
+  InstanceId,
+  InstanceMetadata,
+} from "@polkadot/types/interfaces/uniques";
+import type { Multisig, Timepoint } from "@polkadot/types/interfaces/utility";
+import type { VestingInfo } from "@polkadot/types/interfaces/vesting";
+import type {
+  AssetInstance,
+  AssetInstanceV0,
+  AssetInstanceV1,
+  AssetInstanceV2,
+  BodyId,
+  BodyPart,
+  DoubleEncodedCall,
+  Fungibility,
+  FungibilityV0,
+  FungibilityV1,
+  FungibilityV2,
+  InboundStatus,
+  InstructionV2,
+  InteriorMultiLocation,
+  Junction,
+  JunctionV0,
+  JunctionV1,
+  JunctionV2,
+  Junctions,
+  JunctionsV1,
+  JunctionsV2,
+  MultiAsset,
+  MultiAssetFilter,
+  MultiAssetFilterV1,
+  MultiAssetFilterV2,
+  MultiAssetV0,
+  MultiAssetV1,
+  MultiAssetV2,
+  MultiAssets,
+  MultiAssetsV1,
+  MultiAssetsV2,
+  MultiLocation,
+  MultiLocationV0,
+  MultiLocationV1,
+  MultiLocationV2,
+  NetworkId,
+  OriginKindV0,
+  OriginKindV1,
+  OriginKindV2,
+  OutboundStatus,
+  Outcome,
+  QueryId,
+  QueryStatus,
+  QueueConfigData,
+  Response,
+  ResponseV0,
+  ResponseV1,
+  ResponseV2,
+  ResponseV2Error,
+  ResponseV2Result,
+  VersionMigrationStage,
+  VersionedMultiAsset,
+  VersionedMultiAssets,
+  VersionedMultiLocation,
+  VersionedResponse,
+  VersionedXcm,
+  WeightLimitV2,
+  WildFungibility,
+  WildFungibilityV0,
+  WildFungibilityV1,
+  WildFungibilityV2,
+  WildMultiAsset,
+  WildMultiAssetV1,
+  WildMultiAssetV2,
+  Xcm,
+  XcmAssetId,
+  XcmError,
+  XcmErrorV0,
+  XcmErrorV1,
+  XcmErrorV2,
+  XcmOrder,
+  XcmOrderV0,
+  XcmOrderV1,
+  XcmOrderV2,
+  XcmOrigin,
+  XcmOriginKind,
+  XcmV0,
+  XcmV1,
+  XcmV2,
+  XcmVersion,
+  XcmpMessageFormat,
+} from "@polkadot/types/interfaces/xcm";
+
+declare module "@polkadot/types/types/registry" {
+  interface InterfaceTypes {
+    AbridgedCandidateReceipt: AbridgedCandidateReceipt;
+    AbridgedHostConfiguration: AbridgedHostConfiguration;
+    AbridgedHrmpChannel: AbridgedHrmpChannel;
+    AccountData: AccountData;
+    AccountId: AccountId;
+    AccountId20: AccountId20;
+    AccountId32: AccountId32;
+    AccountIdOf: AccountIdOf;
+    AccountIndex: AccountIndex;
+    AccountInfo: AccountInfo;
+    AccountInfoWithDualRefCount: AccountInfoWithDualRefCount;
+    AccountInfoWithProviders: AccountInfoWithProviders;
+    AccountInfoWithRefCount: AccountInfoWithRefCount;
+    AccountInfoWithRefCountU8: AccountInfoWithRefCountU8;
+    AccountInfoWithTripleRefCount: AccountInfoWithTripleRefCount;
+    AccountStatus: AccountStatus;
+    AccountValidity: AccountValidity;
+    AccountVote: AccountVote;
+    AccountVoteSplit: AccountVoteSplit;
+    AccountVoteStandard: AccountVoteStandard;
+    ActiveEraInfo: ActiveEraInfo;
+    ActiveGilt: ActiveGilt;
+    ActiveGiltsTotal: ActiveGiltsTotal;
+    ActiveIndex: ActiveIndex;
+    ActiveRecovery: ActiveRecovery;
+    Address: Address;
+    AliveContractInfo: AliveContractInfo;
+    AllowedSlots: AllowedSlots;
+    AnySignature: AnySignature;
+    ApiId: ApiId;
+    ApplyExtrinsicResult: ApplyExtrinsicResult;
+    ApplyExtrinsicResultPre6: ApplyExtrinsicResultPre6;
+    ApprovalFlag: ApprovalFlag;
+    Approvals: Approvals;
+    ArithmeticError: ArithmeticError;
+    AssetApproval: AssetApproval;
+    AssetApprovalKey: AssetApprovalKey;
+    AssetBalance: AssetBalance;
+    AssetDestroyWitness: AssetDestroyWitness;
+    AssetDetails: AssetDetails;
+    AssetId: AssetId;
+    AssetInstance: AssetInstance;
+    AssetInstanceV0: AssetInstanceV0;
+    AssetInstanceV1: AssetInstanceV1;
+    AssetInstanceV2: AssetInstanceV2;
+    AssetMetadata: AssetMetadata;
+    AssetOptions: AssetOptions;
+    AssignmentId: AssignmentId;
+    AssignmentKind: AssignmentKind;
+    AttestedCandidate: AttestedCandidate;
+    AuctionIndex: AuctionIndex;
+    AuthIndex: AuthIndex;
+    AuthorityDiscoveryId: AuthorityDiscoveryId;
+    AuthorityId: AuthorityId;
+    AuthorityIndex: AuthorityIndex;
+    AuthorityList: AuthorityList;
+    AuthoritySet: AuthoritySet;
+    AuthoritySetChange: AuthoritySetChange;
+    AuthoritySetChanges: AuthoritySetChanges;
+    AuthoritySignature: AuthoritySignature;
+    AuthorityWeight: AuthorityWeight;
+    AvailabilityBitfield: AvailabilityBitfield;
+    AvailabilityBitfieldRecord: AvailabilityBitfieldRecord;
+    BabeAuthorityWeight: BabeAuthorityWeight;
+    BabeBlockWeight: BabeBlockWeight;
+    BabeEpochConfiguration: BabeEpochConfiguration;
+    BabeEquivocationProof: BabeEquivocationProof;
+    BabeGenesisConfiguration: BabeGenesisConfiguration;
+    BabeGenesisConfigurationV1: BabeGenesisConfigurationV1;
+    BabeWeight: BabeWeight;
+    BackedCandidate: BackedCandidate;
+    Balance: Balance;
+    BalanceLock: BalanceLock;
+    BalanceLockTo212: BalanceLockTo212;
+    BalanceOf: BalanceOf;
+    BalanceStatus: BalanceStatus;
+    BeefyAuthoritySet: BeefyAuthoritySet;
+    BeefyCommitment: BeefyCommitment;
+    BeefyId: BeefyId;
+    BeefyKey: BeefyKey;
+    BeefyNextAuthoritySet: BeefyNextAuthoritySet;
+    BeefyPayload: BeefyPayload;
+    BeefyPayloadId: BeefyPayloadId;
+    BeefySignedCommitment: BeefySignedCommitment;
+    BenchmarkConfig: BenchmarkConfig;
+    BenchmarkList: BenchmarkList;
+    BenchmarkMetadata: BenchmarkMetadata;
+    BenchmarkParameter: BenchmarkParameter;
+    Bid: Bid;
+    Bidder: Bidder;
+    BidKind: BidKind;
+    BitVec: BitVec;
+    Block: Block;
+    BlockAttestations: BlockAttestations;
+    BlockHash: BlockHash;
+    BlockLength: BlockLength;
+    BlockNumber: BlockNumber;
+    BlockNumberFor: BlockNumberFor;
+    BlockNumberOf: BlockNumberOf;
+    BlockStats: BlockStats;
+    BlockTrace: BlockTrace;
+    BlockTraceEvent: BlockTraceEvent;
+    BlockTraceEventData: BlockTraceEventData;
+    BlockTraceSpan: BlockTraceSpan;
+    BlockV0: BlockV0;
+    BlockV1: BlockV1;
+    BlockV2: BlockV2;
+    BlockWeights: BlockWeights;
+    BodyId: BodyId;
+    BodyPart: BodyPart;
+    bool: bool;
+    Bool: Bool;
+    Bounty: Bounty;
+    BountyIndex: BountyIndex;
+    BountyStatus: BountyStatus;
+    BountyStatusActive: BountyStatusActive;
+    BountyStatusCuratorProposed: BountyStatusCuratorProposed;
+    BountyStatusPendingPayout: BountyStatusPendingPayout;
+    BridgedBlockHash: BridgedBlockHash;
+    BridgedBlockNumber: BridgedBlockNumber;
+    BridgedHeader: BridgedHeader;
+    BridgeMessageId: BridgeMessageId;
+    BufferedSessionChange: BufferedSessionChange;
+    Bytes: Bytes;
+    Call: Call;
+    CallHash: CallHash;
+    CallHashOf: CallHashOf;
+    CallIndex: CallIndex;
+    CallOrigin: CallOrigin;
+    CandidateCommitments: CandidateCommitments;
+    CandidateDescriptor: CandidateDescriptor;
+    CandidateEvent: CandidateEvent;
+    CandidateHash: CandidateHash;
+    CandidateInfo: CandidateInfo;
+    CandidatePendingAvailability: CandidatePendingAvailability;
+    CandidateReceipt: CandidateReceipt;
+    ChainId: ChainId;
+    ChainProperties: ChainProperties;
+    ChainType: ChainType;
+    ChangesTrieConfiguration: ChangesTrieConfiguration;
+    ChangesTrieSignal: ChangesTrieSignal;
+    CheckInherentsResult: CheckInherentsResult;
+    ClassDetails: ClassDetails;
+    ClassId: ClassId;
+    ClassMetadata: ClassMetadata;
+    CodecHash: CodecHash;
+    CodeHash: CodeHash;
+    CodeSource: CodeSource;
+    CodeUploadRequest: CodeUploadRequest;
+    CodeUploadResult: CodeUploadResult;
+    CodeUploadResultValue: CodeUploadResultValue;
+    CollationInfo: CollationInfo;
+    CollationInfoV1: CollationInfoV1;
+    CollatorId: CollatorId;
+    CollatorSignature: CollatorSignature;
+    CollectiveOrigin: CollectiveOrigin;
+    CommittedCandidateReceipt: CommittedCandidateReceipt;
+    CompactAssignments: CompactAssignments;
+    CompactAssignmentsTo257: CompactAssignmentsTo257;
+    CompactAssignmentsTo265: CompactAssignmentsTo265;
+    CompactAssignmentsWith16: CompactAssignmentsWith16;
+    CompactAssignmentsWith24: CompactAssignmentsWith24;
+    CompactScore: CompactScore;
+    CompactScoreCompact: CompactScoreCompact;
+    ConfigData: ConfigData;
+    Consensus: Consensus;
+    ConsensusEngineId: ConsensusEngineId;
+    ConsumedWeight: ConsumedWeight;
+    ContractCallFlags: ContractCallFlags;
+    ContractCallRequest: ContractCallRequest;
+    ContractConstructorSpecLatest: ContractConstructorSpecLatest;
+    ContractConstructorSpecV0: ContractConstructorSpecV0;
+    ContractConstructorSpecV1: ContractConstructorSpecV1;
+    ContractConstructorSpecV2: ContractConstructorSpecV2;
+    ContractConstructorSpecV3: ContractConstructorSpecV3;
+    ContractContractSpecV0: ContractContractSpecV0;
+    ContractContractSpecV1: ContractContractSpecV1;
+    ContractContractSpecV2: ContractContractSpecV2;
+    ContractContractSpecV3: ContractContractSpecV3;
+    ContractCryptoHasher: ContractCryptoHasher;
+    ContractDiscriminant: ContractDiscriminant;
+    ContractDisplayName: ContractDisplayName;
+    ContractEventParamSpecLatest: ContractEventParamSpecLatest;
+    ContractEventParamSpecV0: ContractEventParamSpecV0;
+    ContractEventParamSpecV2: ContractEventParamSpecV2;
+    ContractEventSpecLatest: ContractEventSpecLatest;
+    ContractEventSpecV0: ContractEventSpecV0;
+    ContractEventSpecV1: ContractEventSpecV1;
+    ContractEventSpecV2: ContractEventSpecV2;
+    ContractExecResult: ContractExecResult;
+    ContractExecResultOk: ContractExecResultOk;
+    ContractExecResultResult: ContractExecResultResult;
+    ContractExecResultSuccessTo255: ContractExecResultSuccessTo255;
+    ContractExecResultSuccessTo260: ContractExecResultSuccessTo260;
+    ContractExecResultTo255: ContractExecResultTo255;
+    ContractExecResultTo260: ContractExecResultTo260;
+    ContractExecResultTo267: ContractExecResultTo267;
+    ContractInfo: ContractInfo;
+    ContractInstantiateResult: ContractInstantiateResult;
+    ContractInstantiateResultTo267: ContractInstantiateResultTo267;
+    ContractInstantiateResultTo299: ContractInstantiateResultTo299;
+    ContractLayoutArray: ContractLayoutArray;
+    ContractLayoutCell: ContractLayoutCell;
+    ContractLayoutEnum: ContractLayoutEnum;
+    ContractLayoutHash: ContractLayoutHash;
+    ContractLayoutHashingStrategy: ContractLayoutHashingStrategy;
+    ContractLayoutKey: ContractLayoutKey;
+    ContractLayoutStruct: ContractLayoutStruct;
+    ContractLayoutStructField: ContractLayoutStructField;
+    ContractMessageParamSpecLatest: ContractMessageParamSpecLatest;
+    ContractMessageParamSpecV0: ContractMessageParamSpecV0;
+    ContractMessageParamSpecV2: ContractMessageParamSpecV2;
+    ContractMessageSpecLatest: ContractMessageSpecLatest;
+    ContractMessageSpecV0: ContractMessageSpecV0;
+    ContractMessageSpecV1: ContractMessageSpecV1;
+    ContractMessageSpecV2: ContractMessageSpecV2;
+    ContractMetadata: ContractMetadata;
+    ContractMetadataLatest: ContractMetadataLatest;
+    ContractMetadataV0: ContractMetadataV0;
+    ContractMetadataV1: ContractMetadataV1;
+    ContractMetadataV2: ContractMetadataV2;
+    ContractMetadataV3: ContractMetadataV3;
+    ContractProject: ContractProject;
+    ContractProjectContract: ContractProjectContract;
+    ContractProjectInfo: ContractProjectInfo;
+    ContractProjectSource: ContractProjectSource;
+    ContractProjectV0: ContractProjectV0;
+    ContractReturnFlags: ContractReturnFlags;
+    ContractSelector: ContractSelector;
+    ContractStorageKey: ContractStorageKey;
+    ContractStorageLayout: ContractStorageLayout;
+    ContractTypeSpec: ContractTypeSpec;
+    Conviction: Conviction;
+    CoreAssignment: CoreAssignment;
+    CoreIndex: CoreIndex;
+    CoreOccupied: CoreOccupied;
+    CoreState: CoreState;
+    CrateVersion: CrateVersion;
+    CreatedBlock: CreatedBlock;
+    Data: Data;
+    DeferredOffenceOf: DeferredOffenceOf;
+    DefunctVoter: DefunctVoter;
+    DelayKind: DelayKind;
+    DelayKindBest: DelayKindBest;
+    Delegations: Delegations;
+    DeletedContract: DeletedContract;
+    DeliveredMessages: DeliveredMessages;
+    DepositBalance: DepositBalance;
+    DepositBalanceOf: DepositBalanceOf;
+    DestroyWitness: DestroyWitness;
+    Digest: Digest;
+    DigestItem: DigestItem;
+    DigestOf: DigestOf;
+    DispatchClass: DispatchClass;
+    DispatchError: DispatchError;
+    DispatchErrorModule: DispatchErrorModule;
+    DispatchErrorModulePre6: DispatchErrorModulePre6;
+    DispatchErrorModuleU8: DispatchErrorModuleU8;
+    DispatchErrorModuleU8a: DispatchErrorModuleU8a;
+    DispatchErrorPre6: DispatchErrorPre6;
+    DispatchErrorPre6First: DispatchErrorPre6First;
+    DispatchErrorTo198: DispatchErrorTo198;
+    DispatchFeePayment: DispatchFeePayment;
+    DispatchInfo: DispatchInfo;
+    DispatchInfoTo190: DispatchInfoTo190;
+    DispatchInfoTo244: DispatchInfoTo244;
+    DispatchOutcome: DispatchOutcome;
+    DispatchOutcomePre6: DispatchOutcomePre6;
+    DispatchResult: DispatchResult;
+    DispatchResultOf: DispatchResultOf;
+    DispatchResultTo198: DispatchResultTo198;
+    DisputeLocation: DisputeLocation;
+    DisputeResult: DisputeResult;
+    DisputeState: DisputeState;
+    DisputeStatement: DisputeStatement;
+    DisputeStatementSet: DisputeStatementSet;
+    DoubleEncodedCall: DoubleEncodedCall;
+    DoubleVoteReport: DoubleVoteReport;
+    DownwardMessage: DownwardMessage;
+    EcdsaSignature: EcdsaSignature;
+    Ed25519Signature: Ed25519Signature;
+    EIP1559Transaction: EIP1559Transaction;
+    EIP2930Transaction: EIP2930Transaction;
+    ElectionCompute: ElectionCompute;
+    ElectionPhase: ElectionPhase;
+    ElectionResult: ElectionResult;
+    ElectionScore: ElectionScore;
+    ElectionSize: ElectionSize;
+    ElectionStatus: ElectionStatus;
+    EncodedFinalityProofs: EncodedFinalityProofs;
+    EncodedJustification: EncodedJustification;
+    Epoch: Epoch;
+    EpochAuthorship: EpochAuthorship;
+    Era: Era;
+    EraIndex: EraIndex;
+    EraPoints: EraPoints;
+    EraRewardPoints: EraRewardPoints;
+    EraRewards: EraRewards;
+    ErrorMetadataLatest: ErrorMetadataLatest;
+    ErrorMetadataV10: ErrorMetadataV10;
+    ErrorMetadataV11: ErrorMetadataV11;
+    ErrorMetadataV12: ErrorMetadataV12;
+    ErrorMetadataV13: ErrorMetadataV13;
+    ErrorMetadataV14: ErrorMetadataV14;
+    ErrorMetadataV9: ErrorMetadataV9;
+    EthAccessList: EthAccessList;
+    EthAccessListItem: EthAccessListItem;
+    EthAccount: EthAccount;
+    EthAddress: EthAddress;
+    EthBlock: EthBlock;
+    EthBloom: EthBloom;
+    EthCallRequest: EthCallRequest;
+    EthereumAccountId: EthereumAccountId;
+    EthereumAddress: EthereumAddress;
+    EthereumLookupSource: EthereumLookupSource;
+    EthereumSignature: EthereumSignature;
+    EthFeeHistory: EthFeeHistory;
+    EthFilter: EthFilter;
+    EthFilterAddress: EthFilterAddress;
+    EthFilterChanges: EthFilterChanges;
+    EthFilterTopic: EthFilterTopic;
+    EthFilterTopicEntry: EthFilterTopicEntry;
+    EthFilterTopicInner: EthFilterTopicInner;
+    EthHeader: EthHeader;
+    EthLog: EthLog;
+    EthReceipt: EthReceipt;
+    EthReceiptV0: EthReceiptV0;
+    EthReceiptV3: EthReceiptV3;
+    EthRichBlock: EthRichBlock;
+    EthRichHeader: EthRichHeader;
+    EthStorageProof: EthStorageProof;
+    EthSubKind: EthSubKind;
+    EthSubParams: EthSubParams;
+    EthSubResult: EthSubResult;
+    EthSyncInfo: EthSyncInfo;
+    EthSyncStatus: EthSyncStatus;
+    EthTransaction: EthTransaction;
+    EthTransactionAction: EthTransactionAction;
+    EthTransactionCondition: EthTransactionCondition;
+    EthTransactionRequest: EthTransactionRequest;
+    EthTransactionSignature: EthTransactionSignature;
+    EthTransactionStatus: EthTransactionStatus;
+    EthWork: EthWork;
+    Event: Event;
+    EventId: EventId;
+    EventIndex: EventIndex;
+    EventMetadataLatest: EventMetadataLatest;
+    EventMetadataV10: EventMetadataV10;
+    EventMetadataV11: EventMetadataV11;
+    EventMetadataV12: EventMetadataV12;
+    EventMetadataV13: EventMetadataV13;
+    EventMetadataV14: EventMetadataV14;
+    EventMetadataV9: EventMetadataV9;
+    EventRecord: EventRecord;
+    EvmAccount: EvmAccount;
+    EvmCallInfo: EvmCallInfo;
+    EvmCreateInfo: EvmCreateInfo;
+    EvmLog: EvmLog;
+    EvmVicinity: EvmVicinity;
+    ExecReturnValue: ExecReturnValue;
+    ExitError: ExitError;
+    ExitFatal: ExitFatal;
+    ExitReason: ExitReason;
+    ExitRevert: ExitRevert;
+    ExitSucceed: ExitSucceed;
+    ExplicitDisputeStatement: ExplicitDisputeStatement;
+    Exposure: Exposure;
+    ExtendedBalance: ExtendedBalance;
+    Extrinsic: Extrinsic;
+    ExtrinsicEra: ExtrinsicEra;
+    ExtrinsicMetadataLatest: ExtrinsicMetadataLatest;
+    ExtrinsicMetadataV11: ExtrinsicMetadataV11;
+    ExtrinsicMetadataV12: ExtrinsicMetadataV12;
+    ExtrinsicMetadataV13: ExtrinsicMetadataV13;
+    ExtrinsicMetadataV14: ExtrinsicMetadataV14;
+    ExtrinsicOrHash: ExtrinsicOrHash;
+    ExtrinsicPayload: ExtrinsicPayload;
+    ExtrinsicPayloadUnknown: ExtrinsicPayloadUnknown;
+    ExtrinsicPayloadV4: ExtrinsicPayloadV4;
+    ExtrinsicSignature: ExtrinsicSignature;
+    ExtrinsicSignatureV4: ExtrinsicSignatureV4;
+    ExtrinsicStatus: ExtrinsicStatus;
+    ExtrinsicsWeight: ExtrinsicsWeight;
+    ExtrinsicUnknown: ExtrinsicUnknown;
+    ExtrinsicV4: ExtrinsicV4;
+    f32: f32;
+    F32: F32;
+    f64: f64;
+    F64: F64;
+    FeeDetails: FeeDetails;
+    Fixed128: Fixed128;
+    Fixed64: Fixed64;
+    FixedI128: FixedI128;
+    FixedI64: FixedI64;
+    FixedU128: FixedU128;
+    FixedU64: FixedU64;
+    Forcing: Forcing;
+    ForkTreePendingChange: ForkTreePendingChange;
+    ForkTreePendingChangeNode: ForkTreePendingChangeNode;
+    FullIdentification: FullIdentification;
+    FunctionArgumentMetadataLatest: FunctionArgumentMetadataLatest;
+    FunctionArgumentMetadataV10: FunctionArgumentMetadataV10;
+    FunctionArgumentMetadataV11: FunctionArgumentMetadataV11;
+    FunctionArgumentMetadataV12: FunctionArgumentMetadataV12;
+    FunctionArgumentMetadataV13: FunctionArgumentMetadataV13;
+    FunctionArgumentMetadataV14: FunctionArgumentMetadataV14;
+    FunctionArgumentMetadataV9: FunctionArgumentMetadataV9;
+    FunctionMetadataLatest: FunctionMetadataLatest;
+    FunctionMetadataV10: FunctionMetadataV10;
+    FunctionMetadataV11: FunctionMetadataV11;
+    FunctionMetadataV12: FunctionMetadataV12;
+    FunctionMetadataV13: FunctionMetadataV13;
+    FunctionMetadataV14: FunctionMetadataV14;
+    FunctionMetadataV9: FunctionMetadataV9;
+    FundIndex: FundIndex;
+    FundInfo: FundInfo;
+    Fungibility: Fungibility;
+    FungibilityV0: FungibilityV0;
+    FungibilityV1: FungibilityV1;
+    FungibilityV2: FungibilityV2;
+    Gas: Gas;
+    GiltBid: GiltBid;
+    GlobalValidationData: GlobalValidationData;
+    GlobalValidationSchedule: GlobalValidationSchedule;
+    GrandpaCommit: GrandpaCommit;
+    GrandpaEquivocation: GrandpaEquivocation;
+    GrandpaEquivocationProof: GrandpaEquivocationProof;
+    GrandpaEquivocationValue: GrandpaEquivocationValue;
+    GrandpaJustification: GrandpaJustification;
+    GrandpaPrecommit: GrandpaPrecommit;
+    GrandpaPrevote: GrandpaPrevote;
+    GrandpaSignedPrecommit: GrandpaSignedPrecommit;
+    GroupIndex: GroupIndex;
+    GroupRotationInfo: GroupRotationInfo;
+    H1024: H1024;
+    H128: H128;
+    H160: H160;
+    H2048: H2048;
+    H256: H256;
+    H32: H32;
+    H512: H512;
+    H64: H64;
+    Hash: Hash;
+    HeadData: HeadData;
+    Header: Header;
+    HeaderPartial: HeaderPartial;
+    Health: Health;
+    Heartbeat: Heartbeat;
+    HeartbeatTo244: HeartbeatTo244;
+    HostConfiguration: HostConfiguration;
+    HostFnWeights: HostFnWeights;
+    HostFnWeightsTo264: HostFnWeightsTo264;
+    HrmpChannel: HrmpChannel;
+    HrmpChannelId: HrmpChannelId;
+    HrmpOpenChannelRequest: HrmpOpenChannelRequest;
+    i128: i128;
+    I128: I128;
+    i16: i16;
+    I16: I16;
+    i256: i256;
+    I256: I256;
+    i32: i32;
+    I32: I32;
+    I32F32: I32F32;
+    i64: i64;
+    I64: I64;
+    i8: i8;
+    I8: I8;
+    IdentificationTuple: IdentificationTuple;
+    IdentityFields: IdentityFields;
+    IdentityInfo: IdentityInfo;
+    IdentityInfoAdditional: IdentityInfoAdditional;
+    IdentityInfoTo198: IdentityInfoTo198;
+    IdentityJudgement: IdentityJudgement;
+    ImmortalEra: ImmortalEra;
+    ImportedAux: ImportedAux;
+    InboundDownwardMessage: InboundDownwardMessage;
+    InboundHrmpMessage: InboundHrmpMessage;
+    InboundHrmpMessages: InboundHrmpMessages;
+    InboundLaneData: InboundLaneData;
+    InboundRelayer: InboundRelayer;
+    InboundStatus: InboundStatus;
+    IncludedBlocks: IncludedBlocks;
+    InclusionFee: InclusionFee;
+    IncomingParachain: IncomingParachain;
+    IncomingParachainDeploy: IncomingParachainDeploy;
+    IncomingParachainFixed: IncomingParachainFixed;
+    Index: Index;
+    IndicesLookupSource: IndicesLookupSource;
+    IndividualExposure: IndividualExposure;
+    InherentData: InherentData;
+    InherentIdentifier: InherentIdentifier;
+    InitializationData: InitializationData;
+    InstanceDetails: InstanceDetails;
+    InstanceId: InstanceId;
+    InstanceMetadata: InstanceMetadata;
+    InstantiateRequest: InstantiateRequest;
+    InstantiateRequestV1: InstantiateRequestV1;
+    InstantiateRequestV2: InstantiateRequestV2;
+    InstantiateReturnValue: InstantiateReturnValue;
+    InstantiateReturnValueOk: InstantiateReturnValueOk;
+    InstantiateReturnValueTo267: InstantiateReturnValueTo267;
+    InstructionV2: InstructionV2;
+    InstructionWeights: InstructionWeights;
+    InteriorMultiLocation: InteriorMultiLocation;
+    InvalidDisputeStatementKind: InvalidDisputeStatementKind;
+    InvalidTransaction: InvalidTransaction;
+    Json: Json;
+    Junction: Junction;
+    Junctions: Junctions;
+    JunctionsV1: JunctionsV1;
+    JunctionsV2: JunctionsV2;
+    JunctionV0: JunctionV0;
+    JunctionV1: JunctionV1;
+    JunctionV2: JunctionV2;
+    Justification: Justification;
+    JustificationNotification: JustificationNotification;
+    Justifications: Justifications;
+    Key: Key;
+    KeyOwnerProof: KeyOwnerProof;
+    Keys: Keys;
+    KeyType: KeyType;
+    KeyTypeId: KeyTypeId;
+    KeyValue: KeyValue;
+    KeyValueOption: KeyValueOption;
+    Kind: Kind;
+    LaneId: LaneId;
+    LastContribution: LastContribution;
+    LastRuntimeUpgradeInfo: LastRuntimeUpgradeInfo;
+    LeasePeriod: LeasePeriod;
+    LeasePeriodOf: LeasePeriodOf;
+    LegacyTransaction: LegacyTransaction;
+    Limits: Limits;
+    LimitsTo264: LimitsTo264;
+    LocalValidationData: LocalValidationData;
+    LockIdentifier: LockIdentifier;
+    LookupSource: LookupSource;
+    LookupTarget: LookupTarget;
+    LotteryConfig: LotteryConfig;
+    MaybeRandomness: MaybeRandomness;
+    MaybeVrf: MaybeVrf;
+    MemberCount: MemberCount;
+    MembershipProof: MembershipProof;
+    MessageData: MessageData;
+    MessageId: MessageId;
+    MessageIngestionType: MessageIngestionType;
+    MessageKey: MessageKey;
+    MessageNonce: MessageNonce;
+    MessageQueueChain: MessageQueueChain;
+    MessagesDeliveryProofOf: MessagesDeliveryProofOf;
+    MessagesProofOf: MessagesProofOf;
+    MessagingStateSnapshot: MessagingStateSnapshot;
+    MessagingStateSnapshotEgressEntry: MessagingStateSnapshotEgressEntry;
+    MetadataAll: MetadataAll;
+    MetadataLatest: MetadataLatest;
+    MetadataV10: MetadataV10;
+    MetadataV11: MetadataV11;
+    MetadataV12: MetadataV12;
+    MetadataV13: MetadataV13;
+    MetadataV14: MetadataV14;
+    MetadataV9: MetadataV9;
+    MigrationStatusResult: MigrationStatusResult;
+    MmrBatchProof: MmrBatchProof;
+    MmrEncodableOpaqueLeaf: MmrEncodableOpaqueLeaf;
+    MmrError: MmrError;
+    MmrLeafBatchProof: MmrLeafBatchProof;
+    MmrLeafIndex: MmrLeafIndex;
+    MmrLeafProof: MmrLeafProof;
+    MmrNodeIndex: MmrNodeIndex;
+    MmrProof: MmrProof;
+    MmrRootHash: MmrRootHash;
+    ModuleConstantMetadataV10: ModuleConstantMetadataV10;
+    ModuleConstantMetadataV11: ModuleConstantMetadataV11;
+    ModuleConstantMetadataV12: ModuleConstantMetadataV12;
+    ModuleConstantMetadataV13: ModuleConstantMetadataV13;
+    ModuleConstantMetadataV9: ModuleConstantMetadataV9;
+    ModuleId: ModuleId;
+    ModuleMetadataV10: ModuleMetadataV10;
+    ModuleMetadataV11: ModuleMetadataV11;
+    ModuleMetadataV12: ModuleMetadataV12;
+    ModuleMetadataV13: ModuleMetadataV13;
+    ModuleMetadataV9: ModuleMetadataV9;
+    Moment: Moment;
+    MomentOf: MomentOf;
+    MoreAttestations: MoreAttestations;
+    MortalEra: MortalEra;
+    MultiAddress: MultiAddress;
+    MultiAsset: MultiAsset;
+    MultiAssetFilter: MultiAssetFilter;
+    MultiAssetFilterV1: MultiAssetFilterV1;
+    MultiAssetFilterV2: MultiAssetFilterV2;
+    MultiAssets: MultiAssets;
+    MultiAssetsV1: MultiAssetsV1;
+    MultiAssetsV2: MultiAssetsV2;
+    MultiAssetV0: MultiAssetV0;
+    MultiAssetV1: MultiAssetV1;
+    MultiAssetV2: MultiAssetV2;
+    MultiDisputeStatementSet: MultiDisputeStatementSet;
+    MultiLocation: MultiLocation;
+    MultiLocationV0: MultiLocationV0;
+    MultiLocationV1: MultiLocationV1;
+    MultiLocationV2: MultiLocationV2;
+    Multiplier: Multiplier;
+    Multisig: Multisig;
+    MultiSignature: MultiSignature;
+    MultiSigner: MultiSigner;
+    NetworkId: NetworkId;
+    NetworkState: NetworkState;
+    NetworkStatePeerset: NetworkStatePeerset;
+    NetworkStatePeersetInfo: NetworkStatePeersetInfo;
+    NewBidder: NewBidder;
+    NextAuthority: NextAuthority;
+    NextConfigDescriptor: NextConfigDescriptor;
+    NextConfigDescriptorV1: NextConfigDescriptorV1;
+    NodeRole: NodeRole;
+    Nominations: Nominations;
+    NominatorIndex: NominatorIndex;
+    NominatorIndexCompact: NominatorIndexCompact;
+    NotConnectedPeer: NotConnectedPeer;
+    NpApiError: NpApiError;
+    Null: Null;
+    OccupiedCore: OccupiedCore;
+    OccupiedCoreAssumption: OccupiedCoreAssumption;
+    OffchainAccuracy: OffchainAccuracy;
+    OffchainAccuracyCompact: OffchainAccuracyCompact;
+    OffenceDetails: OffenceDetails;
+    Offender: Offender;
+    OldV1SessionInfo: OldV1SessionInfo;
+    OpaqueCall: OpaqueCall;
+    OpaqueKeyOwnershipProof: OpaqueKeyOwnershipProof;
+    OpaqueMetadata: OpaqueMetadata;
+    OpaqueMultiaddr: OpaqueMultiaddr;
+    OpaqueNetworkState: OpaqueNetworkState;
+    OpaquePeerId: OpaquePeerId;
+    OpaqueTimeSlot: OpaqueTimeSlot;
+    OpenTip: OpenTip;
+    OpenTipFinderTo225: OpenTipFinderTo225;
+    OpenTipTip: OpenTipTip;
+    OpenTipTo225: OpenTipTo225;
+    OperatingMode: OperatingMode;
+    OptionBool: OptionBool;
+    Origin: Origin;
+    OriginCaller: OriginCaller;
+    OriginKindV0: OriginKindV0;
+    OriginKindV1: OriginKindV1;
+    OriginKindV2: OriginKindV2;
+    OutboundHrmpMessage: OutboundHrmpMessage;
+    OutboundLaneData: OutboundLaneData;
+    OutboundMessageFee: OutboundMessageFee;
+    OutboundPayload: OutboundPayload;
+    OutboundStatus: OutboundStatus;
+    Outcome: Outcome;
+    OverweightIndex: OverweightIndex;
+    Owner: Owner;
+    PageCounter: PageCounter;
+    PageIndexData: PageIndexData;
+    PalletCallMetadataLatest: PalletCallMetadataLatest;
+    PalletCallMetadataV14: PalletCallMetadataV14;
+    PalletConstantMetadataLatest: PalletConstantMetadataLatest;
+    PalletConstantMetadataV14: PalletConstantMetadataV14;
+    PalletErrorMetadataLatest: PalletErrorMetadataLatest;
+    PalletErrorMetadataV14: PalletErrorMetadataV14;
+    PalletEventMetadataLatest: PalletEventMetadataLatest;
+    PalletEventMetadataV14: PalletEventMetadataV14;
+    PalletId: PalletId;
+    PalletMetadataLatest: PalletMetadataLatest;
+    PalletMetadataV14: PalletMetadataV14;
+    PalletsOrigin: PalletsOrigin;
+    PalletStorageMetadataLatest: PalletStorageMetadataLatest;
+    PalletStorageMetadataV14: PalletStorageMetadataV14;
+    PalletVersion: PalletVersion;
+    ParachainDispatchOrigin: ParachainDispatchOrigin;
+    ParachainInherentData: ParachainInherentData;
+    ParachainProposal: ParachainProposal;
+    ParachainsInherentData: ParachainsInherentData;
+    ParaGenesisArgs: ParaGenesisArgs;
+    ParaId: ParaId;
+    ParaInfo: ParaInfo;
+    ParaLifecycle: ParaLifecycle;
+    Parameter: Parameter;
+    ParaPastCodeMeta: ParaPastCodeMeta;
+    ParaScheduling: ParaScheduling;
+    ParathreadClaim: ParathreadClaim;
+    ParathreadClaimQueue: ParathreadClaimQueue;
+    ParathreadEntry: ParathreadEntry;
+    ParaValidatorIndex: ParaValidatorIndex;
+    Pays: Pays;
+    Peer: Peer;
+    PeerEndpoint: PeerEndpoint;
+    PeerEndpointAddr: PeerEndpointAddr;
+    PeerInfo: PeerInfo;
+    PeerPing: PeerPing;
+    PendingChange: PendingChange;
+    PendingPause: PendingPause;
+    PendingResume: PendingResume;
+    Perbill: Perbill;
+    Percent: Percent;
+    PerDispatchClassU32: PerDispatchClassU32;
+    PerDispatchClassWeight: PerDispatchClassWeight;
+    PerDispatchClassWeightsPerClass: PerDispatchClassWeightsPerClass;
+    Period: Period;
+    Permill: Permill;
+    PermissionLatest: PermissionLatest;
+    PermissionsV1: PermissionsV1;
+    PermissionVersions: PermissionVersions;
+    Perquintill: Perquintill;
+    PersistedValidationData: PersistedValidationData;
+    PerU16: PerU16;
+    Phantom: Phantom;
+    PhantomData: PhantomData;
+    Phase: Phase;
+    PhragmenScore: PhragmenScore;
+    Points: Points;
+    PortableType: PortableType;
+    PortableTypeV14: PortableTypeV14;
+    Precommits: Precommits;
+    PrefabWasmModule: PrefabWasmModule;
+    PrefixedStorageKey: PrefixedStorageKey;
+    PreimageStatus: PreimageStatus;
+    PreimageStatusAvailable: PreimageStatusAvailable;
+    PreRuntime: PreRuntime;
+    Prevotes: Prevotes;
+    Priority: Priority;
+    PriorLock: PriorLock;
+    PropIndex: PropIndex;
+    Proposal: Proposal;
+    ProposalIndex: ProposalIndex;
+    ProxyAnnouncement: ProxyAnnouncement;
+    ProxyDefinition: ProxyDefinition;
+    ProxyState: ProxyState;
+    ProxyType: ProxyType;
+    PvfCheckStatement: PvfCheckStatement;
+    QueryId: QueryId;
+    QueryStatus: QueryStatus;
+    QueueConfigData: QueueConfigData;
+    QueuedParathread: QueuedParathread;
+    Randomness: Randomness;
+    Raw: Raw;
+    RawAuraPreDigest: RawAuraPreDigest;
+    RawBabePreDigest: RawBabePreDigest;
+    RawBabePreDigestCompat: RawBabePreDigestCompat;
+    RawBabePreDigestPrimary: RawBabePreDigestPrimary;
+    RawBabePreDigestPrimaryTo159: RawBabePreDigestPrimaryTo159;
+    RawBabePreDigestSecondaryPlain: RawBabePreDigestSecondaryPlain;
+    RawBabePreDigestSecondaryTo159: RawBabePreDigestSecondaryTo159;
+    RawBabePreDigestSecondaryVRF: RawBabePreDigestSecondaryVRF;
+    RawBabePreDigestTo159: RawBabePreDigestTo159;
+    RawOrigin: RawOrigin;
+    RawSolution: RawSolution;
+    RawSolutionTo265: RawSolutionTo265;
+    RawSolutionWith16: RawSolutionWith16;
+    RawSolutionWith24: RawSolutionWith24;
+    RawVRFOutput: RawVRFOutput;
+    ReadProof: ReadProof;
+    ReadySolution: ReadySolution;
+    Reasons: Reasons;
+    RecoveryConfig: RecoveryConfig;
+    RefCount: RefCount;
+    RefCountTo259: RefCountTo259;
+    ReferendumIndex: ReferendumIndex;
+    ReferendumInfo: ReferendumInfo;
+    ReferendumInfoFinished: ReferendumInfoFinished;
+    ReferendumInfoTo239: ReferendumInfoTo239;
+    ReferendumStatus: ReferendumStatus;
+    RegisteredParachainInfo: RegisteredParachainInfo;
+    RegistrarIndex: RegistrarIndex;
+    RegistrarInfo: RegistrarInfo;
+    Registration: Registration;
+    RegistrationJudgement: RegistrationJudgement;
+    RegistrationTo198: RegistrationTo198;
+    RelayBlockNumber: RelayBlockNumber;
+    RelayChainBlockNumber: RelayChainBlockNumber;
+    RelayChainHash: RelayChainHash;
+    RelayerId: RelayerId;
+    RelayHash: RelayHash;
+    Releases: Releases;
+    Remark: Remark;
+    Renouncing: Renouncing;
+    RentProjection: RentProjection;
+    ReplacementTimes: ReplacementTimes;
+    ReportedRoundStates: ReportedRoundStates;
+    Reporter: Reporter;
+    ReportIdOf: ReportIdOf;
+    ReserveData: ReserveData;
+    ReserveIdentifier: ReserveIdentifier;
+    Response: Response;
+    ResponseV0: ResponseV0;
+    ResponseV1: ResponseV1;
+    ResponseV2: ResponseV2;
+    ResponseV2Error: ResponseV2Error;
+    ResponseV2Result: ResponseV2Result;
+    Retriable: Retriable;
+    RewardDestination: RewardDestination;
+    RewardPoint: RewardPoint;
+    RoundSnapshot: RoundSnapshot;
+    RoundState: RoundState;
+    RpcMethods: RpcMethods;
+    RuntimeDbWeight: RuntimeDbWeight;
+    RuntimeDispatchInfo: RuntimeDispatchInfo;
+    RuntimeVersion: RuntimeVersion;
+    RuntimeVersionApi: RuntimeVersionApi;
+    RuntimeVersionPartial: RuntimeVersionPartial;
+    RuntimeVersionPre3: RuntimeVersionPre3;
+    RuntimeVersionPre4: RuntimeVersionPre4;
+    Schedule: Schedule;
+    Scheduled: Scheduled;
+    ScheduledCore: ScheduledCore;
+    ScheduledTo254: ScheduledTo254;
+    SchedulePeriod: SchedulePeriod;
+    SchedulePriority: SchedulePriority;
+    ScheduleTo212: ScheduleTo212;
+    ScheduleTo258: ScheduleTo258;
+    ScheduleTo264: ScheduleTo264;
+    Scheduling: Scheduling;
+    ScrapedOnChainVotes: ScrapedOnChainVotes;
+    Seal: Seal;
+    SealV0: SealV0;
+    SeatHolder: SeatHolder;
+    SeedOf: SeedOf;
+    ServiceQuality: ServiceQuality;
+    SessionIndex: SessionIndex;
+    SessionInfo: SessionInfo;
+    SessionInfoValidatorGroup: SessionInfoValidatorGroup;
+    SessionKeys1: SessionKeys1;
+    SessionKeys10: SessionKeys10;
+    SessionKeys10B: SessionKeys10B;
+    SessionKeys2: SessionKeys2;
+    SessionKeys3: SessionKeys3;
+    SessionKeys4: SessionKeys4;
+    SessionKeys5: SessionKeys5;
+    SessionKeys6: SessionKeys6;
+    SessionKeys6B: SessionKeys6B;
+    SessionKeys7: SessionKeys7;
+    SessionKeys7B: SessionKeys7B;
+    SessionKeys8: SessionKeys8;
+    SessionKeys8B: SessionKeys8B;
+    SessionKeys9: SessionKeys9;
+    SessionKeys9B: SessionKeys9B;
+    SetId: SetId;
+    SetIndex: SetIndex;
+    Si0Field: Si0Field;
+    Si0LookupTypeId: Si0LookupTypeId;
+    Si0Path: Si0Path;
+    Si0Type: Si0Type;
+    Si0TypeDef: Si0TypeDef;
+    Si0TypeDefArray: Si0TypeDefArray;
+    Si0TypeDefBitSequence: Si0TypeDefBitSequence;
+    Si0TypeDefCompact: Si0TypeDefCompact;
+    Si0TypeDefComposite: Si0TypeDefComposite;
+    Si0TypeDefPhantom: Si0TypeDefPhantom;
+    Si0TypeDefPrimitive: Si0TypeDefPrimitive;
+    Si0TypeDefSequence: Si0TypeDefSequence;
+    Si0TypeDefTuple: Si0TypeDefTuple;
+    Si0TypeDefVariant: Si0TypeDefVariant;
+    Si0TypeParameter: Si0TypeParameter;
+    Si0Variant: Si0Variant;
+    Si1Field: Si1Field;
+    Si1LookupTypeId: Si1LookupTypeId;
+    Si1Path: Si1Path;
+    Si1Type: Si1Type;
+    Si1TypeDef: Si1TypeDef;
+    Si1TypeDefArray: Si1TypeDefArray;
+    Si1TypeDefBitSequence: Si1TypeDefBitSequence;
+    Si1TypeDefCompact: Si1TypeDefCompact;
+    Si1TypeDefComposite: Si1TypeDefComposite;
+    Si1TypeDefPrimitive: Si1TypeDefPrimitive;
+    Si1TypeDefSequence: Si1TypeDefSequence;
+    Si1TypeDefTuple: Si1TypeDefTuple;
+    Si1TypeDefVariant: Si1TypeDefVariant;
+    Si1TypeParameter: Si1TypeParameter;
+    Si1Variant: Si1Variant;
+    SiField: SiField;
+    Signature: Signature;
+    SignedAvailabilityBitfield: SignedAvailabilityBitfield;
+    SignedAvailabilityBitfields: SignedAvailabilityBitfields;
+    SignedBlock: SignedBlock;
+    SignedBlockWithJustification: SignedBlockWithJustification;
+    SignedBlockWithJustifications: SignedBlockWithJustifications;
+    SignedExtensionMetadataLatest: SignedExtensionMetadataLatest;
+    SignedExtensionMetadataV14: SignedExtensionMetadataV14;
+    SignedSubmission: SignedSubmission;
+    SignedSubmissionOf: SignedSubmissionOf;
+    SignedSubmissionTo276: SignedSubmissionTo276;
+    SignerPayload: SignerPayload;
+    SigningContext: SigningContext;
+    SiLookupTypeId: SiLookupTypeId;
+    SiPath: SiPath;
+    SiType: SiType;
+    SiTypeDef: SiTypeDef;
+    SiTypeDefArray: SiTypeDefArray;
+    SiTypeDefBitSequence: SiTypeDefBitSequence;
+    SiTypeDefCompact: SiTypeDefCompact;
+    SiTypeDefComposite: SiTypeDefComposite;
+    SiTypeDefPrimitive: SiTypeDefPrimitive;
+    SiTypeDefSequence: SiTypeDefSequence;
+    SiTypeDefTuple: SiTypeDefTuple;
+    SiTypeDefVariant: SiTypeDefVariant;
+    SiTypeParameter: SiTypeParameter;
+    SiVariant: SiVariant;
+    SlashingSpans: SlashingSpans;
+    SlashingSpansTo204: SlashingSpansTo204;
+    SlashJournalEntry: SlashJournalEntry;
+    Slot: Slot;
+    SlotDuration: SlotDuration;
+    SlotNumber: SlotNumber;
+    SlotRange: SlotRange;
+    SlotRange10: SlotRange10;
+    SocietyJudgement: SocietyJudgement;
+    SocietyVote: SocietyVote;
+    SolutionOrSnapshotSize: SolutionOrSnapshotSize;
+    SolutionSupport: SolutionSupport;
+    SolutionSupports: SolutionSupports;
+    SpanIndex: SpanIndex;
+    SpanRecord: SpanRecord;
+    SpecVersion: SpecVersion;
+    Sr25519Signature: Sr25519Signature;
+    StakingLedger: StakingLedger;
+    StakingLedgerTo223: StakingLedgerTo223;
+    StakingLedgerTo240: StakingLedgerTo240;
+    Statement: Statement;
+    StatementKind: StatementKind;
+    StorageChangeSet: StorageChangeSet;
+    StorageData: StorageData;
+    StorageDeposit: StorageDeposit;
+    StorageEntryMetadataLatest: StorageEntryMetadataLatest;
+    StorageEntryMetadataV10: StorageEntryMetadataV10;
+    StorageEntryMetadataV11: StorageEntryMetadataV11;
+    StorageEntryMetadataV12: StorageEntryMetadataV12;
+    StorageEntryMetadataV13: StorageEntryMetadataV13;
+    StorageEntryMetadataV14: StorageEntryMetadataV14;
+    StorageEntryMetadataV9: StorageEntryMetadataV9;
+    StorageEntryModifierLatest: StorageEntryModifierLatest;
+    StorageEntryModifierV10: StorageEntryModifierV10;
+    StorageEntryModifierV11: StorageEntryModifierV11;
+    StorageEntryModifierV12: StorageEntryModifierV12;
+    StorageEntryModifierV13: StorageEntryModifierV13;
+    StorageEntryModifierV14: StorageEntryModifierV14;
+    StorageEntryModifierV9: StorageEntryModifierV9;
+    StorageEntryTypeLatest: StorageEntryTypeLatest;
+    StorageEntryTypeV10: StorageEntryTypeV10;
+    StorageEntryTypeV11: StorageEntryTypeV11;
+    StorageEntryTypeV12: StorageEntryTypeV12;
+    StorageEntryTypeV13: StorageEntryTypeV13;
+    StorageEntryTypeV14: StorageEntryTypeV14;
+    StorageEntryTypeV9: StorageEntryTypeV9;
+    StorageHasher: StorageHasher;
+    StorageHasherV10: StorageHasherV10;
+    StorageHasherV11: StorageHasherV11;
+    StorageHasherV12: StorageHasherV12;
+    StorageHasherV13: StorageHasherV13;
+    StorageHasherV14: StorageHasherV14;
+    StorageHasherV9: StorageHasherV9;
+    StorageInfo: StorageInfo;
+    StorageKey: StorageKey;
+    StorageKind: StorageKind;
+    StorageMetadataV10: StorageMetadataV10;
+    StorageMetadataV11: StorageMetadataV11;
+    StorageMetadataV12: StorageMetadataV12;
+    StorageMetadataV13: StorageMetadataV13;
+    StorageMetadataV9: StorageMetadataV9;
+    StorageProof: StorageProof;
+    StoredPendingChange: StoredPendingChange;
+    StoredState: StoredState;
+    StrikeCount: StrikeCount;
+    SubId: SubId;
+    SubmissionIndicesOf: SubmissionIndicesOf;
+    Supports: Supports;
+    SyncState: SyncState;
+    SystemInherentData: SystemInherentData;
+    SystemOrigin: SystemOrigin;
+    Tally: Tally;
+    TaskAddress: TaskAddress;
+    TAssetBalance: TAssetBalance;
+    TAssetDepositBalance: TAssetDepositBalance;
+    Text: Text;
+    Timepoint: Timepoint;
+    TokenError: TokenError;
+    TombstoneContractInfo: TombstoneContractInfo;
+    TraceBlockResponse: TraceBlockResponse;
+    TraceError: TraceError;
+    TransactionalError: TransactionalError;
+    TransactionInfo: TransactionInfo;
+    TransactionLongevity: TransactionLongevity;
+    TransactionPriority: TransactionPriority;
+    TransactionSource: TransactionSource;
+    TransactionStorageProof: TransactionStorageProof;
+    TransactionTag: TransactionTag;
+    TransactionV0: TransactionV0;
+    TransactionV1: TransactionV1;
+    TransactionV2: TransactionV2;
+    TransactionValidity: TransactionValidity;
+    TransactionValidityError: TransactionValidityError;
+    TransientValidationData: TransientValidationData;
+    TreasuryProposal: TreasuryProposal;
+    TrieId: TrieId;
+    TrieIndex: TrieIndex;
+    Type: Type;
+    u128: u128;
+    U128: U128;
+    u16: u16;
+    U16: U16;
+    u256: u256;
+    U256: U256;
+    u32: u32;
+    U32: U32;
+    U32F32: U32F32;
+    u64: u64;
+    U64: U64;
+    u8: u8;
+    U8: U8;
+    UnappliedSlash: UnappliedSlash;
+    UnappliedSlashOther: UnappliedSlashOther;
+    UncleEntryItem: UncleEntryItem;
+    UnknownTransaction: UnknownTransaction;
+    UnlockChunk: UnlockChunk;
+    UnrewardedRelayer: UnrewardedRelayer;
+    UnrewardedRelayersState: UnrewardedRelayersState;
+    UpgradeGoAhead: UpgradeGoAhead;
+    UpgradeRestriction: UpgradeRestriction;
+    UpwardMessage: UpwardMessage;
+    usize: usize;
+    USize: USize;
+    ValidationCode: ValidationCode;
+    ValidationCodeHash: ValidationCodeHash;
+    ValidationData: ValidationData;
+    ValidationDataType: ValidationDataType;
+    ValidationFunctionParams: ValidationFunctionParams;
+    ValidatorCount: ValidatorCount;
+    ValidatorId: ValidatorId;
+    ValidatorIdOf: ValidatorIdOf;
+    ValidatorIndex: ValidatorIndex;
+    ValidatorIndexCompact: ValidatorIndexCompact;
+    ValidatorPrefs: ValidatorPrefs;
+    ValidatorPrefsTo145: ValidatorPrefsTo145;
+    ValidatorPrefsTo196: ValidatorPrefsTo196;
+    ValidatorPrefsWithBlocked: ValidatorPrefsWithBlocked;
+    ValidatorPrefsWithCommission: ValidatorPrefsWithCommission;
+    ValidatorSet: ValidatorSet;
+    ValidatorSetId: ValidatorSetId;
+    ValidatorSignature: ValidatorSignature;
+    ValidDisputeStatementKind: ValidDisputeStatementKind;
+    ValidityAttestation: ValidityAttestation;
+    ValidTransaction: ValidTransaction;
+    VecInboundHrmpMessage: VecInboundHrmpMessage;
+    VersionedMultiAsset: VersionedMultiAsset;
+    VersionedMultiAssets: VersionedMultiAssets;
+    VersionedMultiLocation: VersionedMultiLocation;
+    VersionedResponse: VersionedResponse;
+    VersionedXcm: VersionedXcm;
+    VersionMigrationStage: VersionMigrationStage;
+    VestingInfo: VestingInfo;
+    VestingSchedule: VestingSchedule;
+    Vote: Vote;
+    VoteIndex: VoteIndex;
+    Voter: Voter;
+    VoterInfo: VoterInfo;
+    Votes: Votes;
+    VotesTo230: VotesTo230;
+    VoteThreshold: VoteThreshold;
+    VoteWeight: VoteWeight;
+    Voting: Voting;
+    VotingDelegating: VotingDelegating;
+    VotingDirect: VotingDirect;
+    VotingDirectVote: VotingDirectVote;
+    VouchingStatus: VouchingStatus;
+    VrfData: VrfData;
+    VrfOutput: VrfOutput;
+    VrfProof: VrfProof;
+    Weight: Weight;
+    WeightLimitV2: WeightLimitV2;
+    WeightMultiplier: WeightMultiplier;
+    WeightPerClass: WeightPerClass;
+    WeightToFeeCoefficient: WeightToFeeCoefficient;
+    WildFungibility: WildFungibility;
+    WildFungibilityV0: WildFungibilityV0;
+    WildFungibilityV1: WildFungibilityV1;
+    WildFungibilityV2: WildFungibilityV2;
+    WildMultiAsset: WildMultiAsset;
+    WildMultiAssetV1: WildMultiAssetV1;
+    WildMultiAssetV2: WildMultiAssetV2;
+    WinnersData: WinnersData;
+    WinnersData10: WinnersData10;
+    WinnersDataTuple: WinnersDataTuple;
+    WinnersDataTuple10: WinnersDataTuple10;
+    WinningData: WinningData;
+    WinningData10: WinningData10;
+    WinningDataEntry: WinningDataEntry;
+    WithdrawReasons: WithdrawReasons;
+    Xcm: Xcm;
+    XcmAssetId: XcmAssetId;
+    XcmError: XcmError;
+    XcmErrorV0: XcmErrorV0;
+    XcmErrorV1: XcmErrorV1;
+    XcmErrorV2: XcmErrorV2;
+    XcmOrder: XcmOrder;
+    XcmOrderV0: XcmOrderV0;
+    XcmOrderV1: XcmOrderV1;
+    XcmOrderV2: XcmOrderV2;
+    XcmOrigin: XcmOrigin;
+    XcmOriginKind: XcmOriginKind;
+    XcmpMessageFormat: XcmpMessageFormat;
+    XcmV0: XcmV0;
+    XcmV1: XcmV1;
+    XcmV2: XcmV2;
+    XcmVersion: XcmVersion;
+  } // InterfaceTypes
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/index.ts
+++ b/packages/tfchain_client/src/interfaces/chain/index.ts
@@ -1,0 +1,4 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+export * from "./types";

--- a/packages/tfchain_client/src/interfaces/chain/lookup.ts
+++ b/packages/tfchain_client/src/interfaces/chain/lookup.ts
@@ -1,0 +1,2639 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+/* eslint-disable sort-keys */
+
+export default {
+  /**
+   * Lookup3: frame_system::AccountInfo<Nonce, pallet_balances::types::AccountData<Balance>>
+   **/
+  FrameSystemAccountInfo: {
+    nonce: "u32",
+    consumers: "u32",
+    providers: "u32",
+    sufficients: "u32",
+    data: "PalletBalancesAccountData",
+  },
+  /**
+   * Lookup5: pallet_balances::types::AccountData<Balance>
+   **/
+  PalletBalancesAccountData: {
+    free: "u128",
+    reserved: "u128",
+    frozen: "u128",
+    flags: "u128",
+  },
+  /**
+   * Lookup8: frame_support::dispatch::PerDispatchClass<sp_weights::weight_v2::Weight>
+   **/
+  FrameSupportDispatchPerDispatchClassWeight: {
+    normal: "SpWeightsWeightV2Weight",
+    operational: "SpWeightsWeightV2Weight",
+    mandatory: "SpWeightsWeightV2Weight",
+  },
+  /**
+   * Lookup9: sp_weights::weight_v2::Weight
+   **/
+  SpWeightsWeightV2Weight: {
+    refTime: "Compact<u64>",
+    proofSize: "Compact<u64>",
+  },
+  /**
+   * Lookup14: sp_runtime::generic::digest::Digest
+   **/
+  SpRuntimeDigest: {
+    logs: "Vec<SpRuntimeDigestDigestItem>",
+  },
+  /**
+   * Lookup16: sp_runtime::generic::digest::DigestItem
+   **/
+  SpRuntimeDigestDigestItem: {
+    _enum: {
+      Other: "Bytes",
+      __Unused1: "Null",
+      __Unused2: "Null",
+      __Unused3: "Null",
+      Consensus: "([u8;4],Bytes)",
+      Seal: "([u8;4],Bytes)",
+      PreRuntime: "([u8;4],Bytes)",
+      __Unused7: "Null",
+      RuntimeEnvironmentUpdated: "Null",
+    },
+  },
+  /**
+   * Lookup19: frame_system::EventRecord<tfchain_runtime::RuntimeEvent, primitive_types::H256>
+   **/
+  FrameSystemEventRecord: {
+    phase: "FrameSystemPhase",
+    event: "Event",
+    topics: "Vec<H256>",
+  },
+  /**
+   * Lookup21: frame_system::pallet::Event<T>
+   **/
+  FrameSystemEvent: {
+    _enum: {
+      ExtrinsicSuccess: {
+        dispatchInfo: "FrameSupportDispatchDispatchInfo",
+      },
+      ExtrinsicFailed: {
+        dispatchError: "SpRuntimeDispatchError",
+        dispatchInfo: "FrameSupportDispatchDispatchInfo",
+      },
+      CodeUpdated: "Null",
+      NewAccount: {
+        account: "AccountId32",
+      },
+      KilledAccount: {
+        account: "AccountId32",
+      },
+      Remarked: {
+        _alias: {
+          hash_: "hash",
+        },
+        sender: "AccountId32",
+        hash_: "H256",
+      },
+    },
+  },
+  /**
+   * Lookup22: frame_support::dispatch::DispatchInfo
+   **/
+  FrameSupportDispatchDispatchInfo: {
+    weight: "SpWeightsWeightV2Weight",
+    class: "FrameSupportDispatchDispatchClass",
+    paysFee: "FrameSupportDispatchPays",
+  },
+  /**
+   * Lookup23: frame_support::dispatch::DispatchClass
+   **/
+  FrameSupportDispatchDispatchClass: {
+    _enum: ["Normal", "Operational", "Mandatory"],
+  },
+  /**
+   * Lookup24: frame_support::dispatch::Pays
+   **/
+  FrameSupportDispatchPays: {
+    _enum: ["Yes", "No"],
+  },
+  /**
+   * Lookup25: sp_runtime::DispatchError
+   **/
+  SpRuntimeDispatchError: {
+    _enum: {
+      Other: "Null",
+      CannotLookup: "Null",
+      BadOrigin: "Null",
+      Module: "SpRuntimeModuleError",
+      ConsumerRemaining: "Null",
+      NoProviders: "Null",
+      TooManyConsumers: "Null",
+      Token: "SpRuntimeTokenError",
+      Arithmetic: "SpArithmeticArithmeticError",
+      Transactional: "SpRuntimeTransactionalError",
+      Exhausted: "Null",
+      Corruption: "Null",
+      Unavailable: "Null",
+      RootNotAllowed: "Null",
+    },
+  },
+  /**
+   * Lookup26: sp_runtime::ModuleError
+   **/
+  SpRuntimeModuleError: {
+    index: "u8",
+    error: "[u8;4]",
+  },
+  /**
+   * Lookup27: sp_runtime::TokenError
+   **/
+  SpRuntimeTokenError: {
+    _enum: [
+      "FundsUnavailable",
+      "OnlyProvider",
+      "BelowMinimum",
+      "CannotCreate",
+      "UnknownAsset",
+      "Frozen",
+      "Unsupported",
+      "CannotCreateHold",
+      "NotExpendable",
+      "Blocked",
+    ],
+  },
+  /**
+   * Lookup28: sp_arithmetic::ArithmeticError
+   **/
+  SpArithmeticArithmeticError: {
+    _enum: ["Underflow", "Overflow", "DivisionByZero"],
+  },
+  /**
+   * Lookup29: sp_runtime::TransactionalError
+   **/
+  SpRuntimeTransactionalError: {
+    _enum: ["LimitReached", "NoLayer"],
+  },
+  /**
+   * Lookup30: pallet_utility::pallet::Event
+   **/
+  PalletUtilityEvent: {
+    _enum: {
+      BatchInterrupted: {
+        index: "u32",
+        error: "SpRuntimeDispatchError",
+      },
+      BatchCompleted: "Null",
+      BatchCompletedWithErrors: "Null",
+      ItemCompleted: "Null",
+      ItemFailed: {
+        error: "SpRuntimeDispatchError",
+      },
+      DispatchedAs: {
+        result: "Result<Null, SpRuntimeDispatchError>",
+      },
+    },
+  },
+  /**
+   * Lookup33: pallet_scheduler::pallet::Event<T>
+   **/
+  PalletSchedulerEvent: {
+    _enum: {
+      Scheduled: {
+        when: "u32",
+        index: "u32",
+      },
+      Canceled: {
+        when: "u32",
+        index: "u32",
+      },
+      Dispatched: {
+        task: "(u32,u32)",
+        id: "Option<[u8;32]>",
+        result: "Result<Null, SpRuntimeDispatchError>",
+      },
+      CallUnavailable: {
+        task: "(u32,u32)",
+        id: "Option<[u8;32]>",
+      },
+      PeriodicFailed: {
+        task: "(u32,u32)",
+        id: "Option<[u8;32]>",
+      },
+      PermanentlyOverweight: {
+        task: "(u32,u32)",
+        id: "Option<[u8;32]>",
+      },
+    },
+  },
+  /**
+   * Lookup36: substrate_validator_set::pallet::Event<T>
+   **/
+  SubstrateValidatorSetEvent: {
+    _enum: {
+      ValidatorAdditionInitiated: "AccountId32",
+      ValidatorRemovalInitiated: "AccountId32",
+    },
+  },
+  /**
+   * Lookup37: pallet_session::pallet::Event
+   **/
+  PalletSessionEvent: {
+    _enum: {
+      NewSession: {
+        sessionIndex: "u32",
+      },
+    },
+  },
+  /**
+   * Lookup38: pallet_grandpa::pallet::Event
+   **/
+  PalletGrandpaEvent: {
+    _enum: {
+      NewAuthorities: {
+        authoritySet: "Vec<(SpConsensusGrandpaAppPublic,u64)>",
+      },
+      Paused: "Null",
+      Resumed: "Null",
+    },
+  },
+  /**
+   * Lookup41: sp_consensus_grandpa::app::Public
+   **/
+  SpConsensusGrandpaAppPublic: "SpCoreEd25519Public",
+  /**
+   * Lookup42: sp_core::ed25519::Public
+   **/
+  SpCoreEd25519Public: "[u8;32]",
+  /**
+   * Lookup43: pallet_balances::pallet::Event<T, I>
+   **/
+  PalletBalancesEvent: {
+    _enum: {
+      Endowed: {
+        account: "AccountId32",
+        freeBalance: "u128",
+      },
+      DustLost: {
+        account: "AccountId32",
+        amount: "u128",
+      },
+      Transfer: {
+        from: "AccountId32",
+        to: "AccountId32",
+        amount: "u128",
+      },
+      BalanceSet: {
+        who: "AccountId32",
+        free: "u128",
+      },
+      Reserved: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Unreserved: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      ReserveRepatriated: {
+        from: "AccountId32",
+        to: "AccountId32",
+        amount: "u128",
+        destinationStatus: "FrameSupportTokensMiscBalanceStatus",
+      },
+      Deposit: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Withdraw: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Slashed: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Minted: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Burned: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Suspended: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Restored: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Upgraded: {
+        who: "AccountId32",
+      },
+      Issued: {
+        amount: "u128",
+      },
+      Rescinded: {
+        amount: "u128",
+      },
+      Locked: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Unlocked: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Frozen: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+      Thawed: {
+        who: "AccountId32",
+        amount: "u128",
+      },
+    },
+  },
+  /**
+   * Lookup44: frame_support::traits::tokens::misc::BalanceStatus
+   **/
+  FrameSupportTokensMiscBalanceStatus: {
+    _enum: ["Free", "Reserved"],
+  },
+  /**
+   * Lookup45: pallet_transaction_payment::pallet::Event<T>
+   **/
+  PalletTransactionPaymentEvent: {
+    _enum: {
+      TransactionFeePaid: {
+        who: "AccountId32",
+        actualFee: "u128",
+        tip: "u128",
+      },
+    },
+  },
+  /**
+   * Lookup46: pallet_tfgrid::pallet::Event<T>
+   **/
+  PalletTfgridEvent: {
+    _enum: {
+      FarmStored: "TfchainSupportFarm",
+      FarmUpdated: "TfchainSupportFarm",
+      FarmDeleted: "u32",
+      NodeStored: "TfchainSupportNode",
+      NodeUpdated: "TfchainSupportNode",
+      NodeDeleted: "u32",
+      NodeUptimeReported: "(u32,u64,u64)",
+      NodePublicConfigStored: "(u32,Option<TfchainSupportPublicConfig>)",
+      EntityStored: "PalletTfgridEntity",
+      EntityUpdated: "PalletTfgridEntity",
+      EntityDeleted: "u32",
+      TwinStored: "PalletTfgridTwin",
+      TwinUpdated: "PalletTfgridTwin",
+      TwinEntityStored: "(u32,u32,Bytes)",
+      TwinEntityRemoved: "(u32,u32)",
+      TwinDeleted: "u32",
+      TwinAccountBounded: "(u32,AccountId32)",
+      PricingPolicyStored: "PalletTfgridPricingPolicy",
+      FarmingPolicyStored: "PalletTfgridFarmingPolicy",
+      FarmPayoutV2AddressRegistered: "(u32,Bytes)",
+      FarmMarkedAsDedicated: "u32",
+      ConnectionPriceSet: "u32",
+      NodeCertificationSet: "(u32,TfchainSupportNodeCertification)",
+      NodeCertifierAdded: "AccountId32",
+      NodeCertifierRemoved: "AccountId32",
+      FarmingPolicyUpdated: "PalletTfgridFarmingPolicy",
+      FarmingPolicySet: "(u32,Option<TfchainSupportFarmingPolicyLimit>)",
+      FarmCertificationSet: "(u32,TfchainSupportFarmCertification)",
+      ZosVersionUpdated: "Bytes",
+      PowerTargetChanged: {
+        farmId: "u32",
+        nodeId: "u32",
+        powerTarget: "TfchainSupportPower",
+      },
+      PowerStateChanged: {
+        farmId: "u32",
+        nodeId: "u32",
+        powerState: "TfchainSupportPowerState",
+      },
+    },
+  },
+  /**
+   * Lookup47: tfchain_support::types::Farm<pallet_tfgrid::farm::FarmName<T>>
+   **/
+  TfchainSupportFarm: {
+    version: "u32",
+    id: "u32",
+    name: "Bytes",
+    twinId: "u32",
+    pricingPolicyId: "u32",
+    certification: "TfchainSupportFarmCertification",
+    publicIps: "Vec<TfchainSupportPublicIP>",
+    dedicatedFarm: "bool",
+    farmingPolicyLimits: "Option<TfchainSupportFarmingPolicyLimit>",
+  },
+  /**
+   * Lookup50: tfchain_support::types::FarmCertification
+   **/
+  TfchainSupportFarmCertification: {
+    _enum: ["NotCertified", "Gold"],
+  },
+  /**
+   * Lookup52: tfchain_support::types::PublicIP
+   **/
+  TfchainSupportPublicIP: {
+    ip: "Bytes",
+    gateway: "Bytes",
+    contractId: "u64",
+  },
+  /**
+   * Lookup58: tfchain_support::types::FarmingPolicyLimit
+   **/
+  TfchainSupportFarmingPolicyLimit: {
+    farmingPolicyId: "u32",
+    cu: "Option<u64>",
+    su: "Option<u64>",
+    end: "Option<u64>",
+    nodeCount: "Option<u32>",
+    nodeCertification: "bool",
+  },
+  /**
+   * Lookup61: tfchain_support::types::Node<pallet_tfgrid::node::Location<T>, tfchain_support::types::Interface<pallet_tfgrid::interface::InterfaceName<T>, pallet_tfgrid::interface::InterfaceMac<T>, bounded_collections::bounded_vec::BoundedVec<pallet_tfgrid::interface::InterfaceIp<T>, S>>, pallet_tfgrid::node::SerialNumber<T>>
+   **/
+  TfchainSupportNode: {
+    version: "u32",
+    id: "u32",
+    farmId: "u32",
+    twinId: "u32",
+    resources: "TfchainSupportResources",
+    location: "PalletTfgridNodeLocation",
+    publicConfig: "Option<TfchainSupportPublicConfig>",
+    created: "u64",
+    farmingPolicyId: "u32",
+    interfaces: "Vec<TfchainSupportInterfaceInterfaceName>",
+    certification: "TfchainSupportNodeCertification",
+    secureBoot: "bool",
+    virtualized: "bool",
+    serialNumber: "Option<Bytes>",
+    connectionPrice: "u32",
+  },
+  /**
+   * Lookup62: pallet_tfgrid::node::Location<T>
+   **/
+  PalletTfgridNodeLocation: {
+    city: "Bytes",
+    country: "Bytes",
+    latitude: "Bytes",
+    longitude: "Bytes",
+  },
+  /**
+   * Lookup68: tfchain_support::types::Interface<pallet_tfgrid::interface::InterfaceName<T>, pallet_tfgrid::interface::InterfaceMac<T>, bounded_collections::bounded_vec::BoundedVec<pallet_tfgrid::interface::InterfaceIp<T>, S>>
+   **/
+  TfchainSupportInterfaceInterfaceName: {
+    name: "Bytes",
+    mac: "Bytes",
+    ips: "Vec<Bytes>",
+  },
+  /**
+   * Lookup79: tfchain_support::resources::Resources
+   **/
+  TfchainSupportResources: {
+    hru: "u64",
+    sru: "u64",
+    cru: "u64",
+    mru: "u64",
+  },
+  /**
+   * Lookup81: tfchain_support::types::PublicConfig
+   **/
+  TfchainSupportPublicConfig: {
+    ip4: "TfchainSupportIp4",
+    ip6: "Option<TfchainSupportIp6>",
+    domain: "Option<Bytes>",
+  },
+  /**
+   * Lookup82: tfchain_support::types::IP4
+   **/
+  TfchainSupportIp4: {
+    ip: "Bytes",
+    gw: "Bytes",
+  },
+  /**
+   * Lookup84: tfchain_support::types::IP6
+   **/
+  TfchainSupportIp6: {
+    ip: "Bytes",
+    gw: "Bytes",
+  },
+  /**
+   * Lookup89: tfchain_support::types::NodeCertification
+   **/
+  TfchainSupportNodeCertification: {
+    _enum: ["Diy", "Certified"],
+  },
+  /**
+   * Lookup91: pallet_tfgrid::types::Entity<sp_core::crypto::AccountId32, pallet_tfgrid::node::CityName<T>, pallet_tfgrid::node::CountryName<T>>
+   **/
+  PalletTfgridEntity: {
+    version: "u32",
+    id: "u32",
+    name: "Bytes",
+    accountId: "AccountId32",
+    country: "Bytes",
+    city: "Bytes",
+  },
+  /**
+   * Lookup92: pallet_tfgrid::types::Twin<sp_core::crypto::AccountId32>
+   **/
+  PalletTfgridTwin: {
+    id: "u32",
+    accountId: "AccountId32",
+    relay: "Option<Bytes>",
+    entities: "Vec<PalletTfgridEntityProof>",
+    pk: "Option<Bytes>",
+  },
+  /**
+   * Lookup96: pallet_tfgrid::types::EntityProof
+   **/
+  PalletTfgridEntityProof: {
+    entityId: "u32",
+    signature: "Bytes",
+  },
+  /**
+   * Lookup97: pallet_tfgrid::types::PricingPolicy<sp_core::crypto::AccountId32>
+   **/
+  PalletTfgridPricingPolicy: {
+    version: "u32",
+    id: "u32",
+    name: "Bytes",
+    su: "PalletTfgridPolicy",
+    cu: "PalletTfgridPolicy",
+    nu: "PalletTfgridPolicy",
+    ipu: "PalletTfgridPolicy",
+    uniqueName: "PalletTfgridPolicy",
+    domainName: "PalletTfgridPolicy",
+    foundationAccount: "AccountId32",
+    certifiedSalesAccount: "AccountId32",
+    discountForDedicationNodes: "u8",
+  },
+  /**
+   * Lookup98: pallet_tfgrid::types::Policy
+   **/
+  PalletTfgridPolicy: {
+    value: "u32",
+    unit: "PalletTfgridUnit",
+  },
+  /**
+   * Lookup99: pallet_tfgrid::types::Unit
+   **/
+  PalletTfgridUnit: {
+    _enum: ["Bytes", "Kilobytes", "Megabytes", "Gigabytes", "Terrabytes"],
+  },
+  /**
+   * Lookup100: pallet_tfgrid::types::FarmingPolicy<BlockNumber>
+   **/
+  PalletTfgridFarmingPolicy: {
+    version: "u32",
+    id: "u32",
+    name: "Bytes",
+    cu: "u32",
+    su: "u32",
+    nu: "u32",
+    ipv4: "u32",
+    minimalUptime: "u16",
+    policyCreated: "u32",
+    policyEnd: "u32",
+    immutable: "bool",
+    default: "bool",
+    nodeCertification: "TfchainSupportNodeCertification",
+    farmCertification: "TfchainSupportFarmCertification",
+  },
+  /**
+   * Lookup102: tfchain_support::types::Power
+   **/
+  TfchainSupportPower: {
+    _enum: ["Up", "Down"],
+  },
+  /**
+   * Lookup103: tfchain_support::types::PowerState<B>
+   **/
+  TfchainSupportPowerState: {
+    _enum: {
+      Up: "Null",
+      Down: "u32",
+    },
+  },
+  /**
+   * Lookup104: pallet_smart_contract::pallet::Event<T>
+   **/
+  PalletSmartContractEvent: {
+    _enum: {
+      ContractCreated: "PalletSmartContractContract",
+      ContractUpdated: "PalletSmartContractContract",
+      NodeContractCanceled: {
+        contractId: "u64",
+        nodeId: "u32",
+        twinId: "u32",
+      },
+      NameContractCanceled: {
+        contractId: "u64",
+      },
+      IPsReserved: {
+        contractId: "u64",
+        publicIps: "Vec<TfchainSupportPublicIP>",
+      },
+      IPsFreed: {
+        contractId: "u64",
+        publicIps: "Vec<TfchainSupportPublicIP>",
+      },
+      ContractDeployed: "(u64,AccountId32)",
+      ConsumptionReportReceived: "PalletSmartContractConsumption",
+      ContractBilled: "PalletSmartContractContractBill",
+      TokensBurned: {
+        contractId: "u64",
+        amount: "u128",
+      },
+      UpdatedUsedResources: "PalletSmartContractContractResources",
+      NruConsumptionReportReceived: "PalletSmartContractNruConsumption",
+      RentContractCanceled: {
+        contractId: "u64",
+      },
+      ContractGracePeriodStarted: {
+        contractId: "u64",
+        nodeId: "u32",
+        twinId: "u32",
+        blockNumber: "u64",
+      },
+      ContractGracePeriodEnded: {
+        contractId: "u64",
+        nodeId: "u32",
+        twinId: "u32",
+      },
+      SolutionProviderCreated: "PalletSmartContractSolutionProvider",
+      SolutionProviderApproved: "(u64,bool)",
+      ServiceContractCreated: "PalletSmartContractServiceContract",
+      ServiceContractMetadataSet: "PalletSmartContractServiceContract",
+      ServiceContractFeesSet: "PalletSmartContractServiceContract",
+      ServiceContractApproved: "PalletSmartContractServiceContract",
+      ServiceContractCanceled: {
+        serviceContractId: "u64",
+        cause: "PalletSmartContractCause",
+      },
+      ServiceContractBilled: {
+        serviceContract: "PalletSmartContractServiceContract",
+        bill: "PalletSmartContractServiceContractBill",
+        amount: "u128",
+      },
+      BillingFrequencyChanged: "u64",
+      NodeExtraFeeSet: {
+        nodeId: "u32",
+        extraFee: "u64",
+      },
+    },
+  },
+  /**
+   * Lookup105: pallet_smart_contract::types::Contract<T>
+   **/
+  PalletSmartContractContract: {
+    version: "u32",
+    state: "PalletSmartContractContractState",
+    contractId: "u64",
+    twinId: "u32",
+    contractType: "PalletSmartContractContractData",
+    solutionProviderId: "Option<u64>",
+  },
+  /**
+   * Lookup106: pallet_smart_contract::types::ContractState
+   **/
+  PalletSmartContractContractState: {
+    _enum: {
+      Created: "Null",
+      Deleted: "PalletSmartContractCause",
+      GracePeriod: "u64",
+    },
+  },
+  /**
+   * Lookup107: pallet_smart_contract::types::Cause
+   **/
+  PalletSmartContractCause: {
+    _enum: ["CanceledByUser", "OutOfFunds", "CanceledByCollective"],
+  },
+  /**
+   * Lookup108: pallet_smart_contract::types::ContractData<T>
+   **/
+  PalletSmartContractContractData: {
+    _enum: {
+      NodeContract: "PalletSmartContractNodeContract",
+      NameContract: "PalletSmartContractNameContract",
+      RentContract: "PalletSmartContractRentContract",
+    },
+  },
+  /**
+   * Lookup109: pallet_smart_contract::types::NodeContract<T>
+   **/
+  PalletSmartContractNodeContract: {
+    nodeId: "u32",
+    deploymentHash: "[u8;32]",
+    deploymentData: "Bytes",
+    publicIps: "u32",
+    publicIpsList: "Vec<TfchainSupportPublicIP>",
+  },
+  /**
+   * Lookup112: pallet_smart_contract::types::NameContract<T>
+   **/
+  PalletSmartContractNameContract: {
+    name: "Bytes",
+  },
+  /**
+   * Lookup115: pallet_smart_contract::types::RentContract
+   **/
+  PalletSmartContractRentContract: {
+    nodeId: "u32",
+  },
+  /**
+   * Lookup116: pallet_smart_contract::types::Consumption
+   **/
+  PalletSmartContractConsumption: {
+    contractId: "u64",
+    timestamp: "u64",
+    cru: "u64",
+    sru: "u64",
+    hru: "u64",
+    mru: "u64",
+    nru: "u64",
+  },
+  /**
+   * Lookup117: pallet_smart_contract::types::ContractBill
+   **/
+  PalletSmartContractContractBill: {
+    contractId: "u64",
+    timestamp: "u64",
+    discountLevel: "PalletSmartContractDiscountLevel",
+    amountBilled: "u128",
+  },
+  /**
+   * Lookup118: pallet_smart_contract::types::DiscountLevel
+   **/
+  PalletSmartContractDiscountLevel: {
+    _enum: ["None", "Default", "Bronze", "Silver", "Gold"],
+  },
+  /**
+   * Lookup119: pallet_smart_contract::types::ContractResources
+   **/
+  PalletSmartContractContractResources: {
+    contractId: "u64",
+    used: "TfchainSupportResources",
+  },
+  /**
+   * Lookup120: pallet_smart_contract::types::NruConsumption
+   **/
+  PalletSmartContractNruConsumption: {
+    contractId: "u64",
+    timestamp: "u64",
+    window: "u64",
+    nru: "u64",
+  },
+  /**
+   * Lookup121: pallet_smart_contract::types::SolutionProvider<sp_core::crypto::AccountId32>
+   **/
+  PalletSmartContractSolutionProvider: {
+    solutionProviderId: "u64",
+    providers: "Vec<PalletSmartContractProvider>",
+    description: "Bytes",
+    link: "Bytes",
+    approved: "bool",
+  },
+  /**
+   * Lookup123: pallet_smart_contract::types::Provider<sp_core::crypto::AccountId32>
+   **/
+  PalletSmartContractProvider: {
+    who: "AccountId32",
+    take: "u8",
+  },
+  /**
+   * Lookup124: pallet_smart_contract::types::ServiceContract
+   **/
+  PalletSmartContractServiceContract: {
+    serviceContractId: "u64",
+    serviceTwinId: "u32",
+    consumerTwinId: "u32",
+    baseFee: "u64",
+    variableFee: "u64",
+    metadata: "Bytes",
+    acceptedByService: "bool",
+    acceptedByConsumer: "bool",
+    lastBill: "u64",
+    state: "PalletSmartContractServiceContractState",
+  },
+  /**
+   * Lookup126: pallet_smart_contract::types::ServiceContractState
+   **/
+  PalletSmartContractServiceContractState: {
+    _enum: ["Created", "AgreementReady", "ApprovedByBoth"],
+  },
+  /**
+   * Lookup127: pallet_smart_contract::types::ServiceContractBill
+   **/
+  PalletSmartContractServiceContractBill: {
+    variableAmount: "u64",
+    window: "u64",
+    metadata: "Bytes",
+  },
+  /**
+   * Lookup128: pallet_tft_bridge::pallet::Event<T>
+   **/
+  PalletTftBridgeEvent: {
+    _enum: {
+      MintTransactionProposed: "(Bytes,AccountId32,u64)",
+      MintTransactionVoted: "Bytes",
+      MintCompleted: "(PalletTftBridgeMintTransaction,Bytes)",
+      MintTransactionExpired: "(Bytes,u64,AccountId32)",
+      BurnTransactionCreated: "(u64,AccountId32,Bytes,u64)",
+      BurnTransactionProposed: "(u64,Bytes,u64)",
+      BurnTransactionSignatureAdded: "(u64,PalletTftBridgeStellarSignature)",
+      BurnTransactionReady: "u64",
+      BurnTransactionProcessed: "PalletTftBridgeBurnTransaction",
+      BurnTransactionExpired: "(u64,Option<AccountId32>,Bytes,u64)",
+      RefundTransactionCreated: "(Bytes,Bytes,u64)",
+      RefundTransactionsignatureAdded: "(Bytes,PalletTftBridgeStellarSignature)",
+      RefundTransactionReady: "Bytes",
+      RefundTransactionProcessed: "PalletTftBridgeRefundTransaction",
+      RefundTransactionExpired: "(Bytes,Bytes,u64)",
+    },
+  },
+  /**
+   * Lookup129: pallet_tft_bridge::types::MintTransaction<sp_core::crypto::AccountId32, BlockNumber>
+   **/
+  PalletTftBridgeMintTransaction: {
+    amount: "u64",
+    target: "AccountId32",
+    block: "u32",
+    votes: "u32",
+  },
+  /**
+   * Lookup130: pallet_tft_bridge::types::StellarSignature
+   **/
+  PalletTftBridgeStellarSignature: {
+    signature: "Bytes",
+    stellarPubKey: "Bytes",
+  },
+  /**
+   * Lookup131: pallet_tft_bridge::types::BurnTransaction<sp_core::crypto::AccountId32, BlockNumber>
+   **/
+  PalletTftBridgeBurnTransaction: {
+    block: "u32",
+    amount: "u64",
+    source: "Option<AccountId32>",
+    target: "Bytes",
+    signatures: "Vec<PalletTftBridgeStellarSignature>",
+    sequenceNumber: "u64",
+  },
+  /**
+   * Lookup134: pallet_tft_bridge::types::RefundTransaction<BlockNumber>
+   **/
+  PalletTftBridgeRefundTransaction: {
+    block: "u32",
+    amount: "u64",
+    target: "Bytes",
+    txHash: "Bytes",
+    signatures: "Vec<PalletTftBridgeStellarSignature>",
+    sequenceNumber: "u64",
+  },
+  /**
+   * Lookup135: pallet_tft_price::pallet::Event<T>
+   **/
+  PalletTftPriceEvent: {
+    _enum: {
+      PriceStored: "u32",
+      OffchainWorkerExecuted: "AccountId32",
+      AveragePriceStored: "u32",
+      AveragePriceIsAboveMaxPrice: "(u32,u32)",
+      AveragePriceIsBelowMinPrice: "(u32,u32)",
+    },
+  },
+  /**
+   * Lookup136: pallet_burning::pallet::Event<T>
+   **/
+  PalletBurningEvent: {
+    _enum: {
+      BurnTransactionCreated: "(AccountId32,u128,u32,Bytes)",
+    },
+  },
+  /**
+   * Lookup137: pallet_kvstore::pallet::Event<T>
+   **/
+  PalletKvstoreEvent: {
+    _enum: {
+      EntrySet: "(AccountId32,Bytes,Bytes)",
+      EntryGot: "(AccountId32,Bytes,Bytes)",
+      EntryTaken: "(AccountId32,Bytes,Bytes)",
+    },
+  },
+  /**
+   * Lookup138: pallet_collective::pallet::Event<T, I>
+   **/
+  PalletCollectiveEvent: {
+    _enum: {
+      Proposed: {
+        account: "AccountId32",
+        proposalIndex: "u32",
+        proposalHash: "H256",
+        threshold: "u32",
+      },
+      Voted: {
+        account: "AccountId32",
+        proposalHash: "H256",
+        voted: "bool",
+        yes: "u32",
+        no: "u32",
+      },
+      Approved: {
+        proposalHash: "H256",
+      },
+      Disapproved: {
+        proposalHash: "H256",
+      },
+      Executed: {
+        proposalHash: "H256",
+        result: "Result<Null, SpRuntimeDispatchError>",
+      },
+      MemberExecuted: {
+        proposalHash: "H256",
+        result: "Result<Null, SpRuntimeDispatchError>",
+      },
+      Closed: {
+        proposalHash: "H256",
+        yes: "u32",
+        no: "u32",
+      },
+    },
+  },
+  /**
+   * Lookup139: pallet_membership::pallet::Event<T, I>
+   **/
+  PalletMembershipEvent: {
+    _enum: ["MemberAdded", "MemberRemoved", "MembersSwapped", "MembersReset", "KeyChanged", "Dummy"],
+  },
+  /**
+   * Lookup140: pallet_dao::pallet::Event<T>
+   **/
+  PalletDaoEvent: {
+    _enum: {
+      Voted: {
+        account: "AccountId32",
+        proposalHash: "H256",
+        voted: "bool",
+        yes: "u32",
+        no: "u32",
+      },
+      Proposed: {
+        account: "AccountId32",
+        proposalIndex: "u32",
+        proposalHash: "H256",
+        threshold: "u32",
+      },
+      Approved: {
+        proposalHash: "H256",
+      },
+      Disapproved: {
+        proposalHash: "H256",
+      },
+      Executed: {
+        proposalHash: "H256",
+        result: "Result<Null, SpRuntimeDispatchError>",
+      },
+      Closed: {
+        proposalHash: "H256",
+        yes: "u32",
+        yesWeight: "u64",
+        no: "u32",
+        noWeight: "u64",
+      },
+      ClosedByCouncil: {
+        proposalHash: "H256",
+        vetos: "Vec<AccountId32>",
+      },
+      CouncilMemberVeto: {
+        proposalHash: "H256",
+        who: "AccountId32",
+      },
+    },
+  },
+  /**
+   * Lookup142: pallet_validator::pallet::Event<T>
+   **/
+  PalletValidatorEvent: {
+    _enum: {
+      Bonded: "AccountId32",
+      ValidatorRequestCreated: "(AccountId32,PalletValidatorValidator)",
+      ValidatorRequestApproved: "PalletValidatorValidator",
+      ValidatorActivated: "PalletValidatorValidator",
+      ValidatorRemoved: "PalletValidatorValidator",
+      NodeValidatorChanged: "AccountId32",
+      NodeValidatorRemoved: "AccountId32",
+    },
+  },
+  /**
+   * Lookup143: pallet_validator::types::Validator<sp_core::crypto::AccountId32>
+   **/
+  PalletValidatorValidator: {
+    validatorNodeAccount: "AccountId32",
+    stashAccount: "AccountId32",
+    description: "Bytes",
+    tfConnectId: "Bytes",
+    info: "Bytes",
+    state: "PalletValidatorValidatorRequestState",
+  },
+  /**
+   * Lookup144: pallet_validator::types::ValidatorRequestState
+   **/
+  PalletValidatorValidatorRequestState: {
+    _enum: ["Created", "Approved", "Validating"],
+  },
+  /**
+   * Lookup145: frame_system::Phase
+   **/
+  FrameSystemPhase: {
+    _enum: {
+      ApplyExtrinsic: "u32",
+      Finalization: "Null",
+      Initialization: "Null",
+    },
+  },
+  /**
+   * Lookup148: frame_system::LastRuntimeUpgradeInfo
+   **/
+  FrameSystemLastRuntimeUpgradeInfo: {
+    specVersion: "Compact<u32>",
+    specName: "Text",
+  },
+  /**
+   * Lookup151: frame_system::pallet::Call<T>
+   **/
+  FrameSystemCall: {
+    _enum: {
+      remark: {
+        remark: "Bytes",
+      },
+      set_heap_pages: {
+        pages: "u64",
+      },
+      set_code: {
+        code: "Bytes",
+      },
+      set_code_without_checks: {
+        code: "Bytes",
+      },
+      set_storage: {
+        items: "Vec<(Bytes,Bytes)>",
+      },
+      kill_storage: {
+        _alias: {
+          keys_: "keys",
+        },
+        keys_: "Vec<Bytes>",
+      },
+      kill_prefix: {
+        prefix: "Bytes",
+        subkeys: "u32",
+      },
+      remark_with_event: {
+        remark: "Bytes",
+      },
+    },
+  },
+  /**
+   * Lookup155: frame_system::limits::BlockWeights
+   **/
+  FrameSystemLimitsBlockWeights: {
+    baseBlock: "SpWeightsWeightV2Weight",
+    maxBlock: "SpWeightsWeightV2Weight",
+    perClass: "FrameSupportDispatchPerDispatchClassWeightsPerClass",
+  },
+  /**
+   * Lookup156: frame_support::dispatch::PerDispatchClass<frame_system::limits::WeightsPerClass>
+   **/
+  FrameSupportDispatchPerDispatchClassWeightsPerClass: {
+    normal: "FrameSystemLimitsWeightsPerClass",
+    operational: "FrameSystemLimitsWeightsPerClass",
+    mandatory: "FrameSystemLimitsWeightsPerClass",
+  },
+  /**
+   * Lookup157: frame_system::limits::WeightsPerClass
+   **/
+  FrameSystemLimitsWeightsPerClass: {
+    baseExtrinsic: "SpWeightsWeightV2Weight",
+    maxExtrinsic: "Option<SpWeightsWeightV2Weight>",
+    maxTotal: "Option<SpWeightsWeightV2Weight>",
+    reserved: "Option<SpWeightsWeightV2Weight>",
+  },
+  /**
+   * Lookup159: frame_system::limits::BlockLength
+   **/
+  FrameSystemLimitsBlockLength: {
+    max: "FrameSupportDispatchPerDispatchClassU32",
+  },
+  /**
+   * Lookup160: frame_support::dispatch::PerDispatchClass<T>
+   **/
+  FrameSupportDispatchPerDispatchClassU32: {
+    normal: "u32",
+    operational: "u32",
+    mandatory: "u32",
+  },
+  /**
+   * Lookup161: sp_weights::RuntimeDbWeight
+   **/
+  SpWeightsRuntimeDbWeight: {
+    read: "u64",
+    write: "u64",
+  },
+  /**
+   * Lookup162: sp_version::RuntimeVersion
+   **/
+  SpVersionRuntimeVersion: {
+    specName: "Text",
+    implName: "Text",
+    authoringVersion: "u32",
+    specVersion: "u32",
+    implVersion: "u32",
+    apis: "Vec<([u8;8],u32)>",
+    transactionVersion: "u32",
+    stateVersion: "u8",
+  },
+  /**
+   * Lookup167: frame_system::pallet::Error<T>
+   **/
+  FrameSystemError: {
+    _enum: [
+      "InvalidSpecName",
+      "SpecVersionNeedsToIncrease",
+      "FailedToExtractRuntimeVersion",
+      "NonDefaultComposite",
+      "NonZeroRefCount",
+      "CallFiltered",
+    ],
+  },
+  /**
+   * Lookup168: pallet_timestamp::pallet::Call<T>
+   **/
+  PalletTimestampCall: {
+    _enum: {
+      set: {
+        now: "Compact<u64>",
+      },
+    },
+  },
+  /**
+   * Lookup169: pallet_utility::pallet::Call<T>
+   **/
+  PalletUtilityCall: {
+    _enum: {
+      batch: {
+        calls: "Vec<Call>",
+      },
+      as_derivative: {
+        index: "u16",
+        call: "Call",
+      },
+      batch_all: {
+        calls: "Vec<Call>",
+      },
+      dispatch_as: {
+        asOrigin: "TfchainRuntimeOriginCaller",
+        call: "Call",
+      },
+      force_batch: {
+        calls: "Vec<Call>",
+      },
+      with_weight: {
+        call: "Call",
+        weight: "SpWeightsWeightV2Weight",
+      },
+    },
+  },
+  /**
+   * Lookup172: pallet_scheduler::pallet::Call<T>
+   **/
+  PalletSchedulerCall: {
+    _enum: {
+      schedule: {
+        when: "u32",
+        maybePeriodic: "Option<(u32,u32)>",
+        priority: "u8",
+        call: "Call",
+      },
+      cancel: {
+        when: "u32",
+        index: "u32",
+      },
+      schedule_named: {
+        id: "[u8;32]",
+        when: "u32",
+        maybePeriodic: "Option<(u32,u32)>",
+        priority: "u8",
+        call: "Call",
+      },
+      cancel_named: {
+        id: "[u8;32]",
+      },
+      schedule_after: {
+        after: "u32",
+        maybePeriodic: "Option<(u32,u32)>",
+        priority: "u8",
+        call: "Call",
+      },
+      schedule_named_after: {
+        id: "[u8;32]",
+        after: "u32",
+        maybePeriodic: "Option<(u32,u32)>",
+        priority: "u8",
+        call: "Call",
+      },
+    },
+  },
+  /**
+   * Lookup174: substrate_validator_set::pallet::Call<T>
+   **/
+  SubstrateValidatorSetCall: {
+    _enum: {
+      add_validator: {
+        validatorId: "AccountId32",
+      },
+      remove_validator: {
+        validatorId: "AccountId32",
+      },
+      add_validator_again: {
+        validatorId: "AccountId32",
+      },
+    },
+  },
+  /**
+   * Lookup175: pallet_session::pallet::Call<T>
+   **/
+  PalletSessionCall: {
+    _enum: {
+      set_keys: {
+        _alias: {
+          keys_: "keys",
+        },
+        keys_: "TfchainRuntimeOpaqueSessionKeys",
+        proof: "Bytes",
+      },
+      purge_keys: "Null",
+    },
+  },
+  /**
+   * Lookup176: tfchain_runtime::opaque::SessionKeys
+   **/
+  TfchainRuntimeOpaqueSessionKeys: {
+    aura: "SpConsensusAuraSr25519AppSr25519Public",
+    grandpa: "SpConsensusGrandpaAppPublic",
+  },
+  /**
+   * Lookup177: sp_consensus_aura::sr25519::app_sr25519::Public
+   **/
+  SpConsensusAuraSr25519AppSr25519Public: "SpCoreSr25519Public",
+  /**
+   * Lookup178: sp_core::sr25519::Public
+   **/
+  SpCoreSr25519Public: "[u8;32]",
+  /**
+   * Lookup179: pallet_grandpa::pallet::Call<T>
+   **/
+  PalletGrandpaCall: {
+    _enum: {
+      report_equivocation: {
+        equivocationProof: "SpConsensusGrandpaEquivocationProof",
+        keyOwnerProof: "SpCoreVoid",
+      },
+      report_equivocation_unsigned: {
+        equivocationProof: "SpConsensusGrandpaEquivocationProof",
+        keyOwnerProof: "SpCoreVoid",
+      },
+      note_stalled: {
+        delay: "u32",
+        bestFinalizedBlockNumber: "u32",
+      },
+    },
+  },
+  /**
+   * Lookup180: sp_consensus_grandpa::EquivocationProof<primitive_types::H256, N>
+   **/
+  SpConsensusGrandpaEquivocationProof: {
+    setId: "u64",
+    equivocation: "SpConsensusGrandpaEquivocation",
+  },
+  /**
+   * Lookup181: sp_consensus_grandpa::Equivocation<primitive_types::H256, N>
+   **/
+  SpConsensusGrandpaEquivocation: {
+    _enum: {
+      Prevote: "FinalityGrandpaEquivocationPrevote",
+      Precommit: "FinalityGrandpaEquivocationPrecommit",
+    },
+  },
+  /**
+   * Lookup182: finality_grandpa::Equivocation<sp_consensus_grandpa::app::Public, finality_grandpa::Prevote<primitive_types::H256, N>, sp_consensus_grandpa::app::Signature>
+   **/
+  FinalityGrandpaEquivocationPrevote: {
+    roundNumber: "u64",
+    identity: "SpConsensusGrandpaAppPublic",
+    first: "(FinalityGrandpaPrevote,SpConsensusGrandpaAppSignature)",
+    second: "(FinalityGrandpaPrevote,SpConsensusGrandpaAppSignature)",
+  },
+  /**
+   * Lookup183: finality_grandpa::Prevote<primitive_types::H256, N>
+   **/
+  FinalityGrandpaPrevote: {
+    targetHash: "H256",
+    targetNumber: "u32",
+  },
+  /**
+   * Lookup184: sp_consensus_grandpa::app::Signature
+   **/
+  SpConsensusGrandpaAppSignature: "SpCoreEd25519Signature",
+  /**
+   * Lookup185: sp_core::ed25519::Signature
+   **/
+  SpCoreEd25519Signature: "[u8;64]",
+  /**
+   * Lookup188: finality_grandpa::Equivocation<sp_consensus_grandpa::app::Public, finality_grandpa::Precommit<primitive_types::H256, N>, sp_consensus_grandpa::app::Signature>
+   **/
+  FinalityGrandpaEquivocationPrecommit: {
+    roundNumber: "u64",
+    identity: "SpConsensusGrandpaAppPublic",
+    first: "(FinalityGrandpaPrecommit,SpConsensusGrandpaAppSignature)",
+    second: "(FinalityGrandpaPrecommit,SpConsensusGrandpaAppSignature)",
+  },
+  /**
+   * Lookup189: finality_grandpa::Precommit<primitive_types::H256, N>
+   **/
+  FinalityGrandpaPrecommit: {
+    targetHash: "H256",
+    targetNumber: "u32",
+  },
+  /**
+   * Lookup191: sp_core::Void
+   **/
+  SpCoreVoid: "Null",
+  /**
+   * Lookup192: pallet_balances::pallet::Call<T, I>
+   **/
+  PalletBalancesCall: {
+    _enum: {
+      transfer_allow_death: {
+        dest: "MultiAddress",
+        value: "Compact<u128>",
+      },
+      set_balance_deprecated: {
+        who: "MultiAddress",
+        newFree: "Compact<u128>",
+        oldReserved: "Compact<u128>",
+      },
+      force_transfer: {
+        source: "MultiAddress",
+        dest: "MultiAddress",
+        value: "Compact<u128>",
+      },
+      transfer_keep_alive: {
+        dest: "MultiAddress",
+        value: "Compact<u128>",
+      },
+      transfer_all: {
+        dest: "MultiAddress",
+        keepAlive: "bool",
+      },
+      force_unreserve: {
+        who: "MultiAddress",
+        amount: "u128",
+      },
+      upgrade_accounts: {
+        who: "Vec<AccountId32>",
+      },
+      transfer: {
+        dest: "MultiAddress",
+        value: "Compact<u128>",
+      },
+      force_set_balance: {
+        who: "MultiAddress",
+        newFree: "Compact<u128>",
+      },
+    },
+  },
+  /**
+   * Lookup197: pallet_tfgrid::pallet::Call<T>
+   **/
+  PalletTfgridCall: {
+    _enum: {
+      set_storage_version: {
+        version: "PalletTfgridStorageVersion",
+      },
+      create_farm: {
+        name: "Bytes",
+        publicIps: "Vec<TfchainSupportIp4>",
+      },
+      update_farm: {
+        farmId: "u32",
+        name: "Bytes",
+      },
+      add_stellar_payout_v2address: {
+        farmId: "u32",
+        stellarAddress: "Bytes",
+      },
+      set_farm_certification: {
+        farmId: "u32",
+        certification: "TfchainSupportFarmCertification",
+      },
+      add_farm_ip: {
+        farmId: "u32",
+        ip: "Bytes",
+        gw: "Bytes",
+      },
+      remove_farm_ip: {
+        farmId: "u32",
+        ip: "Bytes",
+      },
+      __Unused7: "Null",
+      create_node: {
+        farmId: "u32",
+        resources: "TfchainSupportResources",
+        location: "PalletTfgridLocationInput",
+        interfaces: "Vec<TfchainSupportInterfaceBoundedVec>",
+        secureBoot: "bool",
+        virtualized: "bool",
+        serialNumber: "Option<Bytes>",
+      },
+      update_node: {
+        nodeId: "u32",
+        farmId: "u32",
+        resources: "TfchainSupportResources",
+        location: "PalletTfgridLocationInput",
+        interfaces: "Vec<TfchainSupportInterfaceBoundedVec>",
+        secureBoot: "bool",
+        virtualized: "bool",
+        serialNumber: "Option<Bytes>",
+      },
+      set_node_certification: {
+        nodeId: "u32",
+        nodeCertification: "TfchainSupportNodeCertification",
+      },
+      report_uptime: {
+        uptime: "u64",
+      },
+      add_node_public_config: {
+        farmId: "u32",
+        nodeId: "u32",
+        publicConfig: "Option<TfchainSupportPublicConfig>",
+      },
+      delete_node: {
+        nodeId: "u32",
+      },
+      create_entity: {
+        target: "AccountId32",
+        name: "Bytes",
+        country: "Bytes",
+        city: "Bytes",
+        signature: "Bytes",
+      },
+      update_entity: {
+        name: "Bytes",
+        country: "Bytes",
+        city: "Bytes",
+      },
+      delete_entity: "Null",
+      create_twin: {
+        relay: "Option<Bytes>",
+        pk: "Option<Bytes>",
+      },
+      update_twin: {
+        relay: "Option<Bytes>",
+        pk: "Option<Bytes>",
+      },
+      add_twin_entity: {
+        twinId: "u32",
+        entityId: "u32",
+        signature: "Bytes",
+      },
+      delete_twin_entity: {
+        twinId: "u32",
+        entityId: "u32",
+      },
+      __Unused21: "Null",
+      create_pricing_policy: {
+        name: "Bytes",
+        su: "PalletTfgridPolicy",
+        cu: "PalletTfgridPolicy",
+        nu: "PalletTfgridPolicy",
+        ipu: "PalletTfgridPolicy",
+        uniqueName: "PalletTfgridPolicy",
+        domainName: "PalletTfgridPolicy",
+        foundationAccount: "AccountId32",
+        certifiedSalesAccount: "AccountId32",
+        discountForDedicationNodes: "u8",
+      },
+      update_pricing_policy: {
+        pricingPolicyId: "u32",
+        name: "Bytes",
+        su: "PalletTfgridPolicy",
+        cu: "PalletTfgridPolicy",
+        nu: "PalletTfgridPolicy",
+        ipu: "PalletTfgridPolicy",
+        uniqueName: "PalletTfgridPolicy",
+        domainName: "PalletTfgridPolicy",
+        foundationAccount: "AccountId32",
+        certifiedSalesAccount: "AccountId32",
+        discountForDedicationNodes: "u8",
+      },
+      create_farming_policy: {
+        name: "Bytes",
+        su: "u32",
+        cu: "u32",
+        nu: "u32",
+        ipv4: "u32",
+        minimalUptime: "u16",
+        policyEnd: "u32",
+        immutable: "bool",
+        default: "bool",
+        nodeCertification: "TfchainSupportNodeCertification",
+        farmCertification: "TfchainSupportFarmCertification",
+      },
+      user_accept_tc: {
+        documentLink: "Bytes",
+        documentHash: "Bytes",
+      },
+      delete_node_farm: {
+        nodeId: "u32",
+      },
+      set_farm_dedicated: {
+        farmId: "u32",
+        dedicated: "bool",
+      },
+      force_reset_farm_ip: {
+        farmId: "u32",
+        ip: "Bytes",
+      },
+      set_connection_price: {
+        price: "u32",
+      },
+      add_node_certifier: {
+        certifier: "AccountId32",
+      },
+      remove_node_certifier: {
+        certifier: "AccountId32",
+      },
+      update_farming_policy: {
+        farmingPolicyId: "u32",
+        name: "Bytes",
+        su: "u32",
+        cu: "u32",
+        nu: "u32",
+        ipv4: "u32",
+        minimalUptime: "u16",
+        policyEnd: "u32",
+        default: "bool",
+        nodeCertification: "TfchainSupportNodeCertification",
+        farmCertification: "TfchainSupportFarmCertification",
+      },
+      attach_policy_to_farm: {
+        farmId: "u32",
+        limits: "Option<TfchainSupportFarmingPolicyLimit>",
+      },
+      set_zos_version: {
+        zosVersion: "Bytes",
+      },
+      change_power_state: {
+        powerState: "TfchainSupportPower",
+      },
+      change_power_target: {
+        nodeId: "u32",
+        powerTarget: "TfchainSupportPower",
+      },
+      bond_twin_account: {
+        twinId: "u32",
+      },
+      report_uptime_v2: {
+        uptime: "u64",
+        timestampHint: "u64",
+      },
+    },
+  },
+  /**
+   * Lookup198: pallet_tfgrid::types::StorageVersion
+   **/
+  PalletTfgridStorageVersion: {
+    _enum: [
+      "V1Struct",
+      "V2Struct",
+      "V3Struct",
+      "V4Struct",
+      "V5Struct",
+      "V6Struct",
+      "V7Struct",
+      "V8Struct",
+      "V9Struct",
+      "V10Struct",
+      "V11Struct",
+      "V12Struct",
+      "V13Struct",
+      "V14Struct",
+      "V15Struct",
+      "V16Struct",
+      "V17Struct",
+    ],
+  },
+  /**
+   * Lookup201: pallet_tfgrid::types::LocationInput<bounded_collections::bounded_vec::BoundedVec<T, S>, bounded_collections::bounded_vec::BoundedVec<T, S>, bounded_collections::bounded_vec::BoundedVec<T, S>, bounded_collections::bounded_vec::BoundedVec<T, S>>
+   **/
+  PalletTfgridLocationInput: {
+    city: "Bytes",
+    country: "Bytes",
+    latitude: "Bytes",
+    longitude: "Bytes",
+  },
+  /**
+   * Lookup203: tfchain_support::types::Interface<bounded_collections::bounded_vec::BoundedVec<T, S>, bounded_collections::bounded_vec::BoundedVec<T, S>, bounded_collections::bounded_vec::BoundedVec<bounded_collections::bounded_vec::BoundedVec<T, S>, S>>
+   **/
+  TfchainSupportInterfaceBoundedVec: {
+    name: "Bytes",
+    mac: "Bytes",
+    ips: "Vec<Bytes>",
+  },
+  /**
+   * Lookup208: pallet_smart_contract::pallet::Call<T>
+   **/
+  PalletSmartContractCall: {
+    _enum: {
+      create_node_contract: {
+        nodeId: "u32",
+        deploymentHash: "[u8;32]",
+        deploymentData: "Bytes",
+        publicIps: "u32",
+        solutionProviderId: "Option<u64>",
+      },
+      update_node_contract: {
+        contractId: "u64",
+        deploymentHash: "[u8;32]",
+        deploymentData: "Bytes",
+      },
+      cancel_contract: {
+        contractId: "u64",
+      },
+      __Unused3: "Null",
+      create_name_contract: {
+        name: "Bytes",
+      },
+      add_nru_reports: {
+        reports: "Vec<PalletSmartContractNruConsumption>",
+      },
+      report_contract_resources: {
+        contractResources: "Vec<PalletSmartContractContractResources>",
+      },
+      create_rent_contract: {
+        nodeId: "u32",
+        solutionProviderId: "Option<u64>",
+      },
+      create_solution_provider: {
+        description: "Bytes",
+        link: "Bytes",
+        providers: "Vec<PalletSmartContractProvider>",
+      },
+      approve_solution_provider: {
+        solutionProviderId: "u64",
+        approve: "bool",
+      },
+      bill_contract_for_block: {
+        contractId: "u64",
+      },
+      service_contract_create: {
+        serviceAccount: "AccountId32",
+        consumerAccount: "AccountId32",
+      },
+      service_contract_set_metadata: {
+        serviceContractId: "u64",
+        metadata: "Bytes",
+      },
+      service_contract_set_fees: {
+        serviceContractId: "u64",
+        baseFee: "u64",
+        variableFee: "u64",
+      },
+      service_contract_approve: {
+        serviceContractId: "u64",
+      },
+      service_contract_reject: {
+        serviceContractId: "u64",
+      },
+      service_contract_cancel: {
+        serviceContractId: "u64",
+      },
+      service_contract_bill: {
+        serviceContractId: "u64",
+        variableAmount: "u64",
+        metadata: "Bytes",
+      },
+      change_billing_frequency: {
+        frequency: "u64",
+      },
+      attach_solution_provider_id: {
+        contractId: "u64",
+        solutionProviderId: "u64",
+      },
+      set_dedicated_node_extra_fee: {
+        nodeId: "u32",
+        extraFee: "u64",
+      },
+      cancel_contract_collective: {
+        contractId: "u64",
+      },
+    },
+  },
+  /**
+   * Lookup211: pallet_tft_bridge::pallet::Call<T>
+   **/
+  PalletTftBridgeCall: {
+    _enum: {
+      add_bridge_validator: {
+        target: "AccountId32",
+      },
+      remove_bridge_validator: {
+        target: "AccountId32",
+      },
+      set_fee_account: {
+        target: "AccountId32",
+      },
+      set_withdraw_fee: {
+        amount: "u64",
+      },
+      set_deposit_fee: {
+        amount: "u64",
+      },
+      swap_to_stellar: {
+        targetStellarAddress: "Bytes",
+        amount: "u128",
+      },
+      propose_or_vote_mint_transaction: {
+        transaction: "Bytes",
+        target: "AccountId32",
+        amount: "u64",
+      },
+      propose_burn_transaction_or_add_sig: {
+        transactionId: "u64",
+        target: "Bytes",
+        amount: "u64",
+        signature: "Bytes",
+        stellarPubKey: "Bytes",
+        sequenceNumber: "u64",
+      },
+      set_burn_transaction_executed: {
+        transactionId: "u64",
+      },
+      create_refund_transaction_or_add_sig: {
+        txHash: "Bytes",
+        target: "Bytes",
+        amount: "u64",
+        signature: "Bytes",
+        stellarPubKey: "Bytes",
+        sequenceNumber: "u64",
+      },
+      set_refund_transaction_executed: {
+        txHash: "Bytes",
+      },
+    },
+  },
+  /**
+   * Lookup212: pallet_tft_price::pallet::Call<T>
+   **/
+  PalletTftPriceCall: {
+    _enum: {
+      set_prices: {
+        price: "u32",
+        blockNumber: "u32",
+      },
+      __Unused1: "Null",
+      set_min_tft_price: {
+        price: "u32",
+      },
+      set_max_tft_price: {
+        price: "u32",
+      },
+    },
+  },
+  /**
+   * Lookup213: pallet_burning::pallet::Call<T>
+   **/
+  PalletBurningCall: {
+    _enum: {
+      burn_tft: {
+        amount: "u128",
+        message: "Bytes",
+      },
+    },
+  },
+  /**
+   * Lookup214: pallet_kvstore::pallet::Call<T>
+   **/
+  PalletKvstoreCall: {
+    _enum: {
+      set: {
+        key: "Bytes",
+        value: "Bytes",
+      },
+      delete: {
+        key: "Bytes",
+      },
+    },
+  },
+  /**
+   * Lookup215: pallet_runtime_upgrade::pallet::Call<T>
+   **/
+  PalletRuntimeUpgradeCall: {
+    _enum: {
+      set_code: {
+        code: "Bytes",
+      },
+    },
+  },
+  /**
+   * Lookup216: pallet_collective::pallet::Call<T, I>
+   **/
+  PalletCollectiveCall: {
+    _enum: {
+      set_members: {
+        newMembers: "Vec<AccountId32>",
+        prime: "Option<AccountId32>",
+        oldCount: "u32",
+      },
+      execute: {
+        proposal: "Call",
+        lengthBound: "Compact<u32>",
+      },
+      propose: {
+        threshold: "Compact<u32>",
+        proposal: "Call",
+        lengthBound: "Compact<u32>",
+      },
+      vote: {
+        proposal: "H256",
+        index: "Compact<u32>",
+        approve: "bool",
+      },
+      __Unused4: "Null",
+      disapprove_proposal: {
+        proposalHash: "H256",
+      },
+      close: {
+        proposalHash: "H256",
+        index: "Compact<u32>",
+        proposalWeightBound: "SpWeightsWeightV2Weight",
+        lengthBound: "Compact<u32>",
+      },
+    },
+  },
+  /**
+   * Lookup217: pallet_membership::pallet::Call<T, I>
+   **/
+  PalletMembershipCall: {
+    _enum: {
+      add_member: {
+        who: "MultiAddress",
+      },
+      remove_member: {
+        who: "MultiAddress",
+      },
+      swap_member: {
+        remove: "MultiAddress",
+        add: "MultiAddress",
+      },
+      reset_members: {
+        members: "Vec<AccountId32>",
+      },
+      change_key: {
+        _alias: {
+          new_: "new",
+        },
+        new_: "MultiAddress",
+      },
+      set_prime: {
+        who: "MultiAddress",
+      },
+      clear_prime: "Null",
+    },
+  },
+  /**
+   * Lookup218: pallet_dao::pallet::Call<T>
+   **/
+  PalletDaoCall: {
+    _enum: {
+      propose: {
+        threshold: "Compact<u32>",
+        action: "Call",
+        description: "Bytes",
+        link: "Bytes",
+        duration: "Option<u32>",
+      },
+      vote: {
+        farmId: "u32",
+        proposalHash: "H256",
+        approve: "bool",
+      },
+      veto: {
+        proposalHash: "H256",
+      },
+      close: {
+        proposalHash: "H256",
+        proposalIndex: "Compact<u32>",
+      },
+    },
+  },
+  /**
+   * Lookup219: pallet_validator::pallet::Call<T>
+   **/
+  PalletValidatorCall: {
+    _enum: {
+      create_validator_request: {
+        validatorNodeAccount: "AccountId32",
+        stashAccount: "AccountId32",
+        description: "Bytes",
+        tfConnectId: "Bytes",
+        info: "Bytes",
+      },
+      activate_validator_node: "Null",
+      change_validator_node_account: {
+        newNodeValidatorAccount: "AccountId32",
+      },
+      bond: {
+        validator: "MultiAddress",
+      },
+      approve_validator: {
+        validatorAccount: "MultiAddress",
+      },
+      remove_validator: {
+        validatorAccount: "MultiAddress",
+      },
+    },
+  },
+  /**
+   * Lookup220: tfchain_runtime::OriginCaller
+   **/
+  TfchainRuntimeOriginCaller: {
+    _enum: {
+      system: "FrameSupportDispatchRawOrigin",
+      __Unused1: "Null",
+      Void: "SpCoreVoid",
+      __Unused3: "Null",
+      __Unused4: "Null",
+      __Unused5: "Null",
+      __Unused6: "Null",
+      __Unused7: "Null",
+      __Unused8: "Null",
+      __Unused9: "Null",
+      __Unused10: "Null",
+      __Unused11: "Null",
+      __Unused12: "Null",
+      __Unused13: "Null",
+      __Unused14: "Null",
+      __Unused15: "Null",
+      __Unused16: "Null",
+      __Unused17: "Null",
+      __Unused18: "Null",
+      __Unused19: "Null",
+      __Unused20: "Null",
+      __Unused21: "Null",
+      __Unused22: "Null",
+      __Unused23: "Null",
+      __Unused24: "Null",
+      __Unused25: "Null",
+      __Unused26: "Null",
+      __Unused27: "Null",
+      __Unused28: "Null",
+      __Unused29: "Null",
+      __Unused30: "Null",
+      __Unused31: "Null",
+      __Unused32: "Null",
+      __Unused33: "Null",
+      __Unused34: "Null",
+      __Unused35: "Null",
+      __Unused36: "Null",
+      __Unused37: "Null",
+      __Unused38: "Null",
+      __Unused39: "Null",
+      Council: "PalletCollectiveRawOrigin",
+    },
+  },
+  /**
+   * Lookup221: frame_support::dispatch::RawOrigin<sp_core::crypto::AccountId32>
+   **/
+  FrameSupportDispatchRawOrigin: {
+    _enum: {
+      Root: "Null",
+      Signed: "AccountId32",
+      None: "Null",
+    },
+  },
+  /**
+   * Lookup222: pallet_collective::RawOrigin<sp_core::crypto::AccountId32, I>
+   **/
+  PalletCollectiveRawOrigin: {
+    _enum: {
+      Members: "(u32,u32)",
+      Member: "AccountId32",
+      _Phantom: "Null",
+    },
+  },
+  /**
+   * Lookup223: pallet_utility::pallet::Error<T>
+   **/
+  PalletUtilityError: {
+    _enum: ["TooManyCalls"],
+  },
+  /**
+   * Lookup226: pallet_scheduler::Scheduled<Name, frame_support::traits::preimages::Bounded<tfchain_runtime::RuntimeCall>, BlockNumber, tfchain_runtime::OriginCaller, sp_core::crypto::AccountId32>
+   **/
+  PalletSchedulerScheduled: {
+    maybeId: "Option<[u8;32]>",
+    priority: "u8",
+    call: "FrameSupportPreimagesBounded",
+    maybePeriodic: "Option<(u32,u32)>",
+    origin: "TfchainRuntimeOriginCaller",
+  },
+  /**
+   * Lookup227: frame_support::traits::preimages::Bounded<tfchain_runtime::RuntimeCall>
+   **/
+  FrameSupportPreimagesBounded: {
+    _enum: {
+      Legacy: {
+        _alias: {
+          hash_: "hash",
+        },
+        hash_: "H256",
+      },
+      Inline: "Bytes",
+      Lookup: {
+        _alias: {
+          hash_: "hash",
+        },
+        hash_: "H256",
+        len: "u32",
+      },
+    },
+  },
+  /**
+   * Lookup229: pallet_scheduler::pallet::Error<T>
+   **/
+  PalletSchedulerError: {
+    _enum: ["FailedToSchedule", "NotFound", "TargetBlockNumberInPast", "RescheduleNoChange", "Named"],
+  },
+  /**
+   * Lookup230: substrate_validator_set::pallet::Error<T>
+   **/
+  SubstrateValidatorSetError: {
+    _enum: ["TooLowValidatorCount", "Duplicate", "ValidatorNotApproved", "BadOrigin"],
+  },
+  /**
+   * Lookup235: sp_core::crypto::KeyTypeId
+   **/
+  SpCoreCryptoKeyTypeId: "[u8;4]",
+  /**
+   * Lookup236: pallet_session::pallet::Error<T>
+   **/
+  PalletSessionError: {
+    _enum: ["InvalidProof", "NoAssociatedValidatorId", "DuplicatedKey", "NoKeys", "NoAccount"],
+  },
+  /**
+   * Lookup240: pallet_grandpa::StoredState<N>
+   **/
+  PalletGrandpaStoredState: {
+    _enum: {
+      Live: "Null",
+      PendingPause: {
+        scheduledAt: "u32",
+        delay: "u32",
+      },
+      Paused: "Null",
+      PendingResume: {
+        scheduledAt: "u32",
+        delay: "u32",
+      },
+    },
+  },
+  /**
+   * Lookup241: pallet_grandpa::StoredPendingChange<N, Limit>
+   **/
+  PalletGrandpaStoredPendingChange: {
+    scheduledAt: "u32",
+    delay: "u32",
+    nextAuthorities: "Vec<(SpConsensusGrandpaAppPublic,u64)>",
+    forced: "Option<u32>",
+  },
+  /**
+   * Lookup243: pallet_grandpa::pallet::Error<T>
+   **/
+  PalletGrandpaError: {
+    _enum: [
+      "PauseFailed",
+      "ResumeFailed",
+      "ChangePending",
+      "TooSoon",
+      "InvalidKeyOwnershipProof",
+      "InvalidEquivocationProof",
+      "DuplicateOffenceReport",
+    ],
+  },
+  /**
+   * Lookup245: pallet_balances::types::BalanceLock<Balance>
+   **/
+  PalletBalancesBalanceLock: {
+    id: "[u8;8]",
+    amount: "u128",
+    reasons: "PalletBalancesReasons",
+  },
+  /**
+   * Lookup246: pallet_balances::types::Reasons
+   **/
+  PalletBalancesReasons: {
+    _enum: ["Fee", "Misc", "All"],
+  },
+  /**
+   * Lookup249: pallet_balances::types::ReserveData<ReserveIdentifier, Balance>
+   **/
+  PalletBalancesReserveData: {
+    id: "[u8;8]",
+    amount: "u128",
+  },
+  /**
+   * Lookup252: pallet_balances::types::IdAmount<Id, Balance>
+   **/
+  PalletBalancesIdAmount: {
+    id: "Null",
+    amount: "u128",
+  },
+  /**
+   * Lookup254: pallet_balances::pallet::Error<T, I>
+   **/
+  PalletBalancesError: {
+    _enum: [
+      "VestingBalance",
+      "LiquidityRestrictions",
+      "InsufficientBalance",
+      "ExistentialDeposit",
+      "Expendability",
+      "ExistingVestingSchedule",
+      "DeadAccount",
+      "TooManyReserves",
+      "TooManyHolds",
+      "TooManyFreezes",
+    ],
+  },
+  /**
+   * Lookup256: pallet_transaction_payment::Releases
+   **/
+  PalletTransactionPaymentReleases: {
+    _enum: ["V1Ancient", "V2"],
+  },
+  /**
+   * Lookup258: pallet_tfgrid::terms_cond::TermsAndConditions<T>
+   **/
+  PalletTfgridTermsCondTermsAndConditions: {
+    accountId: "AccountId32",
+    timestamp: "u64",
+    documentLink: "Bytes",
+    documentHash: "Bytes",
+  },
+  /**
+   * Lookup259: tfchain_support::types::NodePower<B>
+   **/
+  TfchainSupportNodePower: {
+    state: "TfchainSupportPowerState",
+    target: "TfchainSupportPower",
+  },
+  /**
+   * Lookup260: pallet_tfgrid::pallet::Error<T>
+   **/
+  PalletTfgridError: {
+    _enum: [
+      "NoneValue",
+      "StorageOverflow",
+      "CannotCreateNode",
+      "NodeNotExists",
+      "NodeWithTwinIdExists",
+      "CannotDeleteNode",
+      "NodeDeleteNotAuthorized",
+      "NodeUpdateNotAuthorized",
+      "FarmExists",
+      "FarmNotExists",
+      "CannotCreateFarmWrongTwin",
+      "CannotUpdateFarmWrongTwin",
+      "CannotDeleteFarm",
+      "CannotDeleteFarmWithPublicIPs",
+      "CannotDeleteFarmWithNodesAssigned",
+      "CannotDeleteFarmWrongTwin",
+      "IpExists",
+      "IpNotExists",
+      "EntityWithNameExists",
+      "EntityWithPubkeyExists",
+      "EntityNotExists",
+      "EntitySignatureDoesNotMatch",
+      "EntityWithSignatureAlreadyExists",
+      "CannotUpdateEntity",
+      "CannotDeleteEntity",
+      "SignatureLengthIsIncorrect",
+      "TwinExists",
+      "TwinNotExists",
+      "TwinWithPubkeyExists",
+      "CannotCreateTwin",
+      "UnauthorizedToUpdateTwin",
+      "TwinCannotBoundToItself",
+      "PricingPolicyExists",
+      "PricingPolicyNotExists",
+      "PricingPolicyWithDifferentIdExists",
+      "CertificationCodeExists",
+      "FarmingPolicyAlreadyExists",
+      "FarmPayoutAdressAlreadyRegistered",
+      "FarmerDoesNotHaveEnoughFunds",
+      "UserDidNotSignTermsAndConditions",
+      "FarmerDidNotSignTermsAndConditions",
+      "FarmerNotAuthorized",
+      "InvalidFarmName",
+      "AlreadyCertifier",
+      "NotCertifier",
+      "NotAllowedToCertifyNode",
+      "FarmingPolicyNotExists",
+      "RelayTooShort",
+      "RelayTooLong",
+      "InvalidRelay",
+      "FarmNameTooShort",
+      "FarmNameTooLong",
+      "InvalidPublicIP",
+      "PublicIPTooShort",
+      "PublicIPTooLong",
+      "GatewayIPTooShort",
+      "GatewayIPTooLong",
+      "IP4TooShort",
+      "IP4TooLong",
+      "InvalidIP4",
+      "GW4TooShort",
+      "GW4TooLong",
+      "InvalidGW4",
+      "IP6TooShort",
+      "IP6TooLong",
+      "InvalidIP6",
+      "GW6TooShort",
+      "GW6TooLong",
+      "InvalidGW6",
+      "DomainTooShort",
+      "DomainTooLong",
+      "InvalidDomain",
+      "MethodIsDeprecated",
+      "InterfaceNameTooShort",
+      "InterfaceNameTooLong",
+      "InvalidInterfaceName",
+      "InterfaceMacTooShort",
+      "InterfaceMacTooLong",
+      "InvalidMacAddress",
+      "InterfaceIpTooShort",
+      "InterfaceIpTooLong",
+      "InvalidInterfaceIP",
+      "InvalidZosVersion",
+      "FarmingPolicyExpired",
+      "InvalidHRUInput",
+      "InvalidSRUInput",
+      "InvalidCRUInput",
+      "InvalidMRUInput",
+      "LatitudeInputTooShort",
+      "LatitudeInputTooLong",
+      "InvalidLatitudeInput",
+      "LongitudeInputTooShort",
+      "LongitudeInputTooLong",
+      "InvalidLongitudeInput",
+      "CountryNameTooShort",
+      "CountryNameTooLong",
+      "InvalidCountryName",
+      "CityNameTooShort",
+      "CityNameTooLong",
+      "InvalidCityName",
+      "InvalidCountryCityPair",
+      "SerialNumberTooShort",
+      "SerialNumberTooLong",
+      "InvalidSerialNumber",
+      "DocumentLinkInputTooShort",
+      "DocumentLinkInputTooLong",
+      "InvalidDocumentLinkInput",
+      "DocumentHashInputTooShort",
+      "DocumentHashInputTooLong",
+      "InvalidDocumentHashInput",
+      "InvalidPublicConfig",
+      "UnauthorizedToChangePowerTarget",
+      "NodeHasActiveContracts",
+      "InvalidRelayAddress",
+      "InvalidTimestampHint",
+      "InvalidStorageInput",
+    ],
+  },
+  /**
+   * Lookup261: pallet_smart_contract::types::ContractBillingInformation
+   **/
+  PalletSmartContractContractBillingInformation: {
+    previousNuReported: "u64",
+    lastUpdated: "u64",
+    amountUnbilled: "u64",
+  },
+  /**
+   * Lookup264: pallet_smart_contract::types::ContractLock<BalanceOf>
+   **/
+  PalletSmartContractContractLock: {
+    amountLocked: "u128",
+    extraAmountLocked: "u128",
+    lockUpdated: "u64",
+    cycles: "u16",
+  },
+  /**
+   * Lookup265: pallet_smart_contract::types::StorageVersion
+   **/
+  PalletSmartContractStorageVersion: {
+    _enum: ["V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9", "V10", "V11"],
+  },
+  /**
+   * Lookup266: pallet_smart_contract::pallet::Error<T>
+   **/
+  PalletSmartContractError: {
+    _enum: [
+      "TwinNotExists",
+      "NodeNotExists",
+      "FarmNotExists",
+      "FarmHasNotEnoughPublicIPs",
+      "FarmHasNotEnoughPublicIPsFree",
+      "FailedToReserveIP",
+      "FailedToFreeIPs",
+      "ContractNotExists",
+      "TwinNotAuthorizedToUpdateContract",
+      "TwinNotAuthorizedToCancelContract",
+      "NodeNotAuthorizedToDeployContract",
+      "NodeNotAuthorizedToComputeReport",
+      "PricingPolicyNotExists",
+      "ContractIsNotUnique",
+      "ContractWrongBillingLoopIndex",
+      "NameExists",
+      "NameNotValid",
+      "InvalidContractType",
+      "TFTPriceValueError",
+      "NotEnoughResourcesOnNode",
+      "NodeNotAuthorizedToReportResources",
+      "MethodIsDeprecated",
+      "NodeHasActiveContracts",
+      "NodeHasRentContract",
+      "FarmIsNotDedicated",
+      "NodeNotAvailableToDeploy",
+      "CannotUpdateContractInGraceState",
+      "NumOverflow",
+      "OffchainSignedTxCannotSign",
+      "OffchainSignedTxAlreadySent",
+      "OffchainSignedTxNoLocalAccountAvailable",
+      "NameContractNameTooShort",
+      "NameContractNameTooLong",
+      "InvalidProviderConfiguration",
+      "NoSuchSolutionProvider",
+      "SolutionProviderNotApproved",
+      "TwinNotAuthorized",
+      "ServiceContractNotExists",
+      "ServiceContractCreationNotAllowed",
+      "ServiceContractModificationNotAllowed",
+      "ServiceContractApprovalNotAllowed",
+      "ServiceContractRejectionNotAllowed",
+      "ServiceContractBillingNotApprovedByBoth",
+      "ServiceContractBillingVariableAmountTooHigh",
+      "ServiceContractBillMetadataTooLong",
+      "ServiceContractMetadataTooLong",
+      "ServiceContractNotEnoughFundsToPayBill",
+      "CanOnlyIncreaseFrequency",
+      "IsNotAnAuthority",
+      "WrongAuthority",
+      "UnauthorizedToChangeSolutionProviderId",
+      "UnauthorizedToSetExtraFee",
+    ],
+  },
+  /**
+   * Lookup267: pallet_tft_bridge::types::StorageVersion
+   **/
+  PalletTftBridgeStorageVersion: {
+    _enum: ["V1", "V2"],
+  },
+  /**
+   * Lookup268: pallet_tft_bridge::pallet::Error<T>
+   **/
+  PalletTftBridgeError: {
+    _enum: [
+      "ValidatorExists",
+      "ValidatorNotExists",
+      "TransactionValidatorExists",
+      "TransactionValidatorNotExists",
+      "MintTransactionExists",
+      "MintTransactionAlreadyExecuted",
+      "MintTransactionNotExists",
+      "BurnTransactionExists",
+      "BurnTransactionNotExists",
+      "BurnSignatureExists",
+      "EnoughBurnSignaturesPresent",
+      "RefundSignatureExists",
+      "BurnTransactionAlreadyExecuted",
+      "RefundTransactionNotExists",
+      "RefundTransactionAlreadyExecuted",
+      "EnoughRefundSignaturesPresent",
+      "NotEnoughBalanceToSwap",
+      "AmountIsLessThanWithdrawFee",
+      "AmountIsLessThanDepositFee",
+      "WrongParametersProvided",
+      "InvalidStellarPublicKey",
+    ],
+  },
+  /**
+   * Lookup270: pallet_tft_price::pallet::Error<T>
+   **/
+  PalletTftPriceError: {
+    _enum: [
+      "ErrFetchingPrice",
+      "OffchainSignedTxError",
+      "NoLocalAcctForSigning",
+      "AccountUnauthorizedToSetPrice",
+      "MaxPriceBelowMinPriceError",
+      "MinPriceAboveMaxPriceError",
+      "IsNotAnAuthority",
+      "WrongAuthority",
+    ],
+  },
+  /**
+   * Lookup272: pallet_burning::types::Burn<sp_core::crypto::AccountId32, BalanceOf, BlockNumber>
+   **/
+  PalletBurningBurn: {
+    target: "AccountId32",
+    amount: "u128",
+    block: "u32",
+    message: "Bytes",
+  },
+  /**
+   * Lookup273: pallet_burning::pallet::Error<T>
+   **/
+  PalletBurningError: {
+    _enum: ["NotEnoughBalanceToBurn"],
+  },
+  /**
+   * Lookup275: pallet_kvstore::pallet::Error<T>
+   **/
+  PalletKvstoreError: {
+    _enum: ["NoValueStored", "KeyIsTooLarge", "ValueIsTooLarge"],
+  },
+  /**
+   * Lookup277: pallet_collective::Votes<sp_core::crypto::AccountId32, BlockNumber>
+   **/
+  PalletCollectiveVotes: {
+    index: "u32",
+    threshold: "u32",
+    ayes: "Vec<AccountId32>",
+    nays: "Vec<AccountId32>",
+    end: "u32",
+  },
+  /**
+   * Lookup278: pallet_collective::pallet::Error<T, I>
+   **/
+  PalletCollectiveError: {
+    _enum: [
+      "NotMember",
+      "DuplicateProposal",
+      "ProposalMissing",
+      "WrongIndex",
+      "DuplicateVote",
+      "AlreadyInitialized",
+      "TooEarly",
+      "TooManyProposals",
+      "WrongProposalWeight",
+      "WrongProposalLength",
+    ],
+  },
+  /**
+   * Lookup280: pallet_membership::pallet::Error<T, I>
+   **/
+  PalletMembershipError: {
+    _enum: ["AlreadyMember", "NotMember", "TooManyMembers"],
+  },
+  /**
+   * Lookup281: pallet_dao::proposal::DaoProposal
+   **/
+  PalletDaoProposalDaoProposal: {
+    index: "u32",
+    description: "Bytes",
+    link: "Bytes",
+  },
+  /**
+   * Lookup282: pallet_dao::proposal::DaoVotes<BlockNumber, sp_core::crypto::AccountId32>
+   **/
+  PalletDaoProposalDaoVotes: {
+    index: "u32",
+    threshold: "u32",
+    ayes: "Vec<PalletDaoProposalVoteWeight>",
+    nays: "Vec<PalletDaoProposalVoteWeight>",
+    end: "u32",
+    vetos: "Vec<AccountId32>",
+  },
+  /**
+   * Lookup284: pallet_dao::proposal::VoteWeight
+   **/
+  PalletDaoProposalVoteWeight: {
+    farmId: "u32",
+    weight: "u64",
+  },
+  /**
+   * Lookup285: pallet_dao::pallet::Error<T>
+   **/
+  PalletDaoError: {
+    _enum: [
+      "NoneValue",
+      "StorageOverflow",
+      "FarmNotExists",
+      "NotCouncilMember",
+      "WrongProposalLength",
+      "DuplicateProposal",
+      "NotAuthorizedToVote",
+      "ProposalMissing",
+      "WrongIndex",
+      "DuplicateVote",
+      "DuplicateVeto",
+      "WrongProposalWeight",
+      "TooEarly",
+      "TimeLimitReached",
+      "OngoingVoteAndTresholdStillNotMet",
+      "FarmHasNoNodes",
+      "InvalidProposalDuration",
+      "ThresholdTooLow",
+    ],
+  },
+  /**
+   * Lookup286: pallet_validator::pallet::Error<T>
+   **/
+  PalletValidatorError: {
+    _enum: [
+      "BadOrigin",
+      "NotCouncilMember",
+      "AlreadyBonded",
+      "StashNotBonded",
+      "StashBondedWithWrongValidator",
+      "CannotBondWithSameAccount",
+      "DuplicateValidator",
+      "ValidatorNotFound",
+      "ValidatorNotApproved",
+      "UnauthorizedToActivateValidator",
+      "ValidatorValidatingAlready",
+      "ValidatorNotValidating",
+    ],
+  },
+  /**
+   * Lookup288: sp_runtime::MultiSignature
+   **/
+  SpRuntimeMultiSignature: {
+    _enum: {
+      Ed25519: "SpCoreEd25519Signature",
+      Sr25519: "SpCoreSr25519Signature",
+      Ecdsa: "SpCoreEcdsaSignature",
+    },
+  },
+  /**
+   * Lookup289: sp_core::sr25519::Signature
+   **/
+  SpCoreSr25519Signature: "[u8;64]",
+  /**
+   * Lookup290: sp_core::ecdsa::Signature
+   **/
+  SpCoreEcdsaSignature: "[u8;65]",
+  /**
+   * Lookup293: frame_system::extensions::check_non_zero_sender::CheckNonZeroSender<T>
+   **/
+  FrameSystemExtensionsCheckNonZeroSender: "Null",
+  /**
+   * Lookup294: frame_system::extensions::check_spec_version::CheckSpecVersion<T>
+   **/
+  FrameSystemExtensionsCheckSpecVersion: "Null",
+  /**
+   * Lookup295: frame_system::extensions::check_tx_version::CheckTxVersion<T>
+   **/
+  FrameSystemExtensionsCheckTxVersion: "Null",
+  /**
+   * Lookup296: frame_system::extensions::check_genesis::CheckGenesis<T>
+   **/
+  FrameSystemExtensionsCheckGenesis: "Null",
+  /**
+   * Lookup299: frame_system::extensions::check_nonce::CheckNonce<T>
+   **/
+  FrameSystemExtensionsCheckNonce: "Compact<u32>",
+  /**
+   * Lookup300: frame_system::extensions::check_weight::CheckWeight<T>
+   **/
+  FrameSystemExtensionsCheckWeight: "Null",
+  /**
+   * Lookup301: pallet_transaction_payment::ChargeTransactionPayment<T>
+   **/
+  PalletTransactionPaymentChargeTransactionPayment: "Compact<u128>",
+  /**
+   * Lookup302: tfchain_runtime::Runtime
+   **/
+  TfchainRuntimeRuntime: "Null",
+};

--- a/packages/tfchain_client/src/interfaces/chain/registry.ts
+++ b/packages/tfchain_client/src/interfaces/chain/registry.ts
@@ -1,0 +1,364 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/types/types/registry";
+
+import type {
+  FinalityGrandpaEquivocationPrecommit,
+  FinalityGrandpaEquivocationPrevote,
+  FinalityGrandpaPrecommit,
+  FinalityGrandpaPrevote,
+  FrameSupportDispatchDispatchClass,
+  FrameSupportDispatchDispatchInfo,
+  FrameSupportDispatchPays,
+  FrameSupportDispatchPerDispatchClassU32,
+  FrameSupportDispatchPerDispatchClassWeight,
+  FrameSupportDispatchPerDispatchClassWeightsPerClass,
+  FrameSupportDispatchRawOrigin,
+  FrameSupportPreimagesBounded,
+  FrameSupportTokensMiscBalanceStatus,
+  FrameSystemAccountInfo,
+  FrameSystemCall,
+  FrameSystemError,
+  FrameSystemEvent,
+  FrameSystemEventRecord,
+  FrameSystemExtensionsCheckGenesis,
+  FrameSystemExtensionsCheckNonZeroSender,
+  FrameSystemExtensionsCheckNonce,
+  FrameSystemExtensionsCheckSpecVersion,
+  FrameSystemExtensionsCheckTxVersion,
+  FrameSystemExtensionsCheckWeight,
+  FrameSystemLastRuntimeUpgradeInfo,
+  FrameSystemLimitsBlockLength,
+  FrameSystemLimitsBlockWeights,
+  FrameSystemLimitsWeightsPerClass,
+  FrameSystemPhase,
+  PalletBalancesAccountData,
+  PalletBalancesBalanceLock,
+  PalletBalancesCall,
+  PalletBalancesError,
+  PalletBalancesEvent,
+  PalletBalancesIdAmount,
+  PalletBalancesReasons,
+  PalletBalancesReserveData,
+  PalletBurningBurn,
+  PalletBurningCall,
+  PalletBurningError,
+  PalletBurningEvent,
+  PalletCollectiveCall,
+  PalletCollectiveError,
+  PalletCollectiveEvent,
+  PalletCollectiveRawOrigin,
+  PalletCollectiveVotes,
+  PalletDaoCall,
+  PalletDaoError,
+  PalletDaoEvent,
+  PalletDaoProposalDaoProposal,
+  PalletDaoProposalDaoVotes,
+  PalletDaoProposalVoteWeight,
+  PalletGrandpaCall,
+  PalletGrandpaError,
+  PalletGrandpaEvent,
+  PalletGrandpaStoredPendingChange,
+  PalletGrandpaStoredState,
+  PalletKvstoreCall,
+  PalletKvstoreError,
+  PalletKvstoreEvent,
+  PalletMembershipCall,
+  PalletMembershipError,
+  PalletMembershipEvent,
+  PalletRuntimeUpgradeCall,
+  PalletSchedulerCall,
+  PalletSchedulerError,
+  PalletSchedulerEvent,
+  PalletSchedulerScheduled,
+  PalletSessionCall,
+  PalletSessionError,
+  PalletSessionEvent,
+  PalletSmartContractCall,
+  PalletSmartContractCause,
+  PalletSmartContractConsumption,
+  PalletSmartContractContract,
+  PalletSmartContractContractBill,
+  PalletSmartContractContractBillingInformation,
+  PalletSmartContractContractData,
+  PalletSmartContractContractLock,
+  PalletSmartContractContractResources,
+  PalletSmartContractContractState,
+  PalletSmartContractDiscountLevel,
+  PalletSmartContractError,
+  PalletSmartContractEvent,
+  PalletSmartContractNameContract,
+  PalletSmartContractNodeContract,
+  PalletSmartContractNruConsumption,
+  PalletSmartContractProvider,
+  PalletSmartContractRentContract,
+  PalletSmartContractServiceContract,
+  PalletSmartContractServiceContractBill,
+  PalletSmartContractServiceContractState,
+  PalletSmartContractSolutionProvider,
+  PalletSmartContractStorageVersion,
+  PalletTfgridCall,
+  PalletTfgridEntity,
+  PalletTfgridEntityProof,
+  PalletTfgridError,
+  PalletTfgridEvent,
+  PalletTfgridFarmingPolicy,
+  PalletTfgridLocationInput,
+  PalletTfgridNodeLocation,
+  PalletTfgridPolicy,
+  PalletTfgridPricingPolicy,
+  PalletTfgridStorageVersion,
+  PalletTfgridTermsCondTermsAndConditions,
+  PalletTfgridTwin,
+  PalletTfgridUnit,
+  PalletTftBridgeBurnTransaction,
+  PalletTftBridgeCall,
+  PalletTftBridgeError,
+  PalletTftBridgeEvent,
+  PalletTftBridgeMintTransaction,
+  PalletTftBridgeRefundTransaction,
+  PalletTftBridgeStellarSignature,
+  PalletTftBridgeStorageVersion,
+  PalletTftPriceCall,
+  PalletTftPriceError,
+  PalletTftPriceEvent,
+  PalletTimestampCall,
+  PalletTransactionPaymentChargeTransactionPayment,
+  PalletTransactionPaymentEvent,
+  PalletTransactionPaymentReleases,
+  PalletUtilityCall,
+  PalletUtilityError,
+  PalletUtilityEvent,
+  PalletValidatorCall,
+  PalletValidatorError,
+  PalletValidatorEvent,
+  PalletValidatorValidator,
+  PalletValidatorValidatorRequestState,
+  SpArithmeticArithmeticError,
+  SpConsensusAuraSr25519AppSr25519Public,
+  SpConsensusGrandpaAppPublic,
+  SpConsensusGrandpaAppSignature,
+  SpConsensusGrandpaEquivocation,
+  SpConsensusGrandpaEquivocationProof,
+  SpCoreCryptoKeyTypeId,
+  SpCoreEcdsaSignature,
+  SpCoreEd25519Public,
+  SpCoreEd25519Signature,
+  SpCoreSr25519Public,
+  SpCoreSr25519Signature,
+  SpCoreVoid,
+  SpRuntimeDigest,
+  SpRuntimeDigestDigestItem,
+  SpRuntimeDispatchError,
+  SpRuntimeModuleError,
+  SpRuntimeMultiSignature,
+  SpRuntimeTokenError,
+  SpRuntimeTransactionalError,
+  SpVersionRuntimeVersion,
+  SpWeightsRuntimeDbWeight,
+  SpWeightsWeightV2Weight,
+  SubstrateValidatorSetCall,
+  SubstrateValidatorSetError,
+  SubstrateValidatorSetEvent,
+  TfchainRuntimeOpaqueSessionKeys,
+  TfchainRuntimeOriginCaller,
+  TfchainRuntimeRuntime,
+  TfchainSupportFarm,
+  TfchainSupportFarmCertification,
+  TfchainSupportFarmingPolicyLimit,
+  TfchainSupportInterfaceBoundedVec,
+  TfchainSupportInterfaceInterfaceName,
+  TfchainSupportIp4,
+  TfchainSupportIp6,
+  TfchainSupportNode,
+  TfchainSupportNodeCertification,
+  TfchainSupportNodePower,
+  TfchainSupportPower,
+  TfchainSupportPowerState,
+  TfchainSupportPublicConfig,
+  TfchainSupportPublicIP,
+  TfchainSupportResources,
+} from "@polkadot/types/lookup";
+
+declare module "@polkadot/types/types/registry" {
+  interface InterfaceTypes {
+    FinalityGrandpaEquivocationPrecommit: FinalityGrandpaEquivocationPrecommit;
+    FinalityGrandpaEquivocationPrevote: FinalityGrandpaEquivocationPrevote;
+    FinalityGrandpaPrecommit: FinalityGrandpaPrecommit;
+    FinalityGrandpaPrevote: FinalityGrandpaPrevote;
+    FrameSupportDispatchDispatchClass: FrameSupportDispatchDispatchClass;
+    FrameSupportDispatchDispatchInfo: FrameSupportDispatchDispatchInfo;
+    FrameSupportDispatchPays: FrameSupportDispatchPays;
+    FrameSupportDispatchPerDispatchClassU32: FrameSupportDispatchPerDispatchClassU32;
+    FrameSupportDispatchPerDispatchClassWeight: FrameSupportDispatchPerDispatchClassWeight;
+    FrameSupportDispatchPerDispatchClassWeightsPerClass: FrameSupportDispatchPerDispatchClassWeightsPerClass;
+    FrameSupportDispatchRawOrigin: FrameSupportDispatchRawOrigin;
+    FrameSupportPreimagesBounded: FrameSupportPreimagesBounded;
+    FrameSupportTokensMiscBalanceStatus: FrameSupportTokensMiscBalanceStatus;
+    FrameSystemAccountInfo: FrameSystemAccountInfo;
+    FrameSystemCall: FrameSystemCall;
+    FrameSystemError: FrameSystemError;
+    FrameSystemEvent: FrameSystemEvent;
+    FrameSystemEventRecord: FrameSystemEventRecord;
+    FrameSystemExtensionsCheckGenesis: FrameSystemExtensionsCheckGenesis;
+    FrameSystemExtensionsCheckNonZeroSender: FrameSystemExtensionsCheckNonZeroSender;
+    FrameSystemExtensionsCheckNonce: FrameSystemExtensionsCheckNonce;
+    FrameSystemExtensionsCheckSpecVersion: FrameSystemExtensionsCheckSpecVersion;
+    FrameSystemExtensionsCheckTxVersion: FrameSystemExtensionsCheckTxVersion;
+    FrameSystemExtensionsCheckWeight: FrameSystemExtensionsCheckWeight;
+    FrameSystemLastRuntimeUpgradeInfo: FrameSystemLastRuntimeUpgradeInfo;
+    FrameSystemLimitsBlockLength: FrameSystemLimitsBlockLength;
+    FrameSystemLimitsBlockWeights: FrameSystemLimitsBlockWeights;
+    FrameSystemLimitsWeightsPerClass: FrameSystemLimitsWeightsPerClass;
+    FrameSystemPhase: FrameSystemPhase;
+    PalletBalancesAccountData: PalletBalancesAccountData;
+    PalletBalancesBalanceLock: PalletBalancesBalanceLock;
+    PalletBalancesCall: PalletBalancesCall;
+    PalletBalancesError: PalletBalancesError;
+    PalletBalancesEvent: PalletBalancesEvent;
+    PalletBalancesIdAmount: PalletBalancesIdAmount;
+    PalletBalancesReasons: PalletBalancesReasons;
+    PalletBalancesReserveData: PalletBalancesReserveData;
+    PalletBurningBurn: PalletBurningBurn;
+    PalletBurningCall: PalletBurningCall;
+    PalletBurningError: PalletBurningError;
+    PalletBurningEvent: PalletBurningEvent;
+    PalletCollectiveCall: PalletCollectiveCall;
+    PalletCollectiveError: PalletCollectiveError;
+    PalletCollectiveEvent: PalletCollectiveEvent;
+    PalletCollectiveRawOrigin: PalletCollectiveRawOrigin;
+    PalletCollectiveVotes: PalletCollectiveVotes;
+    PalletDaoCall: PalletDaoCall;
+    PalletDaoError: PalletDaoError;
+    PalletDaoEvent: PalletDaoEvent;
+    PalletDaoProposalDaoProposal: PalletDaoProposalDaoProposal;
+    PalletDaoProposalDaoVotes: PalletDaoProposalDaoVotes;
+    PalletDaoProposalVoteWeight: PalletDaoProposalVoteWeight;
+    PalletGrandpaCall: PalletGrandpaCall;
+    PalletGrandpaError: PalletGrandpaError;
+    PalletGrandpaEvent: PalletGrandpaEvent;
+    PalletGrandpaStoredPendingChange: PalletGrandpaStoredPendingChange;
+    PalletGrandpaStoredState: PalletGrandpaStoredState;
+    PalletKvstoreCall: PalletKvstoreCall;
+    PalletKvstoreError: PalletKvstoreError;
+    PalletKvstoreEvent: PalletKvstoreEvent;
+    PalletMembershipCall: PalletMembershipCall;
+    PalletMembershipError: PalletMembershipError;
+    PalletMembershipEvent: PalletMembershipEvent;
+    PalletRuntimeUpgradeCall: PalletRuntimeUpgradeCall;
+    PalletSchedulerCall: PalletSchedulerCall;
+    PalletSchedulerError: PalletSchedulerError;
+    PalletSchedulerEvent: PalletSchedulerEvent;
+    PalletSchedulerScheduled: PalletSchedulerScheduled;
+    PalletSessionCall: PalletSessionCall;
+    PalletSessionError: PalletSessionError;
+    PalletSessionEvent: PalletSessionEvent;
+    PalletSmartContractCall: PalletSmartContractCall;
+    PalletSmartContractCause: PalletSmartContractCause;
+    PalletSmartContractConsumption: PalletSmartContractConsumption;
+    PalletSmartContractContract: PalletSmartContractContract;
+    PalletSmartContractContractBill: PalletSmartContractContractBill;
+    PalletSmartContractContractBillingInformation: PalletSmartContractContractBillingInformation;
+    PalletSmartContractContractData: PalletSmartContractContractData;
+    PalletSmartContractContractLock: PalletSmartContractContractLock;
+    PalletSmartContractContractResources: PalletSmartContractContractResources;
+    PalletSmartContractContractState: PalletSmartContractContractState;
+    PalletSmartContractDiscountLevel: PalletSmartContractDiscountLevel;
+    PalletSmartContractError: PalletSmartContractError;
+    PalletSmartContractEvent: PalletSmartContractEvent;
+    PalletSmartContractNameContract: PalletSmartContractNameContract;
+    PalletSmartContractNodeContract: PalletSmartContractNodeContract;
+    PalletSmartContractNruConsumption: PalletSmartContractNruConsumption;
+    PalletSmartContractProvider: PalletSmartContractProvider;
+    PalletSmartContractRentContract: PalletSmartContractRentContract;
+    PalletSmartContractServiceContract: PalletSmartContractServiceContract;
+    PalletSmartContractServiceContractBill: PalletSmartContractServiceContractBill;
+    PalletSmartContractServiceContractState: PalletSmartContractServiceContractState;
+    PalletSmartContractSolutionProvider: PalletSmartContractSolutionProvider;
+    PalletSmartContractStorageVersion: PalletSmartContractStorageVersion;
+    PalletTfgridCall: PalletTfgridCall;
+    PalletTfgridEntity: PalletTfgridEntity;
+    PalletTfgridEntityProof: PalletTfgridEntityProof;
+    PalletTfgridError: PalletTfgridError;
+    PalletTfgridEvent: PalletTfgridEvent;
+    PalletTfgridFarmingPolicy: PalletTfgridFarmingPolicy;
+    PalletTfgridLocationInput: PalletTfgridLocationInput;
+    PalletTfgridNodeLocation: PalletTfgridNodeLocation;
+    PalletTfgridPolicy: PalletTfgridPolicy;
+    PalletTfgridPricingPolicy: PalletTfgridPricingPolicy;
+    PalletTfgridStorageVersion: PalletTfgridStorageVersion;
+    PalletTfgridTermsCondTermsAndConditions: PalletTfgridTermsCondTermsAndConditions;
+    PalletTfgridTwin: PalletTfgridTwin;
+    PalletTfgridUnit: PalletTfgridUnit;
+    PalletTftBridgeBurnTransaction: PalletTftBridgeBurnTransaction;
+    PalletTftBridgeCall: PalletTftBridgeCall;
+    PalletTftBridgeError: PalletTftBridgeError;
+    PalletTftBridgeEvent: PalletTftBridgeEvent;
+    PalletTftBridgeMintTransaction: PalletTftBridgeMintTransaction;
+    PalletTftBridgeRefundTransaction: PalletTftBridgeRefundTransaction;
+    PalletTftBridgeStellarSignature: PalletTftBridgeStellarSignature;
+    PalletTftBridgeStorageVersion: PalletTftBridgeStorageVersion;
+    PalletTftPriceCall: PalletTftPriceCall;
+    PalletTftPriceError: PalletTftPriceError;
+    PalletTftPriceEvent: PalletTftPriceEvent;
+    PalletTimestampCall: PalletTimestampCall;
+    PalletTransactionPaymentChargeTransactionPayment: PalletTransactionPaymentChargeTransactionPayment;
+    PalletTransactionPaymentEvent: PalletTransactionPaymentEvent;
+    PalletTransactionPaymentReleases: PalletTransactionPaymentReleases;
+    PalletUtilityCall: PalletUtilityCall;
+    PalletUtilityError: PalletUtilityError;
+    PalletUtilityEvent: PalletUtilityEvent;
+    PalletValidatorCall: PalletValidatorCall;
+    PalletValidatorError: PalletValidatorError;
+    PalletValidatorEvent: PalletValidatorEvent;
+    PalletValidatorValidator: PalletValidatorValidator;
+    PalletValidatorValidatorRequestState: PalletValidatorValidatorRequestState;
+    SpArithmeticArithmeticError: SpArithmeticArithmeticError;
+    SpConsensusAuraSr25519AppSr25519Public: SpConsensusAuraSr25519AppSr25519Public;
+    SpConsensusGrandpaAppPublic: SpConsensusGrandpaAppPublic;
+    SpConsensusGrandpaAppSignature: SpConsensusGrandpaAppSignature;
+    SpConsensusGrandpaEquivocation: SpConsensusGrandpaEquivocation;
+    SpConsensusGrandpaEquivocationProof: SpConsensusGrandpaEquivocationProof;
+    SpCoreCryptoKeyTypeId: SpCoreCryptoKeyTypeId;
+    SpCoreEcdsaSignature: SpCoreEcdsaSignature;
+    SpCoreEd25519Public: SpCoreEd25519Public;
+    SpCoreEd25519Signature: SpCoreEd25519Signature;
+    SpCoreSr25519Public: SpCoreSr25519Public;
+    SpCoreSr25519Signature: SpCoreSr25519Signature;
+    SpCoreVoid: SpCoreVoid;
+    SpRuntimeDigest: SpRuntimeDigest;
+    SpRuntimeDigestDigestItem: SpRuntimeDigestDigestItem;
+    SpRuntimeDispatchError: SpRuntimeDispatchError;
+    SpRuntimeModuleError: SpRuntimeModuleError;
+    SpRuntimeMultiSignature: SpRuntimeMultiSignature;
+    SpRuntimeTokenError: SpRuntimeTokenError;
+    SpRuntimeTransactionalError: SpRuntimeTransactionalError;
+    SpVersionRuntimeVersion: SpVersionRuntimeVersion;
+    SpWeightsRuntimeDbWeight: SpWeightsRuntimeDbWeight;
+    SpWeightsWeightV2Weight: SpWeightsWeightV2Weight;
+    SubstrateValidatorSetCall: SubstrateValidatorSetCall;
+    SubstrateValidatorSetError: SubstrateValidatorSetError;
+    SubstrateValidatorSetEvent: SubstrateValidatorSetEvent;
+    TfchainRuntimeOpaqueSessionKeys: TfchainRuntimeOpaqueSessionKeys;
+    TfchainRuntimeOriginCaller: TfchainRuntimeOriginCaller;
+    TfchainRuntimeRuntime: TfchainRuntimeRuntime;
+    TfchainSupportFarm: TfchainSupportFarm;
+    TfchainSupportFarmCertification: TfchainSupportFarmCertification;
+    TfchainSupportFarmingPolicyLimit: TfchainSupportFarmingPolicyLimit;
+    TfchainSupportInterfaceBoundedVec: TfchainSupportInterfaceBoundedVec;
+    TfchainSupportInterfaceInterfaceName: TfchainSupportInterfaceInterfaceName;
+    TfchainSupportIp4: TfchainSupportIp4;
+    TfchainSupportIp6: TfchainSupportIp6;
+    TfchainSupportNode: TfchainSupportNode;
+    TfchainSupportNodeCertification: TfchainSupportNodeCertification;
+    TfchainSupportNodePower: TfchainSupportNodePower;
+    TfchainSupportPower: TfchainSupportPower;
+    TfchainSupportPowerState: TfchainSupportPowerState;
+    TfchainSupportPublicConfig: TfchainSupportPublicConfig;
+    TfchainSupportPublicIP: TfchainSupportPublicIP;
+    TfchainSupportResources: TfchainSupportResources;
+  } // InterfaceTypes
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/types-lookup.ts
+++ b/packages/tfchain_client/src/interfaces/chain/types-lookup.ts
@@ -1,0 +1,3273 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+// import type lookup before we augment - in some environments
+// this is required to allow for ambient/previous definitions
+import "@polkadot/types/lookup";
+
+import type {
+  Bytes,
+  Compact,
+  Enum,
+  Null,
+  Option,
+  Result,
+  Struct,
+  Text,
+  U8aFixed,
+  Vec,
+  bool,
+  u128,
+  u16,
+  u32,
+  u64,
+  u8,
+} from "@polkadot/types-codec";
+import type { ITuple } from "@polkadot/types-codec/types";
+import type { AccountId32, Call, H256, MultiAddress } from "@polkadot/types/interfaces/runtime";
+import type { Event } from "@polkadot/types/interfaces/system";
+
+declare module "@polkadot/types/lookup" {
+  /** @name FrameSystemAccountInfo (3) */
+  interface FrameSystemAccountInfo extends Struct {
+    readonly nonce: u32;
+    readonly consumers: u32;
+    readonly providers: u32;
+    readonly sufficients: u32;
+    readonly data: PalletBalancesAccountData;
+  }
+
+  /** @name PalletBalancesAccountData (5) */
+  interface PalletBalancesAccountData extends Struct {
+    readonly free: u128;
+    readonly reserved: u128;
+    readonly frozen: u128;
+    readonly flags: u128;
+  }
+
+  /** @name FrameSupportDispatchPerDispatchClassWeight (8) */
+  interface FrameSupportDispatchPerDispatchClassWeight extends Struct {
+    readonly normal: SpWeightsWeightV2Weight;
+    readonly operational: SpWeightsWeightV2Weight;
+    readonly mandatory: SpWeightsWeightV2Weight;
+  }
+
+  /** @name SpWeightsWeightV2Weight (9) */
+  interface SpWeightsWeightV2Weight extends Struct {
+    readonly refTime: Compact<u64>;
+    readonly proofSize: Compact<u64>;
+  }
+
+  /** @name SpRuntimeDigest (14) */
+  interface SpRuntimeDigest extends Struct {
+    readonly logs: Vec<SpRuntimeDigestDigestItem>;
+  }
+
+  /** @name SpRuntimeDigestDigestItem (16) */
+  interface SpRuntimeDigestDigestItem extends Enum {
+    readonly isOther: boolean;
+    readonly asOther: Bytes;
+    readonly isConsensus: boolean;
+    readonly asConsensus: ITuple<[U8aFixed, Bytes]>;
+    readonly isSeal: boolean;
+    readonly asSeal: ITuple<[U8aFixed, Bytes]>;
+    readonly isPreRuntime: boolean;
+    readonly asPreRuntime: ITuple<[U8aFixed, Bytes]>;
+    readonly isRuntimeEnvironmentUpdated: boolean;
+    readonly type: "Other" | "Consensus" | "Seal" | "PreRuntime" | "RuntimeEnvironmentUpdated";
+  }
+
+  /** @name FrameSystemEventRecord (19) */
+  interface FrameSystemEventRecord extends Struct {
+    readonly phase: FrameSystemPhase;
+    readonly event: Event;
+    readonly topics: Vec<H256>;
+  }
+
+  /** @name FrameSystemEvent (21) */
+  interface FrameSystemEvent extends Enum {
+    readonly isExtrinsicSuccess: boolean;
+    readonly asExtrinsicSuccess: {
+      readonly dispatchInfo: FrameSupportDispatchDispatchInfo;
+    } & Struct;
+    readonly isExtrinsicFailed: boolean;
+    readonly asExtrinsicFailed: {
+      readonly dispatchError: SpRuntimeDispatchError;
+      readonly dispatchInfo: FrameSupportDispatchDispatchInfo;
+    } & Struct;
+    readonly isCodeUpdated: boolean;
+    readonly isNewAccount: boolean;
+    readonly asNewAccount: {
+      readonly account: AccountId32;
+    } & Struct;
+    readonly isKilledAccount: boolean;
+    readonly asKilledAccount: {
+      readonly account: AccountId32;
+    } & Struct;
+    readonly isRemarked: boolean;
+    readonly asRemarked: {
+      readonly sender: AccountId32;
+      readonly hash_: H256;
+    } & Struct;
+    readonly type: "ExtrinsicSuccess" | "ExtrinsicFailed" | "CodeUpdated" | "NewAccount" | "KilledAccount" | "Remarked";
+  }
+
+  /** @name FrameSupportDispatchDispatchInfo (22) */
+  interface FrameSupportDispatchDispatchInfo extends Struct {
+    readonly weight: SpWeightsWeightV2Weight;
+    readonly class: FrameSupportDispatchDispatchClass;
+    readonly paysFee: FrameSupportDispatchPays;
+  }
+
+  /** @name FrameSupportDispatchDispatchClass (23) */
+  interface FrameSupportDispatchDispatchClass extends Enum {
+    readonly isNormal: boolean;
+    readonly isOperational: boolean;
+    readonly isMandatory: boolean;
+    readonly type: "Normal" | "Operational" | "Mandatory";
+  }
+
+  /** @name FrameSupportDispatchPays (24) */
+  interface FrameSupportDispatchPays extends Enum {
+    readonly isYes: boolean;
+    readonly isNo: boolean;
+    readonly type: "Yes" | "No";
+  }
+
+  /** @name SpRuntimeDispatchError (25) */
+  interface SpRuntimeDispatchError extends Enum {
+    readonly isOther: boolean;
+    readonly isCannotLookup: boolean;
+    readonly isBadOrigin: boolean;
+    readonly isModule: boolean;
+    readonly asModule: SpRuntimeModuleError;
+    readonly isConsumerRemaining: boolean;
+    readonly isNoProviders: boolean;
+    readonly isTooManyConsumers: boolean;
+    readonly isToken: boolean;
+    readonly asToken: SpRuntimeTokenError;
+    readonly isArithmetic: boolean;
+    readonly asArithmetic: SpArithmeticArithmeticError;
+    readonly isTransactional: boolean;
+    readonly asTransactional: SpRuntimeTransactionalError;
+    readonly isExhausted: boolean;
+    readonly isCorruption: boolean;
+    readonly isUnavailable: boolean;
+    readonly isRootNotAllowed: boolean;
+    readonly type:
+      | "Other"
+      | "CannotLookup"
+      | "BadOrigin"
+      | "Module"
+      | "ConsumerRemaining"
+      | "NoProviders"
+      | "TooManyConsumers"
+      | "Token"
+      | "Arithmetic"
+      | "Transactional"
+      | "Exhausted"
+      | "Corruption"
+      | "Unavailable"
+      | "RootNotAllowed";
+  }
+
+  /** @name SpRuntimeModuleError (26) */
+  interface SpRuntimeModuleError extends Struct {
+    readonly index: u8;
+    readonly error: U8aFixed;
+  }
+
+  /** @name SpRuntimeTokenError (27) */
+  interface SpRuntimeTokenError extends Enum {
+    readonly isFundsUnavailable: boolean;
+    readonly isOnlyProvider: boolean;
+    readonly isBelowMinimum: boolean;
+    readonly isCannotCreate: boolean;
+    readonly isUnknownAsset: boolean;
+    readonly isFrozen: boolean;
+    readonly isUnsupported: boolean;
+    readonly isCannotCreateHold: boolean;
+    readonly isNotExpendable: boolean;
+    readonly isBlocked: boolean;
+    readonly type:
+      | "FundsUnavailable"
+      | "OnlyProvider"
+      | "BelowMinimum"
+      | "CannotCreate"
+      | "UnknownAsset"
+      | "Frozen"
+      | "Unsupported"
+      | "CannotCreateHold"
+      | "NotExpendable"
+      | "Blocked";
+  }
+
+  /** @name SpArithmeticArithmeticError (28) */
+  interface SpArithmeticArithmeticError extends Enum {
+    readonly isUnderflow: boolean;
+    readonly isOverflow: boolean;
+    readonly isDivisionByZero: boolean;
+    readonly type: "Underflow" | "Overflow" | "DivisionByZero";
+  }
+
+  /** @name SpRuntimeTransactionalError (29) */
+  interface SpRuntimeTransactionalError extends Enum {
+    readonly isLimitReached: boolean;
+    readonly isNoLayer: boolean;
+    readonly type: "LimitReached" | "NoLayer";
+  }
+
+  /** @name PalletUtilityEvent (30) */
+  interface PalletUtilityEvent extends Enum {
+    readonly isBatchInterrupted: boolean;
+    readonly asBatchInterrupted: {
+      readonly index: u32;
+      readonly error: SpRuntimeDispatchError;
+    } & Struct;
+    readonly isBatchCompleted: boolean;
+    readonly isBatchCompletedWithErrors: boolean;
+    readonly isItemCompleted: boolean;
+    readonly isItemFailed: boolean;
+    readonly asItemFailed: {
+      readonly error: SpRuntimeDispatchError;
+    } & Struct;
+    readonly isDispatchedAs: boolean;
+    readonly asDispatchedAs: {
+      readonly result: Result<Null, SpRuntimeDispatchError>;
+    } & Struct;
+    readonly type:
+      | "BatchInterrupted"
+      | "BatchCompleted"
+      | "BatchCompletedWithErrors"
+      | "ItemCompleted"
+      | "ItemFailed"
+      | "DispatchedAs";
+  }
+
+  /** @name PalletSchedulerEvent (33) */
+  interface PalletSchedulerEvent extends Enum {
+    readonly isScheduled: boolean;
+    readonly asScheduled: {
+      readonly when: u32;
+      readonly index: u32;
+    } & Struct;
+    readonly isCanceled: boolean;
+    readonly asCanceled: {
+      readonly when: u32;
+      readonly index: u32;
+    } & Struct;
+    readonly isDispatched: boolean;
+    readonly asDispatched: {
+      readonly task: ITuple<[u32, u32]>;
+      readonly id: Option<U8aFixed>;
+      readonly result: Result<Null, SpRuntimeDispatchError>;
+    } & Struct;
+    readonly isCallUnavailable: boolean;
+    readonly asCallUnavailable: {
+      readonly task: ITuple<[u32, u32]>;
+      readonly id: Option<U8aFixed>;
+    } & Struct;
+    readonly isPeriodicFailed: boolean;
+    readonly asPeriodicFailed: {
+      readonly task: ITuple<[u32, u32]>;
+      readonly id: Option<U8aFixed>;
+    } & Struct;
+    readonly isPermanentlyOverweight: boolean;
+    readonly asPermanentlyOverweight: {
+      readonly task: ITuple<[u32, u32]>;
+      readonly id: Option<U8aFixed>;
+    } & Struct;
+    readonly type:
+      | "Scheduled"
+      | "Canceled"
+      | "Dispatched"
+      | "CallUnavailable"
+      | "PeriodicFailed"
+      | "PermanentlyOverweight";
+  }
+
+  /** @name SubstrateValidatorSetEvent (36) */
+  interface SubstrateValidatorSetEvent extends Enum {
+    readonly isValidatorAdditionInitiated: boolean;
+    readonly asValidatorAdditionInitiated: AccountId32;
+    readonly isValidatorRemovalInitiated: boolean;
+    readonly asValidatorRemovalInitiated: AccountId32;
+    readonly type: "ValidatorAdditionInitiated" | "ValidatorRemovalInitiated";
+  }
+
+  /** @name PalletSessionEvent (37) */
+  interface PalletSessionEvent extends Enum {
+    readonly isNewSession: boolean;
+    readonly asNewSession: {
+      readonly sessionIndex: u32;
+    } & Struct;
+    readonly type: "NewSession";
+  }
+
+  /** @name PalletGrandpaEvent (38) */
+  interface PalletGrandpaEvent extends Enum {
+    readonly isNewAuthorities: boolean;
+    readonly asNewAuthorities: {
+      readonly authoritySet: Vec<ITuple<[SpConsensusGrandpaAppPublic, u64]>>;
+    } & Struct;
+    readonly isPaused: boolean;
+    readonly isResumed: boolean;
+    readonly type: "NewAuthorities" | "Paused" | "Resumed";
+  }
+
+  /** @name SpConsensusGrandpaAppPublic (41) */
+  interface SpConsensusGrandpaAppPublic extends SpCoreEd25519Public {}
+
+  /** @name SpCoreEd25519Public (42) */
+  interface SpCoreEd25519Public extends U8aFixed {}
+
+  /** @name PalletBalancesEvent (43) */
+  interface PalletBalancesEvent extends Enum {
+    readonly isEndowed: boolean;
+    readonly asEndowed: {
+      readonly account: AccountId32;
+      readonly freeBalance: u128;
+    } & Struct;
+    readonly isDustLost: boolean;
+    readonly asDustLost: {
+      readonly account: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isTransfer: boolean;
+    readonly asTransfer: {
+      readonly from: AccountId32;
+      readonly to: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isBalanceSet: boolean;
+    readonly asBalanceSet: {
+      readonly who: AccountId32;
+      readonly free: u128;
+    } & Struct;
+    readonly isReserved: boolean;
+    readonly asReserved: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isUnreserved: boolean;
+    readonly asUnreserved: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isReserveRepatriated: boolean;
+    readonly asReserveRepatriated: {
+      readonly from: AccountId32;
+      readonly to: AccountId32;
+      readonly amount: u128;
+      readonly destinationStatus: FrameSupportTokensMiscBalanceStatus;
+    } & Struct;
+    readonly isDeposit: boolean;
+    readonly asDeposit: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isWithdraw: boolean;
+    readonly asWithdraw: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isSlashed: boolean;
+    readonly asSlashed: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isMinted: boolean;
+    readonly asMinted: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isBurned: boolean;
+    readonly asBurned: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isSuspended: boolean;
+    readonly asSuspended: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isRestored: boolean;
+    readonly asRestored: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isUpgraded: boolean;
+    readonly asUpgraded: {
+      readonly who: AccountId32;
+    } & Struct;
+    readonly isIssued: boolean;
+    readonly asIssued: {
+      readonly amount: u128;
+    } & Struct;
+    readonly isRescinded: boolean;
+    readonly asRescinded: {
+      readonly amount: u128;
+    } & Struct;
+    readonly isLocked: boolean;
+    readonly asLocked: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isUnlocked: boolean;
+    readonly asUnlocked: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isFrozen: boolean;
+    readonly asFrozen: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly isThawed: boolean;
+    readonly asThawed: {
+      readonly who: AccountId32;
+      readonly amount: u128;
+    } & Struct;
+    readonly type:
+      | "Endowed"
+      | "DustLost"
+      | "Transfer"
+      | "BalanceSet"
+      | "Reserved"
+      | "Unreserved"
+      | "ReserveRepatriated"
+      | "Deposit"
+      | "Withdraw"
+      | "Slashed"
+      | "Minted"
+      | "Burned"
+      | "Suspended"
+      | "Restored"
+      | "Upgraded"
+      | "Issued"
+      | "Rescinded"
+      | "Locked"
+      | "Unlocked"
+      | "Frozen"
+      | "Thawed";
+  }
+
+  /** @name FrameSupportTokensMiscBalanceStatus (44) */
+  interface FrameSupportTokensMiscBalanceStatus extends Enum {
+    readonly isFree: boolean;
+    readonly isReserved: boolean;
+    readonly type: "Free" | "Reserved";
+  }
+
+  /** @name PalletTransactionPaymentEvent (45) */
+  interface PalletTransactionPaymentEvent extends Enum {
+    readonly isTransactionFeePaid: boolean;
+    readonly asTransactionFeePaid: {
+      readonly who: AccountId32;
+      readonly actualFee: u128;
+      readonly tip: u128;
+    } & Struct;
+    readonly type: "TransactionFeePaid";
+  }
+
+  /** @name PalletTfgridEvent (46) */
+  interface PalletTfgridEvent extends Enum {
+    readonly isFarmStored: boolean;
+    readonly asFarmStored: TfchainSupportFarm;
+    readonly isFarmUpdated: boolean;
+    readonly asFarmUpdated: TfchainSupportFarm;
+    readonly isFarmDeleted: boolean;
+    readonly asFarmDeleted: u32;
+    readonly isNodeStored: boolean;
+    readonly asNodeStored: TfchainSupportNode;
+    readonly isNodeUpdated: boolean;
+    readonly asNodeUpdated: TfchainSupportNode;
+    readonly isNodeDeleted: boolean;
+    readonly asNodeDeleted: u32;
+    readonly isNodeUptimeReported: boolean;
+    readonly asNodeUptimeReported: ITuple<[u32, u64, u64]>;
+    readonly isNodePublicConfigStored: boolean;
+    readonly asNodePublicConfigStored: ITuple<[u32, Option<TfchainSupportPublicConfig>]>;
+    readonly isEntityStored: boolean;
+    readonly asEntityStored: PalletTfgridEntity;
+    readonly isEntityUpdated: boolean;
+    readonly asEntityUpdated: PalletTfgridEntity;
+    readonly isEntityDeleted: boolean;
+    readonly asEntityDeleted: u32;
+    readonly isTwinStored: boolean;
+    readonly asTwinStored: PalletTfgridTwin;
+    readonly isTwinUpdated: boolean;
+    readonly asTwinUpdated: PalletTfgridTwin;
+    readonly isTwinEntityStored: boolean;
+    readonly asTwinEntityStored: ITuple<[u32, u32, Bytes]>;
+    readonly isTwinEntityRemoved: boolean;
+    readonly asTwinEntityRemoved: ITuple<[u32, u32]>;
+    readonly isTwinDeleted: boolean;
+    readonly asTwinDeleted: u32;
+    readonly isTwinAccountBounded: boolean;
+    readonly asTwinAccountBounded: ITuple<[u32, AccountId32]>;
+    readonly isPricingPolicyStored: boolean;
+    readonly asPricingPolicyStored: PalletTfgridPricingPolicy;
+    readonly isFarmingPolicyStored: boolean;
+    readonly asFarmingPolicyStored: PalletTfgridFarmingPolicy;
+    readonly isFarmPayoutV2AddressRegistered: boolean;
+    readonly asFarmPayoutV2AddressRegistered: ITuple<[u32, Bytes]>;
+    readonly isFarmMarkedAsDedicated: boolean;
+    readonly asFarmMarkedAsDedicated: u32;
+    readonly isConnectionPriceSet: boolean;
+    readonly asConnectionPriceSet: u32;
+    readonly isNodeCertificationSet: boolean;
+    readonly asNodeCertificationSet: ITuple<[u32, TfchainSupportNodeCertification]>;
+    readonly isNodeCertifierAdded: boolean;
+    readonly asNodeCertifierAdded: AccountId32;
+    readonly isNodeCertifierRemoved: boolean;
+    readonly asNodeCertifierRemoved: AccountId32;
+    readonly isFarmingPolicyUpdated: boolean;
+    readonly asFarmingPolicyUpdated: PalletTfgridFarmingPolicy;
+    readonly isFarmingPolicySet: boolean;
+    readonly asFarmingPolicySet: ITuple<[u32, Option<TfchainSupportFarmingPolicyLimit>]>;
+    readonly isFarmCertificationSet: boolean;
+    readonly asFarmCertificationSet: ITuple<[u32, TfchainSupportFarmCertification]>;
+    readonly isZosVersionUpdated: boolean;
+    readonly asZosVersionUpdated: Bytes;
+    readonly isPowerTargetChanged: boolean;
+    readonly asPowerTargetChanged: {
+      readonly farmId: u32;
+      readonly nodeId: u32;
+      readonly powerTarget: TfchainSupportPower;
+    } & Struct;
+    readonly isPowerStateChanged: boolean;
+    readonly asPowerStateChanged: {
+      readonly farmId: u32;
+      readonly nodeId: u32;
+      readonly powerState: TfchainSupportPowerState;
+    } & Struct;
+    readonly type:
+      | "FarmStored"
+      | "FarmUpdated"
+      | "FarmDeleted"
+      | "NodeStored"
+      | "NodeUpdated"
+      | "NodeDeleted"
+      | "NodeUptimeReported"
+      | "NodePublicConfigStored"
+      | "EntityStored"
+      | "EntityUpdated"
+      | "EntityDeleted"
+      | "TwinStored"
+      | "TwinUpdated"
+      | "TwinEntityStored"
+      | "TwinEntityRemoved"
+      | "TwinDeleted"
+      | "TwinAccountBounded"
+      | "PricingPolicyStored"
+      | "FarmingPolicyStored"
+      | "FarmPayoutV2AddressRegistered"
+      | "FarmMarkedAsDedicated"
+      | "ConnectionPriceSet"
+      | "NodeCertificationSet"
+      | "NodeCertifierAdded"
+      | "NodeCertifierRemoved"
+      | "FarmingPolicyUpdated"
+      | "FarmingPolicySet"
+      | "FarmCertificationSet"
+      | "ZosVersionUpdated"
+      | "PowerTargetChanged"
+      | "PowerStateChanged";
+  }
+
+  /** @name TfchainSupportFarm (47) */
+  interface TfchainSupportFarm extends Struct {
+    readonly version: u32;
+    readonly id: u32;
+    readonly name: Bytes;
+    readonly twinId: u32;
+    readonly pricingPolicyId: u32;
+    readonly certification: TfchainSupportFarmCertification;
+    readonly publicIps: Vec<TfchainSupportPublicIP>;
+    readonly dedicatedFarm: bool;
+    readonly farmingPolicyLimits: Option<TfchainSupportFarmingPolicyLimit>;
+  }
+
+  /** @name TfchainSupportFarmCertification (50) */
+  interface TfchainSupportFarmCertification extends Enum {
+    readonly isNotCertified: boolean;
+    readonly isGold: boolean;
+    readonly type: "NotCertified" | "Gold";
+  }
+
+  /** @name TfchainSupportPublicIP (52) */
+  interface TfchainSupportPublicIP extends Struct {
+    readonly ip: Bytes;
+    readonly gateway: Bytes;
+    readonly contractId: u64;
+  }
+
+  /** @name TfchainSupportFarmingPolicyLimit (58) */
+  interface TfchainSupportFarmingPolicyLimit extends Struct {
+    readonly farmingPolicyId: u32;
+    readonly cu: Option<u64>;
+    readonly su: Option<u64>;
+    readonly end: Option<u64>;
+    readonly nodeCount: Option<u32>;
+    readonly nodeCertification: bool;
+  }
+
+  /** @name TfchainSupportNode (61) */
+  interface TfchainSupportNode extends Struct {
+    readonly version: u32;
+    readonly id: u32;
+    readonly farmId: u32;
+    readonly twinId: u32;
+    readonly resources: TfchainSupportResources;
+    readonly location: PalletTfgridNodeLocation;
+    readonly publicConfig: Option<TfchainSupportPublicConfig>;
+    readonly created: u64;
+    readonly farmingPolicyId: u32;
+    readonly interfaces: Vec<TfchainSupportInterfaceInterfaceName>;
+    readonly certification: TfchainSupportNodeCertification;
+    readonly secureBoot: bool;
+    readonly virtualized: bool;
+    readonly serialNumber: Option<Bytes>;
+    readonly connectionPrice: u32;
+  }
+
+  /** @name PalletTfgridNodeLocation (62) */
+  interface PalletTfgridNodeLocation extends Struct {
+    readonly city: Bytes;
+    readonly country: Bytes;
+    readonly latitude: Bytes;
+    readonly longitude: Bytes;
+  }
+
+  /** @name TfchainSupportInterfaceInterfaceName (68) */
+  interface TfchainSupportInterfaceInterfaceName extends Struct {
+    readonly name: Bytes;
+    readonly mac: Bytes;
+    readonly ips: Vec<Bytes>;
+  }
+
+  /** @name TfchainSupportResources (79) */
+  interface TfchainSupportResources extends Struct {
+    readonly hru: u64;
+    readonly sru: u64;
+    readonly cru: u64;
+    readonly mru: u64;
+  }
+
+  /** @name TfchainSupportPublicConfig (81) */
+  interface TfchainSupportPublicConfig extends Struct {
+    readonly ip4: TfchainSupportIp4;
+    readonly ip6: Option<TfchainSupportIp6>;
+    readonly domain: Option<Bytes>;
+  }
+
+  /** @name TfchainSupportIp4 (82) */
+  interface TfchainSupportIp4 extends Struct {
+    readonly ip: Bytes;
+    readonly gw: Bytes;
+  }
+
+  /** @name TfchainSupportIp6 (84) */
+  interface TfchainSupportIp6 extends Struct {
+    readonly ip: Bytes;
+    readonly gw: Bytes;
+  }
+
+  /** @name TfchainSupportNodeCertification (89) */
+  interface TfchainSupportNodeCertification extends Enum {
+    readonly isDiy: boolean;
+    readonly isCertified: boolean;
+    readonly type: "Diy" | "Certified";
+  }
+
+  /** @name PalletTfgridEntity (91) */
+  interface PalletTfgridEntity extends Struct {
+    readonly version: u32;
+    readonly id: u32;
+    readonly name: Bytes;
+    readonly accountId: AccountId32;
+    readonly country: Bytes;
+    readonly city: Bytes;
+  }
+
+  /** @name PalletTfgridTwin (92) */
+  interface PalletTfgridTwin extends Struct {
+    readonly id: u32;
+    readonly accountId: AccountId32;
+    readonly relay: Option<Bytes>;
+    readonly entities: Vec<PalletTfgridEntityProof>;
+    readonly pk: Option<Bytes>;
+  }
+
+  /** @name PalletTfgridEntityProof (96) */
+  interface PalletTfgridEntityProof extends Struct {
+    readonly entityId: u32;
+    readonly signature: Bytes;
+  }
+
+  /** @name PalletTfgridPricingPolicy (97) */
+  interface PalletTfgridPricingPolicy extends Struct {
+    readonly version: u32;
+    readonly id: u32;
+    readonly name: Bytes;
+    readonly su: PalletTfgridPolicy;
+    readonly cu: PalletTfgridPolicy;
+    readonly nu: PalletTfgridPolicy;
+    readonly ipu: PalletTfgridPolicy;
+    readonly uniqueName: PalletTfgridPolicy;
+    readonly domainName: PalletTfgridPolicy;
+    readonly foundationAccount: AccountId32;
+    readonly certifiedSalesAccount: AccountId32;
+    readonly discountForDedicationNodes: u8;
+  }
+
+  /** @name PalletTfgridPolicy (98) */
+  interface PalletTfgridPolicy extends Struct {
+    readonly value: u32;
+    readonly unit: PalletTfgridUnit;
+  }
+
+  /** @name PalletTfgridUnit (99) */
+  interface PalletTfgridUnit extends Enum {
+    readonly isBytes: boolean;
+    readonly isKilobytes: boolean;
+    readonly isMegabytes: boolean;
+    readonly isGigabytes: boolean;
+    readonly isTerrabytes: boolean;
+    readonly type: "Bytes" | "Kilobytes" | "Megabytes" | "Gigabytes" | "Terrabytes";
+  }
+
+  /** @name PalletTfgridFarmingPolicy (100) */
+  interface PalletTfgridFarmingPolicy extends Struct {
+    readonly version: u32;
+    readonly id: u32;
+    readonly name: Bytes;
+    readonly cu: u32;
+    readonly su: u32;
+    readonly nu: u32;
+    readonly ipv4: u32;
+    readonly minimalUptime: u16;
+    readonly policyCreated: u32;
+    readonly policyEnd: u32;
+    readonly immutable: bool;
+    readonly default: bool;
+    readonly nodeCertification: TfchainSupportNodeCertification;
+    readonly farmCertification: TfchainSupportFarmCertification;
+  }
+
+  /** @name TfchainSupportPower (102) */
+  interface TfchainSupportPower extends Enum {
+    readonly isUp: boolean;
+    readonly isDown: boolean;
+    readonly type: "Up" | "Down";
+  }
+
+  /** @name TfchainSupportPowerState (103) */
+  interface TfchainSupportPowerState extends Enum {
+    readonly isUp: boolean;
+    readonly isDown: boolean;
+    readonly asDown: u32;
+    readonly type: "Up" | "Down";
+  }
+
+  /** @name PalletSmartContractEvent (104) */
+  interface PalletSmartContractEvent extends Enum {
+    readonly isContractCreated: boolean;
+    readonly asContractCreated: PalletSmartContractContract;
+    readonly isContractUpdated: boolean;
+    readonly asContractUpdated: PalletSmartContractContract;
+    readonly isNodeContractCanceled: boolean;
+    readonly asNodeContractCanceled: {
+      readonly contractId: u64;
+      readonly nodeId: u32;
+      readonly twinId: u32;
+    } & Struct;
+    readonly isNameContractCanceled: boolean;
+    readonly asNameContractCanceled: {
+      readonly contractId: u64;
+    } & Struct;
+    readonly isIPsReserved: boolean;
+    readonly asIPsReserved: {
+      readonly contractId: u64;
+      readonly publicIps: Vec<TfchainSupportPublicIP>;
+    } & Struct;
+    readonly isIPsFreed: boolean;
+    readonly asIPsFreed: {
+      readonly contractId: u64;
+      readonly publicIps: Vec<TfchainSupportPublicIP>;
+    } & Struct;
+    readonly isContractDeployed: boolean;
+    readonly asContractDeployed: ITuple<[u64, AccountId32]>;
+    readonly isConsumptionReportReceived: boolean;
+    readonly asConsumptionReportReceived: PalletSmartContractConsumption;
+    readonly isContractBilled: boolean;
+    readonly asContractBilled: PalletSmartContractContractBill;
+    readonly isTokensBurned: boolean;
+    readonly asTokensBurned: {
+      readonly contractId: u64;
+      readonly amount: u128;
+    } & Struct;
+    readonly isUpdatedUsedResources: boolean;
+    readonly asUpdatedUsedResources: PalletSmartContractContractResources;
+    readonly isNruConsumptionReportReceived: boolean;
+    readonly asNruConsumptionReportReceived: PalletSmartContractNruConsumption;
+    readonly isRentContractCanceled: boolean;
+    readonly asRentContractCanceled: {
+      readonly contractId: u64;
+    } & Struct;
+    readonly isContractGracePeriodStarted: boolean;
+    readonly asContractGracePeriodStarted: {
+      readonly contractId: u64;
+      readonly nodeId: u32;
+      readonly twinId: u32;
+      readonly blockNumber: u64;
+    } & Struct;
+    readonly isContractGracePeriodEnded: boolean;
+    readonly asContractGracePeriodEnded: {
+      readonly contractId: u64;
+      readonly nodeId: u32;
+      readonly twinId: u32;
+    } & Struct;
+    readonly isSolutionProviderCreated: boolean;
+    readonly asSolutionProviderCreated: PalletSmartContractSolutionProvider;
+    readonly isSolutionProviderApproved: boolean;
+    readonly asSolutionProviderApproved: ITuple<[u64, bool]>;
+    readonly isServiceContractCreated: boolean;
+    readonly asServiceContractCreated: PalletSmartContractServiceContract;
+    readonly isServiceContractMetadataSet: boolean;
+    readonly asServiceContractMetadataSet: PalletSmartContractServiceContract;
+    readonly isServiceContractFeesSet: boolean;
+    readonly asServiceContractFeesSet: PalletSmartContractServiceContract;
+    readonly isServiceContractApproved: boolean;
+    readonly asServiceContractApproved: PalletSmartContractServiceContract;
+    readonly isServiceContractCanceled: boolean;
+    readonly asServiceContractCanceled: {
+      readonly serviceContractId: u64;
+      readonly cause: PalletSmartContractCause;
+    } & Struct;
+    readonly isServiceContractBilled: boolean;
+    readonly asServiceContractBilled: {
+      readonly serviceContract: PalletSmartContractServiceContract;
+      readonly bill: PalletSmartContractServiceContractBill;
+      readonly amount: u128;
+    } & Struct;
+    readonly isBillingFrequencyChanged: boolean;
+    readonly asBillingFrequencyChanged: u64;
+    readonly isNodeExtraFeeSet: boolean;
+    readonly asNodeExtraFeeSet: {
+      readonly nodeId: u32;
+      readonly extraFee: u64;
+    } & Struct;
+    readonly type:
+      | "ContractCreated"
+      | "ContractUpdated"
+      | "NodeContractCanceled"
+      | "NameContractCanceled"
+      | "IPsReserved"
+      | "IPsFreed"
+      | "ContractDeployed"
+      | "ConsumptionReportReceived"
+      | "ContractBilled"
+      | "TokensBurned"
+      | "UpdatedUsedResources"
+      | "NruConsumptionReportReceived"
+      | "RentContractCanceled"
+      | "ContractGracePeriodStarted"
+      | "ContractGracePeriodEnded"
+      | "SolutionProviderCreated"
+      | "SolutionProviderApproved"
+      | "ServiceContractCreated"
+      | "ServiceContractMetadataSet"
+      | "ServiceContractFeesSet"
+      | "ServiceContractApproved"
+      | "ServiceContractCanceled"
+      | "ServiceContractBilled"
+      | "BillingFrequencyChanged"
+      | "NodeExtraFeeSet";
+  }
+
+  /** @name PalletSmartContractContract (105) */
+  interface PalletSmartContractContract extends Struct {
+    readonly version: u32;
+    readonly state: PalletSmartContractContractState;
+    readonly contractId: u64;
+    readonly twinId: u32;
+    readonly contractType: PalletSmartContractContractData;
+    readonly solutionProviderId: Option<u64>;
+  }
+
+  /** @name PalletSmartContractContractState (106) */
+  interface PalletSmartContractContractState extends Enum {
+    readonly isCreated: boolean;
+    readonly isDeleted: boolean;
+    readonly asDeleted: PalletSmartContractCause;
+    readonly isGracePeriod: boolean;
+    readonly asGracePeriod: u64;
+    readonly type: "Created" | "Deleted" | "GracePeriod";
+  }
+
+  /** @name PalletSmartContractCause (107) */
+  interface PalletSmartContractCause extends Enum {
+    readonly isCanceledByUser: boolean;
+    readonly isOutOfFunds: boolean;
+    readonly isCanceledByCollective: boolean;
+    readonly type: "CanceledByUser" | "OutOfFunds" | "CanceledByCollective";
+  }
+
+  /** @name PalletSmartContractContractData (108) */
+  interface PalletSmartContractContractData extends Enum {
+    readonly isNodeContract: boolean;
+    readonly asNodeContract: PalletSmartContractNodeContract;
+    readonly isNameContract: boolean;
+    readonly asNameContract: PalletSmartContractNameContract;
+    readonly isRentContract: boolean;
+    readonly asRentContract: PalletSmartContractRentContract;
+    readonly type: "NodeContract" | "NameContract" | "RentContract";
+  }
+
+  /** @name PalletSmartContractNodeContract (109) */
+  interface PalletSmartContractNodeContract extends Struct {
+    readonly nodeId: u32;
+    readonly deploymentHash: U8aFixed;
+    readonly deploymentData: Bytes;
+    readonly publicIps: u32;
+    readonly publicIpsList: Vec<TfchainSupportPublicIP>;
+  }
+
+  /** @name PalletSmartContractNameContract (112) */
+  interface PalletSmartContractNameContract extends Struct {
+    readonly name: Bytes;
+  }
+
+  /** @name PalletSmartContractRentContract (115) */
+  interface PalletSmartContractRentContract extends Struct {
+    readonly nodeId: u32;
+  }
+
+  /** @name PalletSmartContractConsumption (116) */
+  interface PalletSmartContractConsumption extends Struct {
+    readonly contractId: u64;
+    readonly timestamp: u64;
+    readonly cru: u64;
+    readonly sru: u64;
+    readonly hru: u64;
+    readonly mru: u64;
+    readonly nru: u64;
+  }
+
+  /** @name PalletSmartContractContractBill (117) */
+  interface PalletSmartContractContractBill extends Struct {
+    readonly contractId: u64;
+    readonly timestamp: u64;
+    readonly discountLevel: PalletSmartContractDiscountLevel;
+    readonly amountBilled: u128;
+  }
+
+  /** @name PalletSmartContractDiscountLevel (118) */
+  interface PalletSmartContractDiscountLevel extends Enum {
+    readonly isNone: boolean;
+    readonly isDefault: boolean;
+    readonly isBronze: boolean;
+    readonly isSilver: boolean;
+    readonly isGold: boolean;
+    readonly type: "None" | "Default" | "Bronze" | "Silver" | "Gold";
+  }
+
+  /** @name PalletSmartContractContractResources (119) */
+  interface PalletSmartContractContractResources extends Struct {
+    readonly contractId: u64;
+    readonly used: TfchainSupportResources;
+  }
+
+  /** @name PalletSmartContractNruConsumption (120) */
+  interface PalletSmartContractNruConsumption extends Struct {
+    readonly contractId: u64;
+    readonly timestamp: u64;
+    readonly window: u64;
+    readonly nru: u64;
+  }
+
+  /** @name PalletSmartContractSolutionProvider (121) */
+  interface PalletSmartContractSolutionProvider extends Struct {
+    readonly solutionProviderId: u64;
+    readonly providers: Vec<PalletSmartContractProvider>;
+    readonly description: Bytes;
+    readonly link: Bytes;
+    readonly approved: bool;
+  }
+
+  /** @name PalletSmartContractProvider (123) */
+  interface PalletSmartContractProvider extends Struct {
+    readonly who: AccountId32;
+    readonly take: u8;
+  }
+
+  /** @name PalletSmartContractServiceContract (124) */
+  interface PalletSmartContractServiceContract extends Struct {
+    readonly serviceContractId: u64;
+    readonly serviceTwinId: u32;
+    readonly consumerTwinId: u32;
+    readonly baseFee: u64;
+    readonly variableFee: u64;
+    readonly metadata: Bytes;
+    readonly acceptedByService: bool;
+    readonly acceptedByConsumer: bool;
+    readonly lastBill: u64;
+    readonly state: PalletSmartContractServiceContractState;
+  }
+
+  /** @name PalletSmartContractServiceContractState (126) */
+  interface PalletSmartContractServiceContractState extends Enum {
+    readonly isCreated: boolean;
+    readonly isAgreementReady: boolean;
+    readonly isApprovedByBoth: boolean;
+    readonly type: "Created" | "AgreementReady" | "ApprovedByBoth";
+  }
+
+  /** @name PalletSmartContractServiceContractBill (127) */
+  interface PalletSmartContractServiceContractBill extends Struct {
+    readonly variableAmount: u64;
+    readonly window: u64;
+    readonly metadata: Bytes;
+  }
+
+  /** @name PalletTftBridgeEvent (128) */
+  interface PalletTftBridgeEvent extends Enum {
+    readonly isMintTransactionProposed: boolean;
+    readonly asMintTransactionProposed: ITuple<[Bytes, AccountId32, u64]>;
+    readonly isMintTransactionVoted: boolean;
+    readonly asMintTransactionVoted: Bytes;
+    readonly isMintCompleted: boolean;
+    readonly asMintCompleted: ITuple<[PalletTftBridgeMintTransaction, Bytes]>;
+    readonly isMintTransactionExpired: boolean;
+    readonly asMintTransactionExpired: ITuple<[Bytes, u64, AccountId32]>;
+    readonly isBurnTransactionCreated: boolean;
+    readonly asBurnTransactionCreated: ITuple<[u64, AccountId32, Bytes, u64]>;
+    readonly isBurnTransactionProposed: boolean;
+    readonly asBurnTransactionProposed: ITuple<[u64, Bytes, u64]>;
+    readonly isBurnTransactionSignatureAdded: boolean;
+    readonly asBurnTransactionSignatureAdded: ITuple<[u64, PalletTftBridgeStellarSignature]>;
+    readonly isBurnTransactionReady: boolean;
+    readonly asBurnTransactionReady: u64;
+    readonly isBurnTransactionProcessed: boolean;
+    readonly asBurnTransactionProcessed: PalletTftBridgeBurnTransaction;
+    readonly isBurnTransactionExpired: boolean;
+    readonly asBurnTransactionExpired: ITuple<[u64, Option<AccountId32>, Bytes, u64]>;
+    readonly isRefundTransactionCreated: boolean;
+    readonly asRefundTransactionCreated: ITuple<[Bytes, Bytes, u64]>;
+    readonly isRefundTransactionsignatureAdded: boolean;
+    readonly asRefundTransactionsignatureAdded: ITuple<[Bytes, PalletTftBridgeStellarSignature]>;
+    readonly isRefundTransactionReady: boolean;
+    readonly asRefundTransactionReady: Bytes;
+    readonly isRefundTransactionProcessed: boolean;
+    readonly asRefundTransactionProcessed: PalletTftBridgeRefundTransaction;
+    readonly isRefundTransactionExpired: boolean;
+    readonly asRefundTransactionExpired: ITuple<[Bytes, Bytes, u64]>;
+    readonly type:
+      | "MintTransactionProposed"
+      | "MintTransactionVoted"
+      | "MintCompleted"
+      | "MintTransactionExpired"
+      | "BurnTransactionCreated"
+      | "BurnTransactionProposed"
+      | "BurnTransactionSignatureAdded"
+      | "BurnTransactionReady"
+      | "BurnTransactionProcessed"
+      | "BurnTransactionExpired"
+      | "RefundTransactionCreated"
+      | "RefundTransactionsignatureAdded"
+      | "RefundTransactionReady"
+      | "RefundTransactionProcessed"
+      | "RefundTransactionExpired";
+  }
+
+  /** @name PalletTftBridgeMintTransaction (129) */
+  interface PalletTftBridgeMintTransaction extends Struct {
+    readonly amount: u64;
+    readonly target: AccountId32;
+    readonly block: u32;
+    readonly votes: u32;
+  }
+
+  /** @name PalletTftBridgeStellarSignature (130) */
+  interface PalletTftBridgeStellarSignature extends Struct {
+    readonly signature: Bytes;
+    readonly stellarPubKey: Bytes;
+  }
+
+  /** @name PalletTftBridgeBurnTransaction (131) */
+  interface PalletTftBridgeBurnTransaction extends Struct {
+    readonly block: u32;
+    readonly amount: u64;
+    readonly source: Option<AccountId32>;
+    readonly target: Bytes;
+    readonly signatures: Vec<PalletTftBridgeStellarSignature>;
+    readonly sequenceNumber: u64;
+  }
+
+  /** @name PalletTftBridgeRefundTransaction (134) */
+  interface PalletTftBridgeRefundTransaction extends Struct {
+    readonly block: u32;
+    readonly amount: u64;
+    readonly target: Bytes;
+    readonly txHash: Bytes;
+    readonly signatures: Vec<PalletTftBridgeStellarSignature>;
+    readonly sequenceNumber: u64;
+  }
+
+  /** @name PalletTftPriceEvent (135) */
+  interface PalletTftPriceEvent extends Enum {
+    readonly isPriceStored: boolean;
+    readonly asPriceStored: u32;
+    readonly isOffchainWorkerExecuted: boolean;
+    readonly asOffchainWorkerExecuted: AccountId32;
+    readonly isAveragePriceStored: boolean;
+    readonly asAveragePriceStored: u32;
+    readonly isAveragePriceIsAboveMaxPrice: boolean;
+    readonly asAveragePriceIsAboveMaxPrice: ITuple<[u32, u32]>;
+    readonly isAveragePriceIsBelowMinPrice: boolean;
+    readonly asAveragePriceIsBelowMinPrice: ITuple<[u32, u32]>;
+    readonly type:
+      | "PriceStored"
+      | "OffchainWorkerExecuted"
+      | "AveragePriceStored"
+      | "AveragePriceIsAboveMaxPrice"
+      | "AveragePriceIsBelowMinPrice";
+  }
+
+  /** @name PalletBurningEvent (136) */
+  interface PalletBurningEvent extends Enum {
+    readonly isBurnTransactionCreated: boolean;
+    readonly asBurnTransactionCreated: ITuple<[AccountId32, u128, u32, Bytes]>;
+    readonly type: "BurnTransactionCreated";
+  }
+
+  /** @name PalletKvstoreEvent (137) */
+  interface PalletKvstoreEvent extends Enum {
+    readonly isEntrySet: boolean;
+    readonly asEntrySet: ITuple<[AccountId32, Bytes, Bytes]>;
+    readonly isEntryGot: boolean;
+    readonly asEntryGot: ITuple<[AccountId32, Bytes, Bytes]>;
+    readonly isEntryTaken: boolean;
+    readonly asEntryTaken: ITuple<[AccountId32, Bytes, Bytes]>;
+    readonly type: "EntrySet" | "EntryGot" | "EntryTaken";
+  }
+
+  /** @name PalletCollectiveEvent (138) */
+  interface PalletCollectiveEvent extends Enum {
+    readonly isProposed: boolean;
+    readonly asProposed: {
+      readonly account: AccountId32;
+      readonly proposalIndex: u32;
+      readonly proposalHash: H256;
+      readonly threshold: u32;
+    } & Struct;
+    readonly isVoted: boolean;
+    readonly asVoted: {
+      readonly account: AccountId32;
+      readonly proposalHash: H256;
+      readonly voted: bool;
+      readonly yes: u32;
+      readonly no: u32;
+    } & Struct;
+    readonly isApproved: boolean;
+    readonly asApproved: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isDisapproved: boolean;
+    readonly asDisapproved: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isExecuted: boolean;
+    readonly asExecuted: {
+      readonly proposalHash: H256;
+      readonly result: Result<Null, SpRuntimeDispatchError>;
+    } & Struct;
+    readonly isMemberExecuted: boolean;
+    readonly asMemberExecuted: {
+      readonly proposalHash: H256;
+      readonly result: Result<Null, SpRuntimeDispatchError>;
+    } & Struct;
+    readonly isClosed: boolean;
+    readonly asClosed: {
+      readonly proposalHash: H256;
+      readonly yes: u32;
+      readonly no: u32;
+    } & Struct;
+    readonly type: "Proposed" | "Voted" | "Approved" | "Disapproved" | "Executed" | "MemberExecuted" | "Closed";
+  }
+
+  /** @name PalletMembershipEvent (139) */
+  interface PalletMembershipEvent extends Enum {
+    readonly isMemberAdded: boolean;
+    readonly isMemberRemoved: boolean;
+    readonly isMembersSwapped: boolean;
+    readonly isMembersReset: boolean;
+    readonly isKeyChanged: boolean;
+    readonly isDummy: boolean;
+    readonly type: "MemberAdded" | "MemberRemoved" | "MembersSwapped" | "MembersReset" | "KeyChanged" | "Dummy";
+  }
+
+  /** @name PalletDaoEvent (140) */
+  interface PalletDaoEvent extends Enum {
+    readonly isVoted: boolean;
+    readonly asVoted: {
+      readonly account: AccountId32;
+      readonly proposalHash: H256;
+      readonly voted: bool;
+      readonly yes: u32;
+      readonly no: u32;
+    } & Struct;
+    readonly isProposed: boolean;
+    readonly asProposed: {
+      readonly account: AccountId32;
+      readonly proposalIndex: u32;
+      readonly proposalHash: H256;
+      readonly threshold: u32;
+    } & Struct;
+    readonly isApproved: boolean;
+    readonly asApproved: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isDisapproved: boolean;
+    readonly asDisapproved: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isExecuted: boolean;
+    readonly asExecuted: {
+      readonly proposalHash: H256;
+      readonly result: Result<Null, SpRuntimeDispatchError>;
+    } & Struct;
+    readonly isClosed: boolean;
+    readonly asClosed: {
+      readonly proposalHash: H256;
+      readonly yes: u32;
+      readonly yesWeight: u64;
+      readonly no: u32;
+      readonly noWeight: u64;
+    } & Struct;
+    readonly isClosedByCouncil: boolean;
+    readonly asClosedByCouncil: {
+      readonly proposalHash: H256;
+      readonly vetos: Vec<AccountId32>;
+    } & Struct;
+    readonly isCouncilMemberVeto: boolean;
+    readonly asCouncilMemberVeto: {
+      readonly proposalHash: H256;
+      readonly who: AccountId32;
+    } & Struct;
+    readonly type:
+      | "Voted"
+      | "Proposed"
+      | "Approved"
+      | "Disapproved"
+      | "Executed"
+      | "Closed"
+      | "ClosedByCouncil"
+      | "CouncilMemberVeto";
+  }
+
+  /** @name PalletValidatorEvent (142) */
+  interface PalletValidatorEvent extends Enum {
+    readonly isBonded: boolean;
+    readonly asBonded: AccountId32;
+    readonly isValidatorRequestCreated: boolean;
+    readonly asValidatorRequestCreated: ITuple<[AccountId32, PalletValidatorValidator]>;
+    readonly isValidatorRequestApproved: boolean;
+    readonly asValidatorRequestApproved: PalletValidatorValidator;
+    readonly isValidatorActivated: boolean;
+    readonly asValidatorActivated: PalletValidatorValidator;
+    readonly isValidatorRemoved: boolean;
+    readonly asValidatorRemoved: PalletValidatorValidator;
+    readonly isNodeValidatorChanged: boolean;
+    readonly asNodeValidatorChanged: AccountId32;
+    readonly isNodeValidatorRemoved: boolean;
+    readonly asNodeValidatorRemoved: AccountId32;
+    readonly type:
+      | "Bonded"
+      | "ValidatorRequestCreated"
+      | "ValidatorRequestApproved"
+      | "ValidatorActivated"
+      | "ValidatorRemoved"
+      | "NodeValidatorChanged"
+      | "NodeValidatorRemoved";
+  }
+
+  /** @name PalletValidatorValidator (143) */
+  interface PalletValidatorValidator extends Struct {
+    readonly validatorNodeAccount: AccountId32;
+    readonly stashAccount: AccountId32;
+    readonly description: Bytes;
+    readonly tfConnectId: Bytes;
+    readonly info: Bytes;
+    readonly state: PalletValidatorValidatorRequestState;
+  }
+
+  /** @name PalletValidatorValidatorRequestState (144) */
+  interface PalletValidatorValidatorRequestState extends Enum {
+    readonly isCreated: boolean;
+    readonly isApproved: boolean;
+    readonly isValidating: boolean;
+    readonly type: "Created" | "Approved" | "Validating";
+  }
+
+  /** @name FrameSystemPhase (145) */
+  interface FrameSystemPhase extends Enum {
+    readonly isApplyExtrinsic: boolean;
+    readonly asApplyExtrinsic: u32;
+    readonly isFinalization: boolean;
+    readonly isInitialization: boolean;
+    readonly type: "ApplyExtrinsic" | "Finalization" | "Initialization";
+  }
+
+  /** @name FrameSystemLastRuntimeUpgradeInfo (148) */
+  interface FrameSystemLastRuntimeUpgradeInfo extends Struct {
+    readonly specVersion: Compact<u32>;
+    readonly specName: Text;
+  }
+
+  /** @name FrameSystemCall (151) */
+  interface FrameSystemCall extends Enum {
+    readonly isRemark: boolean;
+    readonly asRemark: {
+      readonly remark: Bytes;
+    } & Struct;
+    readonly isSetHeapPages: boolean;
+    readonly asSetHeapPages: {
+      readonly pages: u64;
+    } & Struct;
+    readonly isSetCode: boolean;
+    readonly asSetCode: {
+      readonly code: Bytes;
+    } & Struct;
+    readonly isSetCodeWithoutChecks: boolean;
+    readonly asSetCodeWithoutChecks: {
+      readonly code: Bytes;
+    } & Struct;
+    readonly isSetStorage: boolean;
+    readonly asSetStorage: {
+      readonly items: Vec<ITuple<[Bytes, Bytes]>>;
+    } & Struct;
+    readonly isKillStorage: boolean;
+    readonly asKillStorage: {
+      readonly keys_: Vec<Bytes>;
+    } & Struct;
+    readonly isKillPrefix: boolean;
+    readonly asKillPrefix: {
+      readonly prefix: Bytes;
+      readonly subkeys: u32;
+    } & Struct;
+    readonly isRemarkWithEvent: boolean;
+    readonly asRemarkWithEvent: {
+      readonly remark: Bytes;
+    } & Struct;
+    readonly type:
+      | "Remark"
+      | "SetHeapPages"
+      | "SetCode"
+      | "SetCodeWithoutChecks"
+      | "SetStorage"
+      | "KillStorage"
+      | "KillPrefix"
+      | "RemarkWithEvent";
+  }
+
+  /** @name FrameSystemLimitsBlockWeights (155) */
+  interface FrameSystemLimitsBlockWeights extends Struct {
+    readonly baseBlock: SpWeightsWeightV2Weight;
+    readonly maxBlock: SpWeightsWeightV2Weight;
+    readonly perClass: FrameSupportDispatchPerDispatchClassWeightsPerClass;
+  }
+
+  /** @name FrameSupportDispatchPerDispatchClassWeightsPerClass (156) */
+  interface FrameSupportDispatchPerDispatchClassWeightsPerClass extends Struct {
+    readonly normal: FrameSystemLimitsWeightsPerClass;
+    readonly operational: FrameSystemLimitsWeightsPerClass;
+    readonly mandatory: FrameSystemLimitsWeightsPerClass;
+  }
+
+  /** @name FrameSystemLimitsWeightsPerClass (157) */
+  interface FrameSystemLimitsWeightsPerClass extends Struct {
+    readonly baseExtrinsic: SpWeightsWeightV2Weight;
+    readonly maxExtrinsic: Option<SpWeightsWeightV2Weight>;
+    readonly maxTotal: Option<SpWeightsWeightV2Weight>;
+    readonly reserved: Option<SpWeightsWeightV2Weight>;
+  }
+
+  /** @name FrameSystemLimitsBlockLength (159) */
+  interface FrameSystemLimitsBlockLength extends Struct {
+    readonly max: FrameSupportDispatchPerDispatchClassU32;
+  }
+
+  /** @name FrameSupportDispatchPerDispatchClassU32 (160) */
+  interface FrameSupportDispatchPerDispatchClassU32 extends Struct {
+    readonly normal: u32;
+    readonly operational: u32;
+    readonly mandatory: u32;
+  }
+
+  /** @name SpWeightsRuntimeDbWeight (161) */
+  interface SpWeightsRuntimeDbWeight extends Struct {
+    readonly read: u64;
+    readonly write: u64;
+  }
+
+  /** @name SpVersionRuntimeVersion (162) */
+  interface SpVersionRuntimeVersion extends Struct {
+    readonly specName: Text;
+    readonly implName: Text;
+    readonly authoringVersion: u32;
+    readonly specVersion: u32;
+    readonly implVersion: u32;
+    readonly apis: Vec<ITuple<[U8aFixed, u32]>>;
+    readonly transactionVersion: u32;
+    readonly stateVersion: u8;
+  }
+
+  /** @name FrameSystemError (167) */
+  interface FrameSystemError extends Enum {
+    readonly isInvalidSpecName: boolean;
+    readonly isSpecVersionNeedsToIncrease: boolean;
+    readonly isFailedToExtractRuntimeVersion: boolean;
+    readonly isNonDefaultComposite: boolean;
+    readonly isNonZeroRefCount: boolean;
+    readonly isCallFiltered: boolean;
+    readonly type:
+      | "InvalidSpecName"
+      | "SpecVersionNeedsToIncrease"
+      | "FailedToExtractRuntimeVersion"
+      | "NonDefaultComposite"
+      | "NonZeroRefCount"
+      | "CallFiltered";
+  }
+
+  /** @name PalletTimestampCall (168) */
+  interface PalletTimestampCall extends Enum {
+    readonly isSet: boolean;
+    readonly asSet: {
+      readonly now: Compact<u64>;
+    } & Struct;
+    readonly type: "Set";
+  }
+
+  /** @name PalletUtilityCall (169) */
+  interface PalletUtilityCall extends Enum {
+    readonly isBatch: boolean;
+    readonly asBatch: {
+      readonly calls: Vec<Call>;
+    } & Struct;
+    readonly isAsDerivative: boolean;
+    readonly asAsDerivative: {
+      readonly index: u16;
+      readonly call: Call;
+    } & Struct;
+    readonly isBatchAll: boolean;
+    readonly asBatchAll: {
+      readonly calls: Vec<Call>;
+    } & Struct;
+    readonly isDispatchAs: boolean;
+    readonly asDispatchAs: {
+      readonly asOrigin: TfchainRuntimeOriginCaller;
+      readonly call: Call;
+    } & Struct;
+    readonly isForceBatch: boolean;
+    readonly asForceBatch: {
+      readonly calls: Vec<Call>;
+    } & Struct;
+    readonly isWithWeight: boolean;
+    readonly asWithWeight: {
+      readonly call: Call;
+      readonly weight: SpWeightsWeightV2Weight;
+    } & Struct;
+    readonly type: "Batch" | "AsDerivative" | "BatchAll" | "DispatchAs" | "ForceBatch" | "WithWeight";
+  }
+
+  /** @name PalletSchedulerCall (172) */
+  interface PalletSchedulerCall extends Enum {
+    readonly isSchedule: boolean;
+    readonly asSchedule: {
+      readonly when: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+    readonly isCancel: boolean;
+    readonly asCancel: {
+      readonly when: u32;
+      readonly index: u32;
+    } & Struct;
+    readonly isScheduleNamed: boolean;
+    readonly asScheduleNamed: {
+      readonly id: U8aFixed;
+      readonly when: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+    readonly isCancelNamed: boolean;
+    readonly asCancelNamed: {
+      readonly id: U8aFixed;
+    } & Struct;
+    readonly isScheduleAfter: boolean;
+    readonly asScheduleAfter: {
+      readonly after: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+    readonly isScheduleNamedAfter: boolean;
+    readonly asScheduleNamedAfter: {
+      readonly id: U8aFixed;
+      readonly after: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+    readonly type: "Schedule" | "Cancel" | "ScheduleNamed" | "CancelNamed" | "ScheduleAfter" | "ScheduleNamedAfter";
+  }
+
+  /** @name SubstrateValidatorSetCall (174) */
+  interface SubstrateValidatorSetCall extends Enum {
+    readonly isAddValidator: boolean;
+    readonly asAddValidator: {
+      readonly validatorId: AccountId32;
+    } & Struct;
+    readonly isRemoveValidator: boolean;
+    readonly asRemoveValidator: {
+      readonly validatorId: AccountId32;
+    } & Struct;
+    readonly isAddValidatorAgain: boolean;
+    readonly asAddValidatorAgain: {
+      readonly validatorId: AccountId32;
+    } & Struct;
+    readonly type: "AddValidator" | "RemoveValidator" | "AddValidatorAgain";
+  }
+
+  /** @name PalletSessionCall (175) */
+  interface PalletSessionCall extends Enum {
+    readonly isSetKeys: boolean;
+    readonly asSetKeys: {
+      readonly keys_: TfchainRuntimeOpaqueSessionKeys;
+      readonly proof: Bytes;
+    } & Struct;
+    readonly isPurgeKeys: boolean;
+    readonly type: "SetKeys" | "PurgeKeys";
+  }
+
+  /** @name TfchainRuntimeOpaqueSessionKeys (176) */
+  interface TfchainRuntimeOpaqueSessionKeys extends Struct {
+    readonly aura: SpConsensusAuraSr25519AppSr25519Public;
+    readonly grandpa: SpConsensusGrandpaAppPublic;
+  }
+
+  /** @name SpConsensusAuraSr25519AppSr25519Public (177) */
+  interface SpConsensusAuraSr25519AppSr25519Public extends SpCoreSr25519Public {}
+
+  /** @name SpCoreSr25519Public (178) */
+  interface SpCoreSr25519Public extends U8aFixed {}
+
+  /** @name PalletGrandpaCall (179) */
+  interface PalletGrandpaCall extends Enum {
+    readonly isReportEquivocation: boolean;
+    readonly asReportEquivocation: {
+      readonly equivocationProof: SpConsensusGrandpaEquivocationProof;
+      readonly keyOwnerProof: SpCoreVoid;
+    } & Struct;
+    readonly isReportEquivocationUnsigned: boolean;
+    readonly asReportEquivocationUnsigned: {
+      readonly equivocationProof: SpConsensusGrandpaEquivocationProof;
+      readonly keyOwnerProof: SpCoreVoid;
+    } & Struct;
+    readonly isNoteStalled: boolean;
+    readonly asNoteStalled: {
+      readonly delay: u32;
+      readonly bestFinalizedBlockNumber: u32;
+    } & Struct;
+    readonly type: "ReportEquivocation" | "ReportEquivocationUnsigned" | "NoteStalled";
+  }
+
+  /** @name SpConsensusGrandpaEquivocationProof (180) */
+  interface SpConsensusGrandpaEquivocationProof extends Struct {
+    readonly setId: u64;
+    readonly equivocation: SpConsensusGrandpaEquivocation;
+  }
+
+  /** @name SpConsensusGrandpaEquivocation (181) */
+  interface SpConsensusGrandpaEquivocation extends Enum {
+    readonly isPrevote: boolean;
+    readonly asPrevote: FinalityGrandpaEquivocationPrevote;
+    readonly isPrecommit: boolean;
+    readonly asPrecommit: FinalityGrandpaEquivocationPrecommit;
+    readonly type: "Prevote" | "Precommit";
+  }
+
+  /** @name FinalityGrandpaEquivocationPrevote (182) */
+  interface FinalityGrandpaEquivocationPrevote extends Struct {
+    readonly roundNumber: u64;
+    readonly identity: SpConsensusGrandpaAppPublic;
+    readonly first: ITuple<[FinalityGrandpaPrevote, SpConsensusGrandpaAppSignature]>;
+    readonly second: ITuple<[FinalityGrandpaPrevote, SpConsensusGrandpaAppSignature]>;
+  }
+
+  /** @name FinalityGrandpaPrevote (183) */
+  interface FinalityGrandpaPrevote extends Struct {
+    readonly targetHash: H256;
+    readonly targetNumber: u32;
+  }
+
+  /** @name SpConsensusGrandpaAppSignature (184) */
+  interface SpConsensusGrandpaAppSignature extends SpCoreEd25519Signature {}
+
+  /** @name SpCoreEd25519Signature (185) */
+  interface SpCoreEd25519Signature extends U8aFixed {}
+
+  /** @name FinalityGrandpaEquivocationPrecommit (188) */
+  interface FinalityGrandpaEquivocationPrecommit extends Struct {
+    readonly roundNumber: u64;
+    readonly identity: SpConsensusGrandpaAppPublic;
+    readonly first: ITuple<[FinalityGrandpaPrecommit, SpConsensusGrandpaAppSignature]>;
+    readonly second: ITuple<[FinalityGrandpaPrecommit, SpConsensusGrandpaAppSignature]>;
+  }
+
+  /** @name FinalityGrandpaPrecommit (189) */
+  interface FinalityGrandpaPrecommit extends Struct {
+    readonly targetHash: H256;
+    readonly targetNumber: u32;
+  }
+
+  /** @name SpCoreVoid (191) */
+  type SpCoreVoid = Null;
+
+  /** @name PalletBalancesCall (192) */
+  interface PalletBalancesCall extends Enum {
+    readonly isTransferAllowDeath: boolean;
+    readonly asTransferAllowDeath: {
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isSetBalanceDeprecated: boolean;
+    readonly asSetBalanceDeprecated: {
+      readonly who: MultiAddress;
+      readonly newFree: Compact<u128>;
+      readonly oldReserved: Compact<u128>;
+    } & Struct;
+    readonly isForceTransfer: boolean;
+    readonly asForceTransfer: {
+      readonly source: MultiAddress;
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isTransferKeepAlive: boolean;
+    readonly asTransferKeepAlive: {
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isTransferAll: boolean;
+    readonly asTransferAll: {
+      readonly dest: MultiAddress;
+      readonly keepAlive: bool;
+    } & Struct;
+    readonly isForceUnreserve: boolean;
+    readonly asForceUnreserve: {
+      readonly who: MultiAddress;
+      readonly amount: u128;
+    } & Struct;
+    readonly isUpgradeAccounts: boolean;
+    readonly asUpgradeAccounts: {
+      readonly who: Vec<AccountId32>;
+    } & Struct;
+    readonly isTransfer: boolean;
+    readonly asTransfer: {
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isForceSetBalance: boolean;
+    readonly asForceSetBalance: {
+      readonly who: MultiAddress;
+      readonly newFree: Compact<u128>;
+    } & Struct;
+    readonly type:
+      | "TransferAllowDeath"
+      | "SetBalanceDeprecated"
+      | "ForceTransfer"
+      | "TransferKeepAlive"
+      | "TransferAll"
+      | "ForceUnreserve"
+      | "UpgradeAccounts"
+      | "Transfer"
+      | "ForceSetBalance";
+  }
+
+  /** @name PalletTfgridCall (197) */
+  interface PalletTfgridCall extends Enum {
+    readonly isSetStorageVersion: boolean;
+    readonly asSetStorageVersion: {
+      readonly version: PalletTfgridStorageVersion;
+    } & Struct;
+    readonly isCreateFarm: boolean;
+    readonly asCreateFarm: {
+      readonly name: Bytes;
+      readonly publicIps: Vec<TfchainSupportIp4>;
+    } & Struct;
+    readonly isUpdateFarm: boolean;
+    readonly asUpdateFarm: {
+      readonly farmId: u32;
+      readonly name: Bytes;
+    } & Struct;
+    readonly isAddStellarPayoutV2address: boolean;
+    readonly asAddStellarPayoutV2address: {
+      readonly farmId: u32;
+      readonly stellarAddress: Bytes;
+    } & Struct;
+    readonly isSetFarmCertification: boolean;
+    readonly asSetFarmCertification: {
+      readonly farmId: u32;
+      readonly certification: TfchainSupportFarmCertification;
+    } & Struct;
+    readonly isAddFarmIp: boolean;
+    readonly asAddFarmIp: {
+      readonly farmId: u32;
+      readonly ip: Bytes;
+      readonly gw: Bytes;
+    } & Struct;
+    readonly isRemoveFarmIp: boolean;
+    readonly asRemoveFarmIp: {
+      readonly farmId: u32;
+      readonly ip: Bytes;
+    } & Struct;
+    readonly isCreateNode: boolean;
+    readonly asCreateNode: {
+      readonly farmId: u32;
+      readonly resources: TfchainSupportResources;
+      readonly location: PalletTfgridLocationInput;
+      readonly interfaces: Vec<TfchainSupportInterfaceBoundedVec>;
+      readonly secureBoot: bool;
+      readonly virtualized: bool;
+      readonly serialNumber: Option<Bytes>;
+    } & Struct;
+    readonly isUpdateNode: boolean;
+    readonly asUpdateNode: {
+      readonly nodeId: u32;
+      readonly farmId: u32;
+      readonly resources: TfchainSupportResources;
+      readonly location: PalletTfgridLocationInput;
+      readonly interfaces: Vec<TfchainSupportInterfaceBoundedVec>;
+      readonly secureBoot: bool;
+      readonly virtualized: bool;
+      readonly serialNumber: Option<Bytes>;
+    } & Struct;
+    readonly isSetNodeCertification: boolean;
+    readonly asSetNodeCertification: {
+      readonly nodeId: u32;
+      readonly nodeCertification: TfchainSupportNodeCertification;
+    } & Struct;
+    readonly isReportUptime: boolean;
+    readonly asReportUptime: {
+      readonly uptime: u64;
+    } & Struct;
+    readonly isAddNodePublicConfig: boolean;
+    readonly asAddNodePublicConfig: {
+      readonly farmId: u32;
+      readonly nodeId: u32;
+      readonly publicConfig: Option<TfchainSupportPublicConfig>;
+    } & Struct;
+    readonly isDeleteNode: boolean;
+    readonly asDeleteNode: {
+      readonly nodeId: u32;
+    } & Struct;
+    readonly isCreateEntity: boolean;
+    readonly asCreateEntity: {
+      readonly target: AccountId32;
+      readonly name: Bytes;
+      readonly country: Bytes;
+      readonly city: Bytes;
+      readonly signature: Bytes;
+    } & Struct;
+    readonly isUpdateEntity: boolean;
+    readonly asUpdateEntity: {
+      readonly name: Bytes;
+      readonly country: Bytes;
+      readonly city: Bytes;
+    } & Struct;
+    readonly isDeleteEntity: boolean;
+    readonly isCreateTwin: boolean;
+    readonly asCreateTwin: {
+      readonly relay: Option<Bytes>;
+      readonly pk: Option<Bytes>;
+    } & Struct;
+    readonly isUpdateTwin: boolean;
+    readonly asUpdateTwin: {
+      readonly relay: Option<Bytes>;
+      readonly pk: Option<Bytes>;
+    } & Struct;
+    readonly isAddTwinEntity: boolean;
+    readonly asAddTwinEntity: {
+      readonly twinId: u32;
+      readonly entityId: u32;
+      readonly signature: Bytes;
+    } & Struct;
+    readonly isDeleteTwinEntity: boolean;
+    readonly asDeleteTwinEntity: {
+      readonly twinId: u32;
+      readonly entityId: u32;
+    } & Struct;
+    readonly isCreatePricingPolicy: boolean;
+    readonly asCreatePricingPolicy: {
+      readonly name: Bytes;
+      readonly su: PalletTfgridPolicy;
+      readonly cu: PalletTfgridPolicy;
+      readonly nu: PalletTfgridPolicy;
+      readonly ipu: PalletTfgridPolicy;
+      readonly uniqueName: PalletTfgridPolicy;
+      readonly domainName: PalletTfgridPolicy;
+      readonly foundationAccount: AccountId32;
+      readonly certifiedSalesAccount: AccountId32;
+      readonly discountForDedicationNodes: u8;
+    } & Struct;
+    readonly isUpdatePricingPolicy: boolean;
+    readonly asUpdatePricingPolicy: {
+      readonly pricingPolicyId: u32;
+      readonly name: Bytes;
+      readonly su: PalletTfgridPolicy;
+      readonly cu: PalletTfgridPolicy;
+      readonly nu: PalletTfgridPolicy;
+      readonly ipu: PalletTfgridPolicy;
+      readonly uniqueName: PalletTfgridPolicy;
+      readonly domainName: PalletTfgridPolicy;
+      readonly foundationAccount: AccountId32;
+      readonly certifiedSalesAccount: AccountId32;
+      readonly discountForDedicationNodes: u8;
+    } & Struct;
+    readonly isCreateFarmingPolicy: boolean;
+    readonly asCreateFarmingPolicy: {
+      readonly name: Bytes;
+      readonly su: u32;
+      readonly cu: u32;
+      readonly nu: u32;
+      readonly ipv4: u32;
+      readonly minimalUptime: u16;
+      readonly policyEnd: u32;
+      readonly immutable: bool;
+      readonly default: bool;
+      readonly nodeCertification: TfchainSupportNodeCertification;
+      readonly farmCertification: TfchainSupportFarmCertification;
+    } & Struct;
+    readonly isUserAcceptTc: boolean;
+    readonly asUserAcceptTc: {
+      readonly documentLink: Bytes;
+      readonly documentHash: Bytes;
+    } & Struct;
+    readonly isDeleteNodeFarm: boolean;
+    readonly asDeleteNodeFarm: {
+      readonly nodeId: u32;
+    } & Struct;
+    readonly isSetFarmDedicated: boolean;
+    readonly asSetFarmDedicated: {
+      readonly farmId: u32;
+      readonly dedicated: bool;
+    } & Struct;
+    readonly isForceResetFarmIp: boolean;
+    readonly asForceResetFarmIp: {
+      readonly farmId: u32;
+      readonly ip: Bytes;
+    } & Struct;
+    readonly isSetConnectionPrice: boolean;
+    readonly asSetConnectionPrice: {
+      readonly price: u32;
+    } & Struct;
+    readonly isAddNodeCertifier: boolean;
+    readonly asAddNodeCertifier: {
+      readonly certifier: AccountId32;
+    } & Struct;
+    readonly isRemoveNodeCertifier: boolean;
+    readonly asRemoveNodeCertifier: {
+      readonly certifier: AccountId32;
+    } & Struct;
+    readonly isUpdateFarmingPolicy: boolean;
+    readonly asUpdateFarmingPolicy: {
+      readonly farmingPolicyId: u32;
+      readonly name: Bytes;
+      readonly su: u32;
+      readonly cu: u32;
+      readonly nu: u32;
+      readonly ipv4: u32;
+      readonly minimalUptime: u16;
+      readonly policyEnd: u32;
+      readonly default: bool;
+      readonly nodeCertification: TfchainSupportNodeCertification;
+      readonly farmCertification: TfchainSupportFarmCertification;
+    } & Struct;
+    readonly isAttachPolicyToFarm: boolean;
+    readonly asAttachPolicyToFarm: {
+      readonly farmId: u32;
+      readonly limits: Option<TfchainSupportFarmingPolicyLimit>;
+    } & Struct;
+    readonly isSetZosVersion: boolean;
+    readonly asSetZosVersion: {
+      readonly zosVersion: Bytes;
+    } & Struct;
+    readonly isChangePowerState: boolean;
+    readonly asChangePowerState: {
+      readonly powerState: TfchainSupportPower;
+    } & Struct;
+    readonly isChangePowerTarget: boolean;
+    readonly asChangePowerTarget: {
+      readonly nodeId: u32;
+      readonly powerTarget: TfchainSupportPower;
+    } & Struct;
+    readonly isBondTwinAccount: boolean;
+    readonly asBondTwinAccount: {
+      readonly twinId: u32;
+    } & Struct;
+    readonly isReportUptimeV2: boolean;
+    readonly asReportUptimeV2: {
+      readonly uptime: u64;
+      readonly timestampHint: u64;
+    } & Struct;
+    readonly type:
+      | "SetStorageVersion"
+      | "CreateFarm"
+      | "UpdateFarm"
+      | "AddStellarPayoutV2address"
+      | "SetFarmCertification"
+      | "AddFarmIp"
+      | "RemoveFarmIp"
+      | "CreateNode"
+      | "UpdateNode"
+      | "SetNodeCertification"
+      | "ReportUptime"
+      | "AddNodePublicConfig"
+      | "DeleteNode"
+      | "CreateEntity"
+      | "UpdateEntity"
+      | "DeleteEntity"
+      | "CreateTwin"
+      | "UpdateTwin"
+      | "AddTwinEntity"
+      | "DeleteTwinEntity"
+      | "CreatePricingPolicy"
+      | "UpdatePricingPolicy"
+      | "CreateFarmingPolicy"
+      | "UserAcceptTc"
+      | "DeleteNodeFarm"
+      | "SetFarmDedicated"
+      | "ForceResetFarmIp"
+      | "SetConnectionPrice"
+      | "AddNodeCertifier"
+      | "RemoveNodeCertifier"
+      | "UpdateFarmingPolicy"
+      | "AttachPolicyToFarm"
+      | "SetZosVersion"
+      | "ChangePowerState"
+      | "ChangePowerTarget"
+      | "BondTwinAccount"
+      | "ReportUptimeV2";
+  }
+
+  /** @name PalletTfgridStorageVersion (198) */
+  interface PalletTfgridStorageVersion extends Enum {
+    readonly isV1Struct: boolean;
+    readonly isV2Struct: boolean;
+    readonly isV3Struct: boolean;
+    readonly isV4Struct: boolean;
+    readonly isV5Struct: boolean;
+    readonly isV6Struct: boolean;
+    readonly isV7Struct: boolean;
+    readonly isV8Struct: boolean;
+    readonly isV9Struct: boolean;
+    readonly isV10Struct: boolean;
+    readonly isV11Struct: boolean;
+    readonly isV12Struct: boolean;
+    readonly isV13Struct: boolean;
+    readonly isV14Struct: boolean;
+    readonly isV15Struct: boolean;
+    readonly isV16Struct: boolean;
+    readonly isV17Struct: boolean;
+    readonly type:
+      | "V1Struct"
+      | "V2Struct"
+      | "V3Struct"
+      | "V4Struct"
+      | "V5Struct"
+      | "V6Struct"
+      | "V7Struct"
+      | "V8Struct"
+      | "V9Struct"
+      | "V10Struct"
+      | "V11Struct"
+      | "V12Struct"
+      | "V13Struct"
+      | "V14Struct"
+      | "V15Struct"
+      | "V16Struct"
+      | "V17Struct";
+  }
+
+  /** @name PalletTfgridLocationInput (201) */
+  interface PalletTfgridLocationInput extends Struct {
+    readonly city: Bytes;
+    readonly country: Bytes;
+    readonly latitude: Bytes;
+    readonly longitude: Bytes;
+  }
+
+  /** @name TfchainSupportInterfaceBoundedVec (203) */
+  interface TfchainSupportInterfaceBoundedVec extends Struct {
+    readonly name: Bytes;
+    readonly mac: Bytes;
+    readonly ips: Vec<Bytes>;
+  }
+
+  /** @name PalletSmartContractCall (208) */
+  interface PalletSmartContractCall extends Enum {
+    readonly isCreateNodeContract: boolean;
+    readonly asCreateNodeContract: {
+      readonly nodeId: u32;
+      readonly deploymentHash: U8aFixed;
+      readonly deploymentData: Bytes;
+      readonly publicIps: u32;
+      readonly solutionProviderId: Option<u64>;
+    } & Struct;
+    readonly isUpdateNodeContract: boolean;
+    readonly asUpdateNodeContract: {
+      readonly contractId: u64;
+      readonly deploymentHash: U8aFixed;
+      readonly deploymentData: Bytes;
+    } & Struct;
+    readonly isCancelContract: boolean;
+    readonly asCancelContract: {
+      readonly contractId: u64;
+    } & Struct;
+    readonly isCreateNameContract: boolean;
+    readonly asCreateNameContract: {
+      readonly name: Bytes;
+    } & Struct;
+    readonly isAddNruReports: boolean;
+    readonly asAddNruReports: {
+      readonly reports: Vec<PalletSmartContractNruConsumption>;
+    } & Struct;
+    readonly isReportContractResources: boolean;
+    readonly asReportContractResources: {
+      readonly contractResources: Vec<PalletSmartContractContractResources>;
+    } & Struct;
+    readonly isCreateRentContract: boolean;
+    readonly asCreateRentContract: {
+      readonly nodeId: u32;
+      readonly solutionProviderId: Option<u64>;
+    } & Struct;
+    readonly isCreateSolutionProvider: boolean;
+    readonly asCreateSolutionProvider: {
+      readonly description: Bytes;
+      readonly link: Bytes;
+      readonly providers: Vec<PalletSmartContractProvider>;
+    } & Struct;
+    readonly isApproveSolutionProvider: boolean;
+    readonly asApproveSolutionProvider: {
+      readonly solutionProviderId: u64;
+      readonly approve: bool;
+    } & Struct;
+    readonly isBillContractForBlock: boolean;
+    readonly asBillContractForBlock: {
+      readonly contractId: u64;
+    } & Struct;
+    readonly isServiceContractCreate: boolean;
+    readonly asServiceContractCreate: {
+      readonly serviceAccount: AccountId32;
+      readonly consumerAccount: AccountId32;
+    } & Struct;
+    readonly isServiceContractSetMetadata: boolean;
+    readonly asServiceContractSetMetadata: {
+      readonly serviceContractId: u64;
+      readonly metadata: Bytes;
+    } & Struct;
+    readonly isServiceContractSetFees: boolean;
+    readonly asServiceContractSetFees: {
+      readonly serviceContractId: u64;
+      readonly baseFee: u64;
+      readonly variableFee: u64;
+    } & Struct;
+    readonly isServiceContractApprove: boolean;
+    readonly asServiceContractApprove: {
+      readonly serviceContractId: u64;
+    } & Struct;
+    readonly isServiceContractReject: boolean;
+    readonly asServiceContractReject: {
+      readonly serviceContractId: u64;
+    } & Struct;
+    readonly isServiceContractCancel: boolean;
+    readonly asServiceContractCancel: {
+      readonly serviceContractId: u64;
+    } & Struct;
+    readonly isServiceContractBill: boolean;
+    readonly asServiceContractBill: {
+      readonly serviceContractId: u64;
+      readonly variableAmount: u64;
+      readonly metadata: Bytes;
+    } & Struct;
+    readonly isChangeBillingFrequency: boolean;
+    readonly asChangeBillingFrequency: {
+      readonly frequency: u64;
+    } & Struct;
+    readonly isAttachSolutionProviderId: boolean;
+    readonly asAttachSolutionProviderId: {
+      readonly contractId: u64;
+      readonly solutionProviderId: u64;
+    } & Struct;
+    readonly isSetDedicatedNodeExtraFee: boolean;
+    readonly asSetDedicatedNodeExtraFee: {
+      readonly nodeId: u32;
+      readonly extraFee: u64;
+    } & Struct;
+    readonly isCancelContractCollective: boolean;
+    readonly asCancelContractCollective: {
+      readonly contractId: u64;
+    } & Struct;
+    readonly type:
+      | "CreateNodeContract"
+      | "UpdateNodeContract"
+      | "CancelContract"
+      | "CreateNameContract"
+      | "AddNruReports"
+      | "ReportContractResources"
+      | "CreateRentContract"
+      | "CreateSolutionProvider"
+      | "ApproveSolutionProvider"
+      | "BillContractForBlock"
+      | "ServiceContractCreate"
+      | "ServiceContractSetMetadata"
+      | "ServiceContractSetFees"
+      | "ServiceContractApprove"
+      | "ServiceContractReject"
+      | "ServiceContractCancel"
+      | "ServiceContractBill"
+      | "ChangeBillingFrequency"
+      | "AttachSolutionProviderId"
+      | "SetDedicatedNodeExtraFee"
+      | "CancelContractCollective";
+  }
+
+  /** @name PalletTftBridgeCall (211) */
+  interface PalletTftBridgeCall extends Enum {
+    readonly isAddBridgeValidator: boolean;
+    readonly asAddBridgeValidator: {
+      readonly target: AccountId32;
+    } & Struct;
+    readonly isRemoveBridgeValidator: boolean;
+    readonly asRemoveBridgeValidator: {
+      readonly target: AccountId32;
+    } & Struct;
+    readonly isSetFeeAccount: boolean;
+    readonly asSetFeeAccount: {
+      readonly target: AccountId32;
+    } & Struct;
+    readonly isSetWithdrawFee: boolean;
+    readonly asSetWithdrawFee: {
+      readonly amount: u64;
+    } & Struct;
+    readonly isSetDepositFee: boolean;
+    readonly asSetDepositFee: {
+      readonly amount: u64;
+    } & Struct;
+    readonly isSwapToStellar: boolean;
+    readonly asSwapToStellar: {
+      readonly targetStellarAddress: Bytes;
+      readonly amount: u128;
+    } & Struct;
+    readonly isProposeOrVoteMintTransaction: boolean;
+    readonly asProposeOrVoteMintTransaction: {
+      readonly transaction: Bytes;
+      readonly target: AccountId32;
+      readonly amount: u64;
+    } & Struct;
+    readonly isProposeBurnTransactionOrAddSig: boolean;
+    readonly asProposeBurnTransactionOrAddSig: {
+      readonly transactionId: u64;
+      readonly target: Bytes;
+      readonly amount: u64;
+      readonly signature: Bytes;
+      readonly stellarPubKey: Bytes;
+      readonly sequenceNumber: u64;
+    } & Struct;
+    readonly isSetBurnTransactionExecuted: boolean;
+    readonly asSetBurnTransactionExecuted: {
+      readonly transactionId: u64;
+    } & Struct;
+    readonly isCreateRefundTransactionOrAddSig: boolean;
+    readonly asCreateRefundTransactionOrAddSig: {
+      readonly txHash: Bytes;
+      readonly target: Bytes;
+      readonly amount: u64;
+      readonly signature: Bytes;
+      readonly stellarPubKey: Bytes;
+      readonly sequenceNumber: u64;
+    } & Struct;
+    readonly isSetRefundTransactionExecuted: boolean;
+    readonly asSetRefundTransactionExecuted: {
+      readonly txHash: Bytes;
+    } & Struct;
+    readonly type:
+      | "AddBridgeValidator"
+      | "RemoveBridgeValidator"
+      | "SetFeeAccount"
+      | "SetWithdrawFee"
+      | "SetDepositFee"
+      | "SwapToStellar"
+      | "ProposeOrVoteMintTransaction"
+      | "ProposeBurnTransactionOrAddSig"
+      | "SetBurnTransactionExecuted"
+      | "CreateRefundTransactionOrAddSig"
+      | "SetRefundTransactionExecuted";
+  }
+
+  /** @name PalletTftPriceCall (212) */
+  interface PalletTftPriceCall extends Enum {
+    readonly isSetPrices: boolean;
+    readonly asSetPrices: {
+      readonly price: u32;
+      readonly blockNumber: u32;
+    } & Struct;
+    readonly isSetMinTftPrice: boolean;
+    readonly asSetMinTftPrice: {
+      readonly price: u32;
+    } & Struct;
+    readonly isSetMaxTftPrice: boolean;
+    readonly asSetMaxTftPrice: {
+      readonly price: u32;
+    } & Struct;
+    readonly type: "SetPrices" | "SetMinTftPrice" | "SetMaxTftPrice";
+  }
+
+  /** @name PalletBurningCall (213) */
+  interface PalletBurningCall extends Enum {
+    readonly isBurnTft: boolean;
+    readonly asBurnTft: {
+      readonly amount: u128;
+      readonly message: Bytes;
+    } & Struct;
+    readonly type: "BurnTft";
+  }
+
+  /** @name PalletKvstoreCall (214) */
+  interface PalletKvstoreCall extends Enum {
+    readonly isSet: boolean;
+    readonly asSet: {
+      readonly key: Bytes;
+      readonly value: Bytes;
+    } & Struct;
+    readonly isDelete: boolean;
+    readonly asDelete: {
+      readonly key: Bytes;
+    } & Struct;
+    readonly type: "Set" | "Delete";
+  }
+
+  /** @name PalletRuntimeUpgradeCall (215) */
+  interface PalletRuntimeUpgradeCall extends Enum {
+    readonly isSetCode: boolean;
+    readonly asSetCode: {
+      readonly code: Bytes;
+    } & Struct;
+    readonly type: "SetCode";
+  }
+
+  /** @name PalletCollectiveCall (216) */
+  interface PalletCollectiveCall extends Enum {
+    readonly isSetMembers: boolean;
+    readonly asSetMembers: {
+      readonly newMembers: Vec<AccountId32>;
+      readonly prime: Option<AccountId32>;
+      readonly oldCount: u32;
+    } & Struct;
+    readonly isExecute: boolean;
+    readonly asExecute: {
+      readonly proposal: Call;
+      readonly lengthBound: Compact<u32>;
+    } & Struct;
+    readonly isPropose: boolean;
+    readonly asPropose: {
+      readonly threshold: Compact<u32>;
+      readonly proposal: Call;
+      readonly lengthBound: Compact<u32>;
+    } & Struct;
+    readonly isVote: boolean;
+    readonly asVote: {
+      readonly proposal: H256;
+      readonly index: Compact<u32>;
+      readonly approve: bool;
+    } & Struct;
+    readonly isDisapproveProposal: boolean;
+    readonly asDisapproveProposal: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isClose: boolean;
+    readonly asClose: {
+      readonly proposalHash: H256;
+      readonly index: Compact<u32>;
+      readonly proposalWeightBound: SpWeightsWeightV2Weight;
+      readonly lengthBound: Compact<u32>;
+    } & Struct;
+    readonly type: "SetMembers" | "Execute" | "Propose" | "Vote" | "DisapproveProposal" | "Close";
+  }
+
+  /** @name PalletMembershipCall (217) */
+  interface PalletMembershipCall extends Enum {
+    readonly isAddMember: boolean;
+    readonly asAddMember: {
+      readonly who: MultiAddress;
+    } & Struct;
+    readonly isRemoveMember: boolean;
+    readonly asRemoveMember: {
+      readonly who: MultiAddress;
+    } & Struct;
+    readonly isSwapMember: boolean;
+    readonly asSwapMember: {
+      readonly remove: MultiAddress;
+      readonly add: MultiAddress;
+    } & Struct;
+    readonly isResetMembers: boolean;
+    readonly asResetMembers: {
+      readonly members: Vec<AccountId32>;
+    } & Struct;
+    readonly isChangeKey: boolean;
+    readonly asChangeKey: {
+      readonly new_: MultiAddress;
+    } & Struct;
+    readonly isSetPrime: boolean;
+    readonly asSetPrime: {
+      readonly who: MultiAddress;
+    } & Struct;
+    readonly isClearPrime: boolean;
+    readonly type:
+      | "AddMember"
+      | "RemoveMember"
+      | "SwapMember"
+      | "ResetMembers"
+      | "ChangeKey"
+      | "SetPrime"
+      | "ClearPrime";
+  }
+
+  /** @name PalletDaoCall (218) */
+  interface PalletDaoCall extends Enum {
+    readonly isPropose: boolean;
+    readonly asPropose: {
+      readonly threshold: Compact<u32>;
+      readonly action: Call;
+      readonly description: Bytes;
+      readonly link: Bytes;
+      readonly duration: Option<u32>;
+    } & Struct;
+    readonly isVote: boolean;
+    readonly asVote: {
+      readonly farmId: u32;
+      readonly proposalHash: H256;
+      readonly approve: bool;
+    } & Struct;
+    readonly isVeto: boolean;
+    readonly asVeto: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isClose: boolean;
+    readonly asClose: {
+      readonly proposalHash: H256;
+      readonly proposalIndex: Compact<u32>;
+    } & Struct;
+    readonly type: "Propose" | "Vote" | "Veto" | "Close";
+  }
+
+  /** @name PalletValidatorCall (219) */
+  interface PalletValidatorCall extends Enum {
+    readonly isCreateValidatorRequest: boolean;
+    readonly asCreateValidatorRequest: {
+      readonly validatorNodeAccount: AccountId32;
+      readonly stashAccount: AccountId32;
+      readonly description: Bytes;
+      readonly tfConnectId: Bytes;
+      readonly info: Bytes;
+    } & Struct;
+    readonly isActivateValidatorNode: boolean;
+    readonly isChangeValidatorNodeAccount: boolean;
+    readonly asChangeValidatorNodeAccount: {
+      readonly newNodeValidatorAccount: AccountId32;
+    } & Struct;
+    readonly isBond: boolean;
+    readonly asBond: {
+      readonly validator: MultiAddress;
+    } & Struct;
+    readonly isApproveValidator: boolean;
+    readonly asApproveValidator: {
+      readonly validatorAccount: MultiAddress;
+    } & Struct;
+    readonly isRemoveValidator: boolean;
+    readonly asRemoveValidator: {
+      readonly validatorAccount: MultiAddress;
+    } & Struct;
+    readonly type:
+      | "CreateValidatorRequest"
+      | "ActivateValidatorNode"
+      | "ChangeValidatorNodeAccount"
+      | "Bond"
+      | "ApproveValidator"
+      | "RemoveValidator";
+  }
+
+  /** @name TfchainRuntimeOriginCaller (220) */
+  interface TfchainRuntimeOriginCaller extends Enum {
+    readonly isSystem: boolean;
+    readonly asSystem: FrameSupportDispatchRawOrigin;
+    readonly isVoid: boolean;
+    readonly isCouncil: boolean;
+    readonly asCouncil: PalletCollectiveRawOrigin;
+    readonly type: "System" | "Void" | "Council";
+  }
+
+  /** @name FrameSupportDispatchRawOrigin (221) */
+  interface FrameSupportDispatchRawOrigin extends Enum {
+    readonly isRoot: boolean;
+    readonly isSigned: boolean;
+    readonly asSigned: AccountId32;
+    readonly isNone: boolean;
+    readonly type: "Root" | "Signed" | "None";
+  }
+
+  /** @name PalletCollectiveRawOrigin (222) */
+  interface PalletCollectiveRawOrigin extends Enum {
+    readonly isMembers: boolean;
+    readonly asMembers: ITuple<[u32, u32]>;
+    readonly isMember: boolean;
+    readonly asMember: AccountId32;
+    readonly isPhantom: boolean;
+    readonly type: "Members" | "Member" | "Phantom";
+  }
+
+  /** @name PalletUtilityError (223) */
+  interface PalletUtilityError extends Enum {
+    readonly isTooManyCalls: boolean;
+    readonly type: "TooManyCalls";
+  }
+
+  /** @name PalletSchedulerScheduled (226) */
+  interface PalletSchedulerScheduled extends Struct {
+    readonly maybeId: Option<U8aFixed>;
+    readonly priority: u8;
+    readonly call: FrameSupportPreimagesBounded;
+    readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+    readonly origin: TfchainRuntimeOriginCaller;
+  }
+
+  /** @name FrameSupportPreimagesBounded (227) */
+  interface FrameSupportPreimagesBounded extends Enum {
+    readonly isLegacy: boolean;
+    readonly asLegacy: {
+      readonly hash_: H256;
+    } & Struct;
+    readonly isInline: boolean;
+    readonly asInline: Bytes;
+    readonly isLookup: boolean;
+    readonly asLookup: {
+      readonly hash_: H256;
+      readonly len: u32;
+    } & Struct;
+    readonly type: "Legacy" | "Inline" | "Lookup";
+  }
+
+  /** @name PalletSchedulerError (229) */
+  interface PalletSchedulerError extends Enum {
+    readonly isFailedToSchedule: boolean;
+    readonly isNotFound: boolean;
+    readonly isTargetBlockNumberInPast: boolean;
+    readonly isRescheduleNoChange: boolean;
+    readonly isNamed: boolean;
+    readonly type: "FailedToSchedule" | "NotFound" | "TargetBlockNumberInPast" | "RescheduleNoChange" | "Named";
+  }
+
+  /** @name SubstrateValidatorSetError (230) */
+  interface SubstrateValidatorSetError extends Enum {
+    readonly isTooLowValidatorCount: boolean;
+    readonly isDuplicate: boolean;
+    readonly isValidatorNotApproved: boolean;
+    readonly isBadOrigin: boolean;
+    readonly type: "TooLowValidatorCount" | "Duplicate" | "ValidatorNotApproved" | "BadOrigin";
+  }
+
+  /** @name SpCoreCryptoKeyTypeId (235) */
+  interface SpCoreCryptoKeyTypeId extends U8aFixed {}
+
+  /** @name PalletSessionError (236) */
+  interface PalletSessionError extends Enum {
+    readonly isInvalidProof: boolean;
+    readonly isNoAssociatedValidatorId: boolean;
+    readonly isDuplicatedKey: boolean;
+    readonly isNoKeys: boolean;
+    readonly isNoAccount: boolean;
+    readonly type: "InvalidProof" | "NoAssociatedValidatorId" | "DuplicatedKey" | "NoKeys" | "NoAccount";
+  }
+
+  /** @name PalletGrandpaStoredState (240) */
+  interface PalletGrandpaStoredState extends Enum {
+    readonly isLive: boolean;
+    readonly isPendingPause: boolean;
+    readonly asPendingPause: {
+      readonly scheduledAt: u32;
+      readonly delay: u32;
+    } & Struct;
+    readonly isPaused: boolean;
+    readonly isPendingResume: boolean;
+    readonly asPendingResume: {
+      readonly scheduledAt: u32;
+      readonly delay: u32;
+    } & Struct;
+    readonly type: "Live" | "PendingPause" | "Paused" | "PendingResume";
+  }
+
+  /** @name PalletGrandpaStoredPendingChange (241) */
+  interface PalletGrandpaStoredPendingChange extends Struct {
+    readonly scheduledAt: u32;
+    readonly delay: u32;
+    readonly nextAuthorities: Vec<ITuple<[SpConsensusGrandpaAppPublic, u64]>>;
+    readonly forced: Option<u32>;
+  }
+
+  /** @name PalletGrandpaError (243) */
+  interface PalletGrandpaError extends Enum {
+    readonly isPauseFailed: boolean;
+    readonly isResumeFailed: boolean;
+    readonly isChangePending: boolean;
+    readonly isTooSoon: boolean;
+    readonly isInvalidKeyOwnershipProof: boolean;
+    readonly isInvalidEquivocationProof: boolean;
+    readonly isDuplicateOffenceReport: boolean;
+    readonly type:
+      | "PauseFailed"
+      | "ResumeFailed"
+      | "ChangePending"
+      | "TooSoon"
+      | "InvalidKeyOwnershipProof"
+      | "InvalidEquivocationProof"
+      | "DuplicateOffenceReport";
+  }
+
+  /** @name PalletBalancesBalanceLock (245) */
+  interface PalletBalancesBalanceLock extends Struct {
+    readonly id: U8aFixed;
+    readonly amount: u128;
+    readonly reasons: PalletBalancesReasons;
+  }
+
+  /** @name PalletBalancesReasons (246) */
+  interface PalletBalancesReasons extends Enum {
+    readonly isFee: boolean;
+    readonly isMisc: boolean;
+    readonly isAll: boolean;
+    readonly type: "Fee" | "Misc" | "All";
+  }
+
+  /** @name PalletBalancesReserveData (249) */
+  interface PalletBalancesReserveData extends Struct {
+    readonly id: U8aFixed;
+    readonly amount: u128;
+  }
+
+  /** @name PalletBalancesIdAmount (252) */
+  interface PalletBalancesIdAmount extends Struct {
+    readonly id: Null;
+    readonly amount: u128;
+  }
+
+  /** @name PalletBalancesError (254) */
+  interface PalletBalancesError extends Enum {
+    readonly isVestingBalance: boolean;
+    readonly isLiquidityRestrictions: boolean;
+    readonly isInsufficientBalance: boolean;
+    readonly isExistentialDeposit: boolean;
+    readonly isExpendability: boolean;
+    readonly isExistingVestingSchedule: boolean;
+    readonly isDeadAccount: boolean;
+    readonly isTooManyReserves: boolean;
+    readonly isTooManyHolds: boolean;
+    readonly isTooManyFreezes: boolean;
+    readonly type:
+      | "VestingBalance"
+      | "LiquidityRestrictions"
+      | "InsufficientBalance"
+      | "ExistentialDeposit"
+      | "Expendability"
+      | "ExistingVestingSchedule"
+      | "DeadAccount"
+      | "TooManyReserves"
+      | "TooManyHolds"
+      | "TooManyFreezes";
+  }
+
+  /** @name PalletTransactionPaymentReleases (256) */
+  interface PalletTransactionPaymentReleases extends Enum {
+    readonly isV1Ancient: boolean;
+    readonly isV2: boolean;
+    readonly type: "V1Ancient" | "V2";
+  }
+
+  /** @name PalletTfgridTermsCondTermsAndConditions (258) */
+  interface PalletTfgridTermsCondTermsAndConditions extends Struct {
+    readonly accountId: AccountId32;
+    readonly timestamp: u64;
+    readonly documentLink: Bytes;
+    readonly documentHash: Bytes;
+  }
+
+  /** @name TfchainSupportNodePower (259) */
+  interface TfchainSupportNodePower extends Struct {
+    readonly state: TfchainSupportPowerState;
+    readonly target: TfchainSupportPower;
+  }
+
+  /** @name PalletTfgridError (260) */
+  interface PalletTfgridError extends Enum {
+    readonly isNoneValue: boolean;
+    readonly isStorageOverflow: boolean;
+    readonly isCannotCreateNode: boolean;
+    readonly isNodeNotExists: boolean;
+    readonly isNodeWithTwinIdExists: boolean;
+    readonly isCannotDeleteNode: boolean;
+    readonly isNodeDeleteNotAuthorized: boolean;
+    readonly isNodeUpdateNotAuthorized: boolean;
+    readonly isFarmExists: boolean;
+    readonly isFarmNotExists: boolean;
+    readonly isCannotCreateFarmWrongTwin: boolean;
+    readonly isCannotUpdateFarmWrongTwin: boolean;
+    readonly isCannotDeleteFarm: boolean;
+    readonly isCannotDeleteFarmWithPublicIPs: boolean;
+    readonly isCannotDeleteFarmWithNodesAssigned: boolean;
+    readonly isCannotDeleteFarmWrongTwin: boolean;
+    readonly isIpExists: boolean;
+    readonly isIpNotExists: boolean;
+    readonly isEntityWithNameExists: boolean;
+    readonly isEntityWithPubkeyExists: boolean;
+    readonly isEntityNotExists: boolean;
+    readonly isEntitySignatureDoesNotMatch: boolean;
+    readonly isEntityWithSignatureAlreadyExists: boolean;
+    readonly isCannotUpdateEntity: boolean;
+    readonly isCannotDeleteEntity: boolean;
+    readonly isSignatureLengthIsIncorrect: boolean;
+    readonly isTwinExists: boolean;
+    readonly isTwinNotExists: boolean;
+    readonly isTwinWithPubkeyExists: boolean;
+    readonly isCannotCreateTwin: boolean;
+    readonly isUnauthorizedToUpdateTwin: boolean;
+    readonly isTwinCannotBoundToItself: boolean;
+    readonly isPricingPolicyExists: boolean;
+    readonly isPricingPolicyNotExists: boolean;
+    readonly isPricingPolicyWithDifferentIdExists: boolean;
+    readonly isCertificationCodeExists: boolean;
+    readonly isFarmingPolicyAlreadyExists: boolean;
+    readonly isFarmPayoutAdressAlreadyRegistered: boolean;
+    readonly isFarmerDoesNotHaveEnoughFunds: boolean;
+    readonly isUserDidNotSignTermsAndConditions: boolean;
+    readonly isFarmerDidNotSignTermsAndConditions: boolean;
+    readonly isFarmerNotAuthorized: boolean;
+    readonly isInvalidFarmName: boolean;
+    readonly isAlreadyCertifier: boolean;
+    readonly isNotCertifier: boolean;
+    readonly isNotAllowedToCertifyNode: boolean;
+    readonly isFarmingPolicyNotExists: boolean;
+    readonly isRelayTooShort: boolean;
+    readonly isRelayTooLong: boolean;
+    readonly isInvalidRelay: boolean;
+    readonly isFarmNameTooShort: boolean;
+    readonly isFarmNameTooLong: boolean;
+    readonly isInvalidPublicIP: boolean;
+    readonly isPublicIPTooShort: boolean;
+    readonly isPublicIPTooLong: boolean;
+    readonly isGatewayIPTooShort: boolean;
+    readonly isGatewayIPTooLong: boolean;
+    readonly isIp4TooShort: boolean;
+    readonly isIp4TooLong: boolean;
+    readonly isInvalidIP4: boolean;
+    readonly isGw4TooShort: boolean;
+    readonly isGw4TooLong: boolean;
+    readonly isInvalidGW4: boolean;
+    readonly isIp6TooShort: boolean;
+    readonly isIp6TooLong: boolean;
+    readonly isInvalidIP6: boolean;
+    readonly isGw6TooShort: boolean;
+    readonly isGw6TooLong: boolean;
+    readonly isInvalidGW6: boolean;
+    readonly isDomainTooShort: boolean;
+    readonly isDomainTooLong: boolean;
+    readonly isInvalidDomain: boolean;
+    readonly isMethodIsDeprecated: boolean;
+    readonly isInterfaceNameTooShort: boolean;
+    readonly isInterfaceNameTooLong: boolean;
+    readonly isInvalidInterfaceName: boolean;
+    readonly isInterfaceMacTooShort: boolean;
+    readonly isInterfaceMacTooLong: boolean;
+    readonly isInvalidMacAddress: boolean;
+    readonly isInterfaceIpTooShort: boolean;
+    readonly isInterfaceIpTooLong: boolean;
+    readonly isInvalidInterfaceIP: boolean;
+    readonly isInvalidZosVersion: boolean;
+    readonly isFarmingPolicyExpired: boolean;
+    readonly isInvalidHRUInput: boolean;
+    readonly isInvalidSRUInput: boolean;
+    readonly isInvalidCRUInput: boolean;
+    readonly isInvalidMRUInput: boolean;
+    readonly isLatitudeInputTooShort: boolean;
+    readonly isLatitudeInputTooLong: boolean;
+    readonly isInvalidLatitudeInput: boolean;
+    readonly isLongitudeInputTooShort: boolean;
+    readonly isLongitudeInputTooLong: boolean;
+    readonly isInvalidLongitudeInput: boolean;
+    readonly isCountryNameTooShort: boolean;
+    readonly isCountryNameTooLong: boolean;
+    readonly isInvalidCountryName: boolean;
+    readonly isCityNameTooShort: boolean;
+    readonly isCityNameTooLong: boolean;
+    readonly isInvalidCityName: boolean;
+    readonly isInvalidCountryCityPair: boolean;
+    readonly isSerialNumberTooShort: boolean;
+    readonly isSerialNumberTooLong: boolean;
+    readonly isInvalidSerialNumber: boolean;
+    readonly isDocumentLinkInputTooShort: boolean;
+    readonly isDocumentLinkInputTooLong: boolean;
+    readonly isInvalidDocumentLinkInput: boolean;
+    readonly isDocumentHashInputTooShort: boolean;
+    readonly isDocumentHashInputTooLong: boolean;
+    readonly isInvalidDocumentHashInput: boolean;
+    readonly isInvalidPublicConfig: boolean;
+    readonly isUnauthorizedToChangePowerTarget: boolean;
+    readonly isNodeHasActiveContracts: boolean;
+    readonly isInvalidRelayAddress: boolean;
+    readonly isInvalidTimestampHint: boolean;
+    readonly isInvalidStorageInput: boolean;
+    readonly type:
+      | "NoneValue"
+      | "StorageOverflow"
+      | "CannotCreateNode"
+      | "NodeNotExists"
+      | "NodeWithTwinIdExists"
+      | "CannotDeleteNode"
+      | "NodeDeleteNotAuthorized"
+      | "NodeUpdateNotAuthorized"
+      | "FarmExists"
+      | "FarmNotExists"
+      | "CannotCreateFarmWrongTwin"
+      | "CannotUpdateFarmWrongTwin"
+      | "CannotDeleteFarm"
+      | "CannotDeleteFarmWithPublicIPs"
+      | "CannotDeleteFarmWithNodesAssigned"
+      | "CannotDeleteFarmWrongTwin"
+      | "IpExists"
+      | "IpNotExists"
+      | "EntityWithNameExists"
+      | "EntityWithPubkeyExists"
+      | "EntityNotExists"
+      | "EntitySignatureDoesNotMatch"
+      | "EntityWithSignatureAlreadyExists"
+      | "CannotUpdateEntity"
+      | "CannotDeleteEntity"
+      | "SignatureLengthIsIncorrect"
+      | "TwinExists"
+      | "TwinNotExists"
+      | "TwinWithPubkeyExists"
+      | "CannotCreateTwin"
+      | "UnauthorizedToUpdateTwin"
+      | "TwinCannotBoundToItself"
+      | "PricingPolicyExists"
+      | "PricingPolicyNotExists"
+      | "PricingPolicyWithDifferentIdExists"
+      | "CertificationCodeExists"
+      | "FarmingPolicyAlreadyExists"
+      | "FarmPayoutAdressAlreadyRegistered"
+      | "FarmerDoesNotHaveEnoughFunds"
+      | "UserDidNotSignTermsAndConditions"
+      | "FarmerDidNotSignTermsAndConditions"
+      | "FarmerNotAuthorized"
+      | "InvalidFarmName"
+      | "AlreadyCertifier"
+      | "NotCertifier"
+      | "NotAllowedToCertifyNode"
+      | "FarmingPolicyNotExists"
+      | "RelayTooShort"
+      | "RelayTooLong"
+      | "InvalidRelay"
+      | "FarmNameTooShort"
+      | "FarmNameTooLong"
+      | "InvalidPublicIP"
+      | "PublicIPTooShort"
+      | "PublicIPTooLong"
+      | "GatewayIPTooShort"
+      | "GatewayIPTooLong"
+      | "Ip4TooShort"
+      | "Ip4TooLong"
+      | "InvalidIP4"
+      | "Gw4TooShort"
+      | "Gw4TooLong"
+      | "InvalidGW4"
+      | "Ip6TooShort"
+      | "Ip6TooLong"
+      | "InvalidIP6"
+      | "Gw6TooShort"
+      | "Gw6TooLong"
+      | "InvalidGW6"
+      | "DomainTooShort"
+      | "DomainTooLong"
+      | "InvalidDomain"
+      | "MethodIsDeprecated"
+      | "InterfaceNameTooShort"
+      | "InterfaceNameTooLong"
+      | "InvalidInterfaceName"
+      | "InterfaceMacTooShort"
+      | "InterfaceMacTooLong"
+      | "InvalidMacAddress"
+      | "InterfaceIpTooShort"
+      | "InterfaceIpTooLong"
+      | "InvalidInterfaceIP"
+      | "InvalidZosVersion"
+      | "FarmingPolicyExpired"
+      | "InvalidHRUInput"
+      | "InvalidSRUInput"
+      | "InvalidCRUInput"
+      | "InvalidMRUInput"
+      | "LatitudeInputTooShort"
+      | "LatitudeInputTooLong"
+      | "InvalidLatitudeInput"
+      | "LongitudeInputTooShort"
+      | "LongitudeInputTooLong"
+      | "InvalidLongitudeInput"
+      | "CountryNameTooShort"
+      | "CountryNameTooLong"
+      | "InvalidCountryName"
+      | "CityNameTooShort"
+      | "CityNameTooLong"
+      | "InvalidCityName"
+      | "InvalidCountryCityPair"
+      | "SerialNumberTooShort"
+      | "SerialNumberTooLong"
+      | "InvalidSerialNumber"
+      | "DocumentLinkInputTooShort"
+      | "DocumentLinkInputTooLong"
+      | "InvalidDocumentLinkInput"
+      | "DocumentHashInputTooShort"
+      | "DocumentHashInputTooLong"
+      | "InvalidDocumentHashInput"
+      | "InvalidPublicConfig"
+      | "UnauthorizedToChangePowerTarget"
+      | "NodeHasActiveContracts"
+      | "InvalidRelayAddress"
+      | "InvalidTimestampHint"
+      | "InvalidStorageInput";
+  }
+
+  /** @name PalletSmartContractContractBillingInformation (261) */
+  interface PalletSmartContractContractBillingInformation extends Struct {
+    readonly previousNuReported: u64;
+    readonly lastUpdated: u64;
+    readonly amountUnbilled: u64;
+  }
+
+  /** @name PalletSmartContractContractLock (264) */
+  interface PalletSmartContractContractLock extends Struct {
+    readonly amountLocked: u128;
+    readonly extraAmountLocked: u128;
+    readonly lockUpdated: u64;
+    readonly cycles: u16;
+  }
+
+  /** @name PalletSmartContractStorageVersion (265) */
+  interface PalletSmartContractStorageVersion extends Enum {
+    readonly isV1: boolean;
+    readonly isV2: boolean;
+    readonly isV3: boolean;
+    readonly isV4: boolean;
+    readonly isV5: boolean;
+    readonly isV6: boolean;
+    readonly isV7: boolean;
+    readonly isV8: boolean;
+    readonly isV9: boolean;
+    readonly isV10: boolean;
+    readonly isV11: boolean;
+    readonly type: "V1" | "V2" | "V3" | "V4" | "V5" | "V6" | "V7" | "V8" | "V9" | "V10" | "V11";
+  }
+
+  /** @name PalletSmartContractError (266) */
+  interface PalletSmartContractError extends Enum {
+    readonly isTwinNotExists: boolean;
+    readonly isNodeNotExists: boolean;
+    readonly isFarmNotExists: boolean;
+    readonly isFarmHasNotEnoughPublicIPs: boolean;
+    readonly isFarmHasNotEnoughPublicIPsFree: boolean;
+    readonly isFailedToReserveIP: boolean;
+    readonly isFailedToFreeIPs: boolean;
+    readonly isContractNotExists: boolean;
+    readonly isTwinNotAuthorizedToUpdateContract: boolean;
+    readonly isTwinNotAuthorizedToCancelContract: boolean;
+    readonly isNodeNotAuthorizedToDeployContract: boolean;
+    readonly isNodeNotAuthorizedToComputeReport: boolean;
+    readonly isPricingPolicyNotExists: boolean;
+    readonly isContractIsNotUnique: boolean;
+    readonly isContractWrongBillingLoopIndex: boolean;
+    readonly isNameExists: boolean;
+    readonly isNameNotValid: boolean;
+    readonly isInvalidContractType: boolean;
+    readonly isTftPriceValueError: boolean;
+    readonly isNotEnoughResourcesOnNode: boolean;
+    readonly isNodeNotAuthorizedToReportResources: boolean;
+    readonly isMethodIsDeprecated: boolean;
+    readonly isNodeHasActiveContracts: boolean;
+    readonly isNodeHasRentContract: boolean;
+    readonly isFarmIsNotDedicated: boolean;
+    readonly isNodeNotAvailableToDeploy: boolean;
+    readonly isCannotUpdateContractInGraceState: boolean;
+    readonly isNumOverflow: boolean;
+    readonly isOffchainSignedTxCannotSign: boolean;
+    readonly isOffchainSignedTxAlreadySent: boolean;
+    readonly isOffchainSignedTxNoLocalAccountAvailable: boolean;
+    readonly isNameContractNameTooShort: boolean;
+    readonly isNameContractNameTooLong: boolean;
+    readonly isInvalidProviderConfiguration: boolean;
+    readonly isNoSuchSolutionProvider: boolean;
+    readonly isSolutionProviderNotApproved: boolean;
+    readonly isTwinNotAuthorized: boolean;
+    readonly isServiceContractNotExists: boolean;
+    readonly isServiceContractCreationNotAllowed: boolean;
+    readonly isServiceContractModificationNotAllowed: boolean;
+    readonly isServiceContractApprovalNotAllowed: boolean;
+    readonly isServiceContractRejectionNotAllowed: boolean;
+    readonly isServiceContractBillingNotApprovedByBoth: boolean;
+    readonly isServiceContractBillingVariableAmountTooHigh: boolean;
+    readonly isServiceContractBillMetadataTooLong: boolean;
+    readonly isServiceContractMetadataTooLong: boolean;
+    readonly isServiceContractNotEnoughFundsToPayBill: boolean;
+    readonly isCanOnlyIncreaseFrequency: boolean;
+    readonly isIsNotAnAuthority: boolean;
+    readonly isWrongAuthority: boolean;
+    readonly isUnauthorizedToChangeSolutionProviderId: boolean;
+    readonly isUnauthorizedToSetExtraFee: boolean;
+    readonly type:
+      | "TwinNotExists"
+      | "NodeNotExists"
+      | "FarmNotExists"
+      | "FarmHasNotEnoughPublicIPs"
+      | "FarmHasNotEnoughPublicIPsFree"
+      | "FailedToReserveIP"
+      | "FailedToFreeIPs"
+      | "ContractNotExists"
+      | "TwinNotAuthorizedToUpdateContract"
+      | "TwinNotAuthorizedToCancelContract"
+      | "NodeNotAuthorizedToDeployContract"
+      | "NodeNotAuthorizedToComputeReport"
+      | "PricingPolicyNotExists"
+      | "ContractIsNotUnique"
+      | "ContractWrongBillingLoopIndex"
+      | "NameExists"
+      | "NameNotValid"
+      | "InvalidContractType"
+      | "TftPriceValueError"
+      | "NotEnoughResourcesOnNode"
+      | "NodeNotAuthorizedToReportResources"
+      | "MethodIsDeprecated"
+      | "NodeHasActiveContracts"
+      | "NodeHasRentContract"
+      | "FarmIsNotDedicated"
+      | "NodeNotAvailableToDeploy"
+      | "CannotUpdateContractInGraceState"
+      | "NumOverflow"
+      | "OffchainSignedTxCannotSign"
+      | "OffchainSignedTxAlreadySent"
+      | "OffchainSignedTxNoLocalAccountAvailable"
+      | "NameContractNameTooShort"
+      | "NameContractNameTooLong"
+      | "InvalidProviderConfiguration"
+      | "NoSuchSolutionProvider"
+      | "SolutionProviderNotApproved"
+      | "TwinNotAuthorized"
+      | "ServiceContractNotExists"
+      | "ServiceContractCreationNotAllowed"
+      | "ServiceContractModificationNotAllowed"
+      | "ServiceContractApprovalNotAllowed"
+      | "ServiceContractRejectionNotAllowed"
+      | "ServiceContractBillingNotApprovedByBoth"
+      | "ServiceContractBillingVariableAmountTooHigh"
+      | "ServiceContractBillMetadataTooLong"
+      | "ServiceContractMetadataTooLong"
+      | "ServiceContractNotEnoughFundsToPayBill"
+      | "CanOnlyIncreaseFrequency"
+      | "IsNotAnAuthority"
+      | "WrongAuthority"
+      | "UnauthorizedToChangeSolutionProviderId"
+      | "UnauthorizedToSetExtraFee";
+  }
+
+  /** @name PalletTftBridgeStorageVersion (267) */
+  interface PalletTftBridgeStorageVersion extends Enum {
+    readonly isV1: boolean;
+    readonly isV2: boolean;
+    readonly type: "V1" | "V2";
+  }
+
+  /** @name PalletTftBridgeError (268) */
+  interface PalletTftBridgeError extends Enum {
+    readonly isValidatorExists: boolean;
+    readonly isValidatorNotExists: boolean;
+    readonly isTransactionValidatorExists: boolean;
+    readonly isTransactionValidatorNotExists: boolean;
+    readonly isMintTransactionExists: boolean;
+    readonly isMintTransactionAlreadyExecuted: boolean;
+    readonly isMintTransactionNotExists: boolean;
+    readonly isBurnTransactionExists: boolean;
+    readonly isBurnTransactionNotExists: boolean;
+    readonly isBurnSignatureExists: boolean;
+    readonly isEnoughBurnSignaturesPresent: boolean;
+    readonly isRefundSignatureExists: boolean;
+    readonly isBurnTransactionAlreadyExecuted: boolean;
+    readonly isRefundTransactionNotExists: boolean;
+    readonly isRefundTransactionAlreadyExecuted: boolean;
+    readonly isEnoughRefundSignaturesPresent: boolean;
+    readonly isNotEnoughBalanceToSwap: boolean;
+    readonly isAmountIsLessThanWithdrawFee: boolean;
+    readonly isAmountIsLessThanDepositFee: boolean;
+    readonly isWrongParametersProvided: boolean;
+    readonly isInvalidStellarPublicKey: boolean;
+    readonly type:
+      | "ValidatorExists"
+      | "ValidatorNotExists"
+      | "TransactionValidatorExists"
+      | "TransactionValidatorNotExists"
+      | "MintTransactionExists"
+      | "MintTransactionAlreadyExecuted"
+      | "MintTransactionNotExists"
+      | "BurnTransactionExists"
+      | "BurnTransactionNotExists"
+      | "BurnSignatureExists"
+      | "EnoughBurnSignaturesPresent"
+      | "RefundSignatureExists"
+      | "BurnTransactionAlreadyExecuted"
+      | "RefundTransactionNotExists"
+      | "RefundTransactionAlreadyExecuted"
+      | "EnoughRefundSignaturesPresent"
+      | "NotEnoughBalanceToSwap"
+      | "AmountIsLessThanWithdrawFee"
+      | "AmountIsLessThanDepositFee"
+      | "WrongParametersProvided"
+      | "InvalidStellarPublicKey";
+  }
+
+  /** @name PalletTftPriceError (270) */
+  interface PalletTftPriceError extends Enum {
+    readonly isErrFetchingPrice: boolean;
+    readonly isOffchainSignedTxError: boolean;
+    readonly isNoLocalAcctForSigning: boolean;
+    readonly isAccountUnauthorizedToSetPrice: boolean;
+    readonly isMaxPriceBelowMinPriceError: boolean;
+    readonly isMinPriceAboveMaxPriceError: boolean;
+    readonly isIsNotAnAuthority: boolean;
+    readonly isWrongAuthority: boolean;
+    readonly type:
+      | "ErrFetchingPrice"
+      | "OffchainSignedTxError"
+      | "NoLocalAcctForSigning"
+      | "AccountUnauthorizedToSetPrice"
+      | "MaxPriceBelowMinPriceError"
+      | "MinPriceAboveMaxPriceError"
+      | "IsNotAnAuthority"
+      | "WrongAuthority";
+  }
+
+  /** @name PalletBurningBurn (272) */
+  interface PalletBurningBurn extends Struct {
+    readonly target: AccountId32;
+    readonly amount: u128;
+    readonly block: u32;
+    readonly message: Bytes;
+  }
+
+  /** @name PalletBurningError (273) */
+  interface PalletBurningError extends Enum {
+    readonly isNotEnoughBalanceToBurn: boolean;
+    readonly type: "NotEnoughBalanceToBurn";
+  }
+
+  /** @name PalletKvstoreError (275) */
+  interface PalletKvstoreError extends Enum {
+    readonly isNoValueStored: boolean;
+    readonly isKeyIsTooLarge: boolean;
+    readonly isValueIsTooLarge: boolean;
+    readonly type: "NoValueStored" | "KeyIsTooLarge" | "ValueIsTooLarge";
+  }
+
+  /** @name PalletCollectiveVotes (277) */
+  interface PalletCollectiveVotes extends Struct {
+    readonly index: u32;
+    readonly threshold: u32;
+    readonly ayes: Vec<AccountId32>;
+    readonly nays: Vec<AccountId32>;
+    readonly end: u32;
+  }
+
+  /** @name PalletCollectiveError (278) */
+  interface PalletCollectiveError extends Enum {
+    readonly isNotMember: boolean;
+    readonly isDuplicateProposal: boolean;
+    readonly isProposalMissing: boolean;
+    readonly isWrongIndex: boolean;
+    readonly isDuplicateVote: boolean;
+    readonly isAlreadyInitialized: boolean;
+    readonly isTooEarly: boolean;
+    readonly isTooManyProposals: boolean;
+    readonly isWrongProposalWeight: boolean;
+    readonly isWrongProposalLength: boolean;
+    readonly type:
+      | "NotMember"
+      | "DuplicateProposal"
+      | "ProposalMissing"
+      | "WrongIndex"
+      | "DuplicateVote"
+      | "AlreadyInitialized"
+      | "TooEarly"
+      | "TooManyProposals"
+      | "WrongProposalWeight"
+      | "WrongProposalLength";
+  }
+
+  /** @name PalletMembershipError (280) */
+  interface PalletMembershipError extends Enum {
+    readonly isAlreadyMember: boolean;
+    readonly isNotMember: boolean;
+    readonly isTooManyMembers: boolean;
+    readonly type: "AlreadyMember" | "NotMember" | "TooManyMembers";
+  }
+
+  /** @name PalletDaoProposalDaoProposal (281) */
+  interface PalletDaoProposalDaoProposal extends Struct {
+    readonly index: u32;
+    readonly description: Bytes;
+    readonly link: Bytes;
+  }
+
+  /** @name PalletDaoProposalDaoVotes (282) */
+  interface PalletDaoProposalDaoVotes extends Struct {
+    readonly index: u32;
+    readonly threshold: u32;
+    readonly ayes: Vec<PalletDaoProposalVoteWeight>;
+    readonly nays: Vec<PalletDaoProposalVoteWeight>;
+    readonly end: u32;
+    readonly vetos: Vec<AccountId32>;
+  }
+
+  /** @name PalletDaoProposalVoteWeight (284) */
+  interface PalletDaoProposalVoteWeight extends Struct {
+    readonly farmId: u32;
+    readonly weight: u64;
+  }
+
+  /** @name PalletDaoError (285) */
+  interface PalletDaoError extends Enum {
+    readonly isNoneValue: boolean;
+    readonly isStorageOverflow: boolean;
+    readonly isFarmNotExists: boolean;
+    readonly isNotCouncilMember: boolean;
+    readonly isWrongProposalLength: boolean;
+    readonly isDuplicateProposal: boolean;
+    readonly isNotAuthorizedToVote: boolean;
+    readonly isProposalMissing: boolean;
+    readonly isWrongIndex: boolean;
+    readonly isDuplicateVote: boolean;
+    readonly isDuplicateVeto: boolean;
+    readonly isWrongProposalWeight: boolean;
+    readonly isTooEarly: boolean;
+    readonly isTimeLimitReached: boolean;
+    readonly isOngoingVoteAndTresholdStillNotMet: boolean;
+    readonly isFarmHasNoNodes: boolean;
+    readonly isInvalidProposalDuration: boolean;
+    readonly isThresholdTooLow: boolean;
+    readonly type:
+      | "NoneValue"
+      | "StorageOverflow"
+      | "FarmNotExists"
+      | "NotCouncilMember"
+      | "WrongProposalLength"
+      | "DuplicateProposal"
+      | "NotAuthorizedToVote"
+      | "ProposalMissing"
+      | "WrongIndex"
+      | "DuplicateVote"
+      | "DuplicateVeto"
+      | "WrongProposalWeight"
+      | "TooEarly"
+      | "TimeLimitReached"
+      | "OngoingVoteAndTresholdStillNotMet"
+      | "FarmHasNoNodes"
+      | "InvalidProposalDuration"
+      | "ThresholdTooLow";
+  }
+
+  /** @name PalletValidatorError (286) */
+  interface PalletValidatorError extends Enum {
+    readonly isBadOrigin: boolean;
+    readonly isNotCouncilMember: boolean;
+    readonly isAlreadyBonded: boolean;
+    readonly isStashNotBonded: boolean;
+    readonly isStashBondedWithWrongValidator: boolean;
+    readonly isCannotBondWithSameAccount: boolean;
+    readonly isDuplicateValidator: boolean;
+    readonly isValidatorNotFound: boolean;
+    readonly isValidatorNotApproved: boolean;
+    readonly isUnauthorizedToActivateValidator: boolean;
+    readonly isValidatorValidatingAlready: boolean;
+    readonly isValidatorNotValidating: boolean;
+    readonly type:
+      | "BadOrigin"
+      | "NotCouncilMember"
+      | "AlreadyBonded"
+      | "StashNotBonded"
+      | "StashBondedWithWrongValidator"
+      | "CannotBondWithSameAccount"
+      | "DuplicateValidator"
+      | "ValidatorNotFound"
+      | "ValidatorNotApproved"
+      | "UnauthorizedToActivateValidator"
+      | "ValidatorValidatingAlready"
+      | "ValidatorNotValidating";
+  }
+
+  /** @name SpRuntimeMultiSignature (288) */
+  interface SpRuntimeMultiSignature extends Enum {
+    readonly isEd25519: boolean;
+    readonly asEd25519: SpCoreEd25519Signature;
+    readonly isSr25519: boolean;
+    readonly asSr25519: SpCoreSr25519Signature;
+    readonly isEcdsa: boolean;
+    readonly asEcdsa: SpCoreEcdsaSignature;
+    readonly type: "Ed25519" | "Sr25519" | "Ecdsa";
+  }
+
+  /** @name SpCoreSr25519Signature (289) */
+  interface SpCoreSr25519Signature extends U8aFixed {}
+
+  /** @name SpCoreEcdsaSignature (290) */
+  interface SpCoreEcdsaSignature extends U8aFixed {}
+
+  /** @name FrameSystemExtensionsCheckNonZeroSender (293) */
+  type FrameSystemExtensionsCheckNonZeroSender = Null;
+
+  /** @name FrameSystemExtensionsCheckSpecVersion (294) */
+  type FrameSystemExtensionsCheckSpecVersion = Null;
+
+  /** @name FrameSystemExtensionsCheckTxVersion (295) */
+  type FrameSystemExtensionsCheckTxVersion = Null;
+
+  /** @name FrameSystemExtensionsCheckGenesis (296) */
+  type FrameSystemExtensionsCheckGenesis = Null;
+
+  /** @name FrameSystemExtensionsCheckNonce (299) */
+  interface FrameSystemExtensionsCheckNonce extends Compact<u32> {}
+
+  /** @name FrameSystemExtensionsCheckWeight (300) */
+  type FrameSystemExtensionsCheckWeight = Null;
+
+  /** @name PalletTransactionPaymentChargeTransactionPayment (301) */
+  interface PalletTransactionPaymentChargeTransactionPayment extends Compact<u128> {}
+
+  /** @name TfchainRuntimeRuntime (302) */
+  type TfchainRuntimeRuntime = Null;
+} // declare module

--- a/packages/tfchain_client/src/interfaces/chain/types.ts
+++ b/packages/tfchain_client/src/interfaces/chain/types.ts
@@ -1,0 +1,4 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+export {};

--- a/packages/tfchain_client/src/interfaces/index.ts
+++ b/packages/tfchain_client/src/interfaces/index.ts
@@ -1,0 +1,3 @@
+export * from "./chain/augment-api";
+export * from "./chain/types-lookup";
+export * from "./chain/lookup";

--- a/packages/tfchain_client/src/nodes.ts
+++ b/packages/tfchain_client/src/nodes.ts
@@ -96,16 +96,7 @@ class Nodes extends QueryNodes {
 
   @checkConnection
   async setPower(options: SetPowerOptions) {
-    let powerTarget: { up?: boolean; down?: boolean };
-    if (options.power) {
-      powerTarget = {
-        up: options.power,
-      };
-    } else {
-      powerTarget = {
-        down: !options.power,
-      };
-    }
+    const powerTarget = options.power ? "Up" : "Down";
 
     const extrinsic = await this.client.api.tx.tfgridModule.changePowerTarget(options.nodeId, powerTarget);
     return this.client.patchExtrinsic<void>(extrinsic);

--- a/packages/tfchain_client/tsconfig-es6.json
+++ b/packages/tfchain_client/tsconfig-es6.json
@@ -21,7 +21,11 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "baseUrl": ".",
-        "skipLibCheck": true /* Skip type checking all .d.ts files. */
+        "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+        "paths": {
+            "@polkadot/types/lookup": ["src/interfaces/chain/types-lookup.ts"],
+            "@polkadot/api-augment*": ["src/interfaces/chain/augment-api.ts"]
+        }
 
     },
     "include": [

--- a/packages/tfchain_client/tsconfig-node.json
+++ b/packages/tfchain_client/tsconfig-node.json
@@ -18,7 +18,11 @@
         "experimentalDecorators": true,
         "allowJs": true,
         "baseUrl": ".",
-        "skipLibCheck": true /* Skip type checking all .d.ts files. */
+        "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+        "paths": {
+            "@polkadot/types/lookup": ["src/interfaces/chain/types-lookup.ts"],
+            "@polkadot/api-augment*": ["src/interfaces/chain/augment-api.ts"]
+        }
 
     },
     "include": [


### PR DESCRIPTION
### Description

Integrate chain types in our project provide such better development experience, We can use the generated types and check auto complete via IDE. Polkadot provides [typegen](https://www.npmjs.com/package/@polkadot/typegen) to generate pre defined types and chain types, currently, we only need the chain types.

### Changes

- create interface dir to contain the chain types
- add script to generate types and adjust the created files to pass the build
- include the created types into tsconfig-*json, to make the compiler aware of it 

## Details:
- Generate a chain types requires `@polkadot/typegen` package of the same version as `@polkadot/api`.
### Generating
First we need to have chain metadata, to generate types based on it, this is done by running the following command:
```bash
curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "state_getMetadata", "params":[]}' -o chainMeta.json <<CHAIN_URL>>
```
The result of this command will be `chainMeta.json` with a content like
```json
{ "jsonrpc": "2.0", "result": "0x6d6574610b6c185379737....", "id": 29 }
```
This file will be used in the following two commands:
- Generate defined chain types and lookup files using `polkadot-types-from-defs `
  ```bash
  ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package @threefold/tfchain_client  --input ./src/interfaces/chain --endpoint ./chainMeta.json
  ```
  > Currently we don't have defined types but this command needed to crate the lookup files, for more details see the [documentation](https://polkadot.js.org/docs/api/start/typescript.user/#definitions)
- Generate types from the chain using `polkadot-types-from-chain`
  ```bash
   ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --endpoint ./chainMeta.json --output ./src/interfaces/chain
  ```
Now types are generated, but we need to let the compiler aware of the generated types, we can do that by add the following paths to `tsconfig-*.json` inside compilerOptions.paths add those lines:
```json
 "@polkadot/types/lookup": ["src/interfaces/chain/types-lookup.ts"],
 "@polkadot/api-augment*": ["src/interfaces/chain/augment-api.ts"]
```
Finally we need to export the generated types
in `src/interfaces/index.ts`
```ts
export * from "./chain/augment-api";
export * from "./chain/types-lookup";
export * from "./chain/lookup";
```
### Usage
We need to import the augmented definitions "somewhere" as documentation says, in our case we will import them in `src/client`.
```ts
import "./interfaces";
import "@polkadot/api-augment";
```
Now we can import any type anywhere in the client as follows:
```ts
// e.g SpRuntimeModuleError
import { SpRuntimeModuleError } from "@polkadot/types/lookup";
```
There are two blockers now from building the project:
1. As we din't have any defined types `src/interfaces/chain/types` is empty and will gives an error while build, for now we just need to export an empty object on it so we add `export {}` to the file.
2. Types with reserved names:
   In `src/interfaces/chain/augment-api-tx.ts` we have `createFarmingPolicy` and `updateFarmingPolicy` functions in tfgridmodule each of them contains parameter named `default` this is not acceptable on Typescript as it is a reserved word, so we could replace it with `_default`.
> All the previous steps are collected into `scripts/generateTypes.bash`
Now everything is ready to go
make sure to build the client after that 

### Related Issues

- #3000 

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
