### PR TITLE
Prevent recursive component tree by displaying SSH keys alert

### DIFF
--- a/packages/playground/src/components/ssh_keys/ManageSshDeployemnt.vue
+++ b/packages/playground/src/components/ssh_keys/ManageSshDeployemnt.vue
@@ -134,7 +134,9 @@ export default defineComponent({
       selectedKeys.value = sshKeysManagement.list().filter(_key => _key.isActive === true);
       // TODO: Remove the below `selectedKeys.value = [selectedKeys.value[0]];` to make the user select more than one key
       // after fixing this issue: https://github.com/threefoldtech/tf-images/issues/231
-      selectedKeys.value = [selectedKeys.value[0]];
+      if (selectedKeys.value.length) {
+        selectedKeys.value = [selectedKeys.value[0]];
+      }
       handleKeys();
       emit("selectedKeys", selectedKeysString.value);
     });
@@ -173,7 +175,9 @@ export default defineComponent({
     }
 
     function handleKeys() {
-      selectedKeysString.value = selectedKeys.value.map(_key => _key.publicKey).join("\n\n");
+      if (selectedKeys.value.length) {
+        selectedKeysString.value = selectedKeys.value.map(_key => _key.publicKey).join("\n\n");
+      }
     }
 
     /* interact with form_validator */

--- a/packages/playground/src/components/view_layout.vue
+++ b/packages/playground/src/components/view_layout.vue
@@ -6,8 +6,10 @@
     />
 
     <template v-if="requireSSH && !ssh">
-      <VAlert variant="tonal" type="error" :text="title + ' requires public ssh key.'" class="mb-4" />
-      <SshkeyView />
+      <VAlert variant="tonal" type="error" class="mb-4">
+        {{ title }} requires a public SSH key. You can generate or import it from the
+        <router-link :to="DashboardRoutes.Deploy.SSHKey">SSH Keys</router-link> page.
+      </VAlert>
     </template>
     <slot v-else :key="tick" />
 
@@ -21,12 +23,11 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRoute } from "vue-router";
 
+import { DashboardRoutes } from "@/router/routes";
 import { useProfileManager } from "@/stores";
-import SshkeyView from "@/views/sshkey_view.vue";
 
 export default {
   name: "ViewLayout",
-  components: { SshkeyView },
   setup() {
     const route = useRoute();
     const profileManager = useProfileManager();
@@ -55,6 +56,7 @@ export default {
       requireSSH: computed(() => route.meta.requireSSH),
       tick,
       viewLayoutContainer,
+      DashboardRoutes,
     };
   },
 };


### PR DESCRIPTION
### Description

What happened? we normally use a view-layout component to wrap all of our views. When creating a new view, the expected structure is:

```html
<view-layout>
  ...
</view-layout>
```
Recently, the <view-layout> component has been added to the SSHKeys view. and this isn't wrong, we import the SSHKeys component within the view-layout component when there are no SSH keys. This setup creates a recursive component tree, leading to a maximum call stack size exceeded error.

### Changes

- Removed the nested '<view-layout>' component from the 'SSHKeys' view.
- Added an alert to inform users that SSH keys are required.
- Included a link in the alert to direct users to the SSH keys page for easy access.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3023

### Screenshots

- ![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/57001890/f05a100d-65db-4ce6-819d-cf6ebcec9700)


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
