### PR TITLE
Detect and Resolve nodes' resources overlapping k8s/caprover

### DIFF
--- a/packages/playground/src/components/caprover_worker.vue
+++ b/packages/playground/src/components/caprover_worker.vue
@@ -32,6 +32,8 @@
     </input-tooltip>
 
     <TfSelectionDetails
+      :selected-machines="selectedMachines"
+      :nodes-lock="nodesLock"
       :filters="{
         ipv4: true,
         certified: $props.modelValue.certified,
@@ -47,8 +49,10 @@
 </template>
 
 <script lang="ts">
+import type AwaitLock from "await-lock";
 import { computed, type PropType } from "vue";
 
+import type { SelectedMachine } from "@/types/nodeSelector";
 import { manual } from "@/utils/manual";
 
 import Networks from "../components/networks.vue";
@@ -61,17 +65,50 @@ export function createWorker(name: string = generateName({ prefix: "wr" })): Cap
   return { name, mycelium: true };
 }
 
+function toMachine(rootFilesystemSize: number, worker?: CaproverWorker): SelectedMachine | undefined {
+  if (!worker || !worker.selectionDetails || !worker.selectionDetails.node) {
+    return undefined;
+  }
+
+  return {
+    nodeId: worker.selectionDetails.node.nodeId,
+    cpu: worker.solution?.cpu ?? 0,
+    memory: worker.solution?.memory ?? 0,
+    disk: (worker.solution?.disk ?? 0) + (rootFilesystemSize ?? 0),
+  };
+}
+
 export default {
   name: "CaproverWorker",
   components: { SelectSolutionFlavor, Networks },
-  props: { modelValue: { type: Object as PropType<CaproverWorker>, required: true } },
+  props: {
+    modelValue: {
+      type: Object as PropType<CaproverWorker>,
+      required: true,
+    },
+    otherWorkers: {
+      type: Array as PropType<CaproverWorker[]>,
+      default: () => [],
+    },
+    nodesLock: Object as PropType<AwaitLock>,
+  },
   setup(props) {
     const rootFilesystemSize = computed(() => {
       const { cpu = 0, memory = 0 } = props.modelValue.solution || {};
       return rootFs(cpu, memory);
     });
 
-    return { rootFilesystemSize, manual };
+    const selectedMachines = computed(() => {
+      return props.otherWorkers.reduce((res, worker) => {
+        const machine = toMachine(rootFilesystemSize.value, worker);
+        if (machine) {
+          res.push(machine);
+        }
+        return res;
+      }, [] as SelectedMachine[]);
+    });
+
+    return { rootFilesystemSize, manual, selectedMachines };
   },
 };
 </script>

--- a/packages/playground/src/components/k8s_worker.vue
+++ b/packages/playground/src/components/k8s_worker.vue
@@ -85,6 +85,7 @@
 
     <TfSelectionDetails
       :selected-machines="selectedMachines"
+      :nodes-lock="nodesLock"
       :filters-validators="{
         memory: { min: 1024 },
         rootFilesystemSize: { min: rootFs($props.modelValue.cpu ?? 0, $props.modelValue.memory ?? 0) },
@@ -104,6 +105,7 @@
 </template>
 
 <script lang="ts">
+import type AwaitLock from "await-lock";
 import { computed, type PropType } from "vue";
 
 import type { SelectedMachine } from "@/types/nodeSelector";
@@ -157,6 +159,7 @@ export default {
       type: Array as PropType<K8SWorker[]>,
       default: () => [],
     },
+    nodesLock: Object as PropType<AwaitLock>,
   },
   setup(props) {
     const selectedMachines = computed(() => {

--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -344,6 +344,7 @@ export default {
 
         _setValidNode();
       },
+      { debounce: 1000 },
     );
 
     return {

--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -193,7 +193,9 @@ export default {
     const gridStore = useGrid();
     const _loadedNodes = ref<NodeInfo[]>([]);
     const loadedNodes = computed(() => {
-      return _loadedNodes.value.filter(node => isNodeValid(node, props.selectedMachines, filters.value));
+      return _loadedNodes.value.filter(
+        node => node.nodeId === props.modelValue?.nodeId || isNodeValid(node, props.selectedMachines, filters.value),
+      );
     });
     const nodesTask = useAsync(loadValidNodes, {
       shouldRun: () => props.validFilters,

--- a/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
@@ -219,6 +219,7 @@ export default {
     useWatchDeep(
       () => props.selectedMachines.map(m => m.nodeId),
       () => nodeId.value && validationTask.value.run(nodeId.value),
+      { debounce: 1000 },
     );
 
     // revalidate if filters updated

--- a/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
@@ -53,6 +53,7 @@
 
 <script lang="ts">
 import type { NodeInfo } from "@threefold/grid_client";
+import type AwaitLock from "await-lock";
 import isInt from "validator/lib/isInt";
 import { onUnmounted, type PropType, ref, watch } from "vue";
 
@@ -62,7 +63,7 @@ import { ValidatorStatus } from "../../hooks/form_validator";
 import { useGrid } from "../../stores";
 import type { SelectedMachine, SelectionDetailsFilters } from "../../types/nodeSelector";
 import { normalizeError } from "../../utils/helpers";
-import { checkNodeCapacityPool, nodesLock, resolveAsync, validateRentContract } from "../../utils/nodeSelector";
+import { checkNodeCapacityPool, resolveAsync, validateRentContract } from "../../utils/nodeSelector";
 import TfNodeDetailsCard from "./TfNodeDetailsCard.vue";
 
 const _defaultError =
@@ -83,6 +84,7 @@ export default {
       type: Array as PropType<SelectedMachine[]>,
       required: true,
     },
+    nodesLock: Object as PropType<AwaitLock>,
   },
   emits: {
     "update:model-value": (node?: NodeInfo) => true || node,
@@ -203,12 +205,12 @@ export default {
         onReset: bindStatus,
         shouldRun: () => props.validFilters,
         async onBeforeTask() {
-          await nodesLock.acquireAsync();
+          await props.nodesLock?.acquireAsync();
           bindStatus(ValidatorStatus.Pending);
         },
         onAfterTask: ({ data }) => {
           bindStatus(data ? ValidatorStatus.Valid : ValidatorStatus.Invalid);
-          nodesLock.release();
+          props.nodesLock?.release();
         },
       },
     );

--- a/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
@@ -63,7 +63,7 @@ import { ValidatorStatus } from "../../hooks/form_validator";
 import { useGrid } from "../../stores";
 import type { SelectedMachine, SelectionDetailsFilters } from "../../types/nodeSelector";
 import { normalizeError } from "../../utils/helpers";
-import { checkNodeCapacityPool, resolveAsync, validateRentContract } from "../../utils/nodeSelector";
+import { checkNodeCapacityPool, release, resolveAsync, validateRentContract } from "../../utils/nodeSelector";
 import TfNodeDetailsCard from "./TfNodeDetailsCard.vue";
 
 const _defaultError =
@@ -210,7 +210,7 @@ export default {
         },
         onAfterTask: ({ data }) => {
           bindStatus(data ? ValidatorStatus.Valid : ValidatorStatus.Invalid);
-          props.nodesLock?.release();
+          release(props.nodesLock);
         },
       },
     );

--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -157,7 +157,7 @@
         <VCol class="tf-node-resource">
           <ResourceDetails
             name="CPU"
-            :used="node?.used_resources.cru ?? 0"
+            :used="(node?.used_resources.cru ?? 0) + selectedMachines.reduce((r, m) => r + m.cpu, 0)"
             :total="node?.total_resources.cru ?? 0"
             :text="cruText"
             :cpuType="dmi?.processor[0]?.version"
@@ -166,7 +166,7 @@
         <VCol class="tf-node-resource">
           <ResourceDetails
             name="Memory"
-            :used="node?.used_resources.mru ?? 0"
+            :used="(node?.used_resources.mru ?? 0) + selectedMachines.reduce((r, m) => r + (m.memory / 1024) * 1e9, 0)"
             :total="node?.total_resources.mru ?? 0"
             :text="mruText"
             :memoryType="dmi?.memory[0]?.type"
@@ -178,7 +178,7 @@
         <VCol class="tf-node-resource">
           <ResourceDetails
             name="SSD Disks"
-            :used="node?.used_resources.sru ?? 0"
+            :used="(node?.used_resources.sru ?? 0) + selectedMachines.reduce((r, m) => r + m.disk * 1e9, 0)"
             :total="node?.total_resources.sru ?? 0"
             :text="sruText"
           />
@@ -238,10 +238,11 @@
 import type { GridClient, NodeInfo, NodeResources } from "@threefold/grid_client";
 import { CertificationType, type GridNode } from "@threefold/gridproxy_client";
 import { computed, onMounted, ref, watch } from "vue";
-import { capitalize } from "vue";
+import { capitalize, type PropType } from "vue";
 
 import { gridProxyClient } from "@/clients";
 import ReserveBtn from "@/dashboard/components/reserve_action_btn.vue";
+import type { SelectedMachine } from "@/types/nodeSelector";
 import toHumanDate from "@/utils/date";
 import { getCountryCode } from "@/utils/get_nodes";
 import { manual } from "@/utils/manual";
@@ -260,6 +261,7 @@ export default {
     status: String as () => "Init" | "Pending" | "Invalid" | "Valid",
     selectable: Boolean,
     flat: Boolean,
+    selectedMachines: { type: Array as PropType<SelectedMachine[]>, default: () => [] },
   },
   emits: {
     "node:select": (node: NodeInfo) => true || node,
@@ -378,7 +380,16 @@ export default {
           return "";
         }
 
-        const used = formatResourceSize(props.node.used_resources[name]);
+        let additionalUsed = 0;
+        if (name === "mru") {
+          additionalUsed = props.selectedMachines.reduce((r, m) => r + (m.memory / 1024) * 1e9, 0);
+        }
+
+        if (name === "sru") {
+          additionalUsed = props.selectedMachines.reduce((r, m) => r + m.disk * 1e9, 0);
+        }
+
+        const used = formatResourceSize(props.node.used_resources[name] + additionalUsed);
         const total = formatResourceSize(props.node.total_resources[name]);
 
         if (total === "0") return "";

--- a/packages/playground/src/components/node_selector/TfSelectionDetails.vue
+++ b/packages/playground/src/components/node_selector/TfSelectionDetails.vue
@@ -22,6 +22,7 @@
           <TfSelectFarm :valid-filters="validFilters" :filters="filters" :location="location" v-model="farm" />
           <TfAutoNodeSelector
             :selected-machines="selectedMachines"
+            :nodes-lock="nodesLock"
             :valid-filters="validFilters"
             :filters="filters"
             :location="location"
@@ -33,6 +34,7 @@
 
         <TfManualNodeSelector
           :selected-machines="selectedMachines"
+          :nodes-lock="nodesLock"
           :valid-filters="validFilters"
           :filters="filters"
           v-model="node"
@@ -69,6 +71,7 @@
 <script lang="ts">
 import type { FarmInfo, GPUCardInfo, NodeInfo } from "@threefold/grid_client";
 import { NodeStatus } from "@threefold/gridproxy_client";
+import type AwaitLock from "await-lock";
 import noop from "lodash/fp/noop.js";
 import type { DeepPartial } from "utility-types";
 import { computed, getCurrentInstance, onMounted, onUnmounted, type PropType, ref, watch } from "vue";
@@ -113,6 +116,7 @@ export default {
       type: Array as PropType<SelectedMachine[]>,
       default: () => [],
     },
+    nodesLock: Object as PropType<AwaitLock>,
   },
   emits: {
     "update:model-value": (value: SelectionDetails) => true || value,

--- a/packages/playground/src/components/node_selector/TfSelectionDetails.vue
+++ b/packages/playground/src/components/node_selector/TfSelectionDetails.vue
@@ -21,6 +21,7 @@
           <TfSelectLocation v-model="location" title="Choose a Location" :status="NodeStatus.Up" />
           <TfSelectFarm :valid-filters="validFilters" :filters="filters" :location="location" v-model="farm" />
           <TfAutoNodeSelector
+            :selected-machines="selectedMachines"
             :valid-filters="validFilters"
             :filters="filters"
             :location="location"
@@ -31,6 +32,7 @@
         </template>
 
         <TfManualNodeSelector
+          :selected-machines="selectedMachines"
           :valid-filters="validFilters"
           :filters="filters"
           v-model="node"
@@ -77,6 +79,7 @@ import type { InputValidatorService } from "../../hooks/input_validator";
 import type {
   DomainInfo,
   SelectedLocation,
+  SelectedMachine,
   SelectionDetails,
   SelectionDetailsFilters,
   SelectionDetailsFiltersValidators,
@@ -106,6 +109,10 @@ export default {
     disableNodeSelection: { type: Boolean, default: () => false },
     status: String as PropType<ValidatorStatus>,
     useFqdn: Boolean,
+    selectedMachines: {
+      type: Array as PropType<SelectedMachine[]>,
+      default: () => [],
+    },
   },
   emits: {
     "update:model-value": (value: SelectionDetails) => true || value,

--- a/packages/playground/src/types/nodeSelector.ts
+++ b/packages/playground/src/types/nodeSelector.ts
@@ -73,3 +73,10 @@ export interface SelectionDetails {
   gpuCards: GPUCardInfo[];
   domain?: DomainInfo;
 }
+
+export interface SelectedMachine {
+  nodeId: number;
+  cpu: number;
+  memory: number;
+  disk: number;
+}

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -1,6 +1,8 @@
 import type { FarmFilterOptions, FarmInfo, FilterOptions, NodeInfo } from "@threefold/grid_client";
 import type { NodeStatus } from "@threefold/gridproxy_client";
 import { GridClientErrors } from "@threefold/types";
+import AwaitLock from "await-lock";
+import shuffle from "lodash/fp/shuffle.js";
 import type { DeepPartial } from "utility-types";
 import { z } from "zod";
 
@@ -13,6 +15,7 @@ import type {
   NormalizeNodeFiltersOptions,
   NumericValidator,
   SelectedLocation,
+  SelectedMachine,
   SelectionDetailsFilters,
   SelectionDetailsFiltersValidators,
 } from "../types/nodeSelector";
@@ -242,7 +245,26 @@ export async function validateRentContract(
     throw err;
   }
 }
+
+export const nodesLock = new AwaitLock();
+
+export function releaseLoadValidNodesLock() {
+  if (nodesLock.acquired) {
+    nodesLock.release();
+  }
+}
+
 export async function loadValidNodes(
+  gridStore: ReturnType<typeof useGrid>,
+  selectionFitlers: SelectionDetailsFilters,
+  filters: FilterOptions,
+  pagination: ReturnType<typeof usePagination>,
+): Promise<NodeInfo[]> {
+  await nodesLock.acquireAsync();
+  return _loadValidNodes(gridStore, selectionFitlers, filters, pagination);
+}
+
+async function _loadValidNodes(
   gridStore: ReturnType<typeof useGrid>,
   selectionFitlers: SelectionDetailsFilters,
   filters: FilterOptions,
@@ -263,6 +285,54 @@ export async function loadValidNodes(
   }
 
   return [];
+}
+
+export function isNodeValid(node: NodeInfo, machines: SelectedMachine[], filters: FilterOptions): boolean {
+  const machinesWithSameNode = machines.filter(m => m.nodeId === node.nodeId);
+  const requiredMru = (filters.mru ?? 0) * 1e9;
+  const requiredSru = (filters.sru ?? 0) * 1e9;
+
+  let mru = node.total_resources.mru - node.used_resources.mru;
+  let sru = node.total_resources.sru - node.used_resources.sru;
+  for (const machine of machinesWithSameNode) {
+    mru -= machine.memory * 1e9;
+    sru -= machine.disk * 1e9;
+  }
+
+  console.log({ node, machinesWithSameNode, machines, requiredMru, requiredSru, mru, sru });
+
+  return mru >= requiredMru && sru >= requiredSru;
+}
+
+export async function selectValidNode(
+  nodes: NodeInfo[],
+  selectedMachines: SelectedMachine[],
+  filters: FilterOptions,
+  oldSelectedNodeId?: number,
+): Promise<NodeInfo | void> {
+  let locked = true;
+  if (!nodesLock.acquired) {
+    locked = false;
+    await nodesLock.acquireAsync();
+  }
+
+  if (oldSelectedNodeId) {
+    const node = nodes.find(n => n.nodeId === oldSelectedNodeId);
+
+    if (node && isNodeValid(node, selectedMachines, filters)) {
+      !locked && nodesLock.release();
+      return node;
+    }
+  }
+
+  for (const node of shuffle(nodes)) {
+    if (isNodeValid(node, selectedMachines, filters)) {
+      !locked && nodesLock.release();
+      return node;
+    }
+  }
+
+  !locked && nodesLock.release();
 }
 
 export async function getNodePageCount(gridStore: ReturnType<typeof useGrid>, filters: FarmFilterOptions) {

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -299,8 +299,6 @@ export function isNodeValid(node: NodeInfo, machines: SelectedMachine[], filters
     sru -= machine.disk * 1e9;
   }
 
-  console.log({ node, machinesWithSameNode, machines, requiredMru, requiredSru, mru, sru });
-
   return mru >= requiredMru && sru >= requiredSru;
 }
 

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -246,6 +246,14 @@ export async function validateRentContract(
   }
 }
 
+export function release(lock?: AwaitLock) {
+  if (lock?.acquired) {
+    lock.release();
+    return true;
+  }
+  return false;
+}
+
 export async function loadValidNodes(
   gridStore: ReturnType<typeof useGrid>,
   selectionFitlers: SelectionDetailsFilters,
@@ -315,7 +323,7 @@ export async function selectValidNode(
 
     if (node && isNodeValid(node, selectedMachines, filters)) {
       if (nodesLock && !locked) {
-        nodesLock.release();
+        release(nodesLock);
       }
       return node;
     }
@@ -324,14 +332,14 @@ export async function selectValidNode(
   for (const node of shuffle(nodes)) {
     if (isNodeValid(node, selectedMachines, filters)) {
       if (nodesLock && !locked) {
-        nodesLock.release();
+        release(nodesLock);
       }
       return node;
     }
   }
 
   if (nodesLock && !locked) {
-    nodesLock.release();
+    release(nodesLock);
   }
 }
 

--- a/packages/playground/src/weblets/tf_caprover.vue
+++ b/packages/playground/src/weblets/tf_caprover.vue
@@ -76,12 +76,16 @@
       </template>
 
       <template #leader>
-        <CaproverWorker v-model="leader" />
+        <CaproverWorker v-model="leader" :other-workers="workers" :nodes-lock="nodesLock" />
       </template>
 
       <template #workers>
         <ExpandableLayout v-model="workers" @add="addWorker" #="{ index }">
-          <CaproverWorker v-model="workers[index]" />
+          <CaproverWorker
+            v-model="workers[index]"
+            :other-workers="[workers, leader].flat(1).filter((_, i) => i !== index)"
+            :nodes-lock="nodesLock"
+          />
         </ExpandableLayout>
       </template>
     </d-tabs>
@@ -106,6 +110,7 @@ import { generateName, generatePassword } from "../utils/strings";
 
 const layout = useLayout();
 const tabs = ref();
+const nodesLock = markRaw(new AwaitLock());
 const profileManager = useProfileManager();
 const domain = ref("");
 const password = ref(generatePassword(10));
@@ -191,6 +196,8 @@ function updateSSHkeyEnv(selectedKeys: string) {
 
 <script lang="ts">
 import type { GridClient } from "@threefold/grid_client";
+import AwaitLock from "await-lock";
+import { markRaw } from "vue";
 
 import { createNetwork } from "@/utils/deploy_helpers";
 

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -65,12 +65,15 @@
       </template>
 
       <template #master>
-        <K8SWorker v-model="master" />
+        <K8SWorker v-model="master" :other-workers="workers" />
       </template>
 
       <template #workers>
         <ExpandableLayout v-model="workers" @add="addWorker" #="{ index }">
-          <K8SWorker v-model="workers[index]" />
+          <K8SWorker
+            v-model="workers[index]"
+            :other-workers="[workers, master].flat(1).filter((_, i) => i !== index)"
+          />
         </ExpandableLayout>
       </template>
     </d-tabs>

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -73,8 +73,8 @@
           <K8SWorker
             v-model="workers[index]"
             :other-workers="[workers, master].flat(1).filter((_, i) => i !== index)"
+            :nodes-lock="nodesLock"
           />
-          <!-- :nodes-lock="nodesLock" -->
         </ExpandableLayout>
       </template>
     </d-tabs>

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -65,7 +65,7 @@
       </template>
 
       <template #master>
-        <K8SWorker v-model="master" :other-workers="workers" />
+        <K8SWorker v-model="master" :other-workers="workers" :nodes-lock="nodesLock" />
       </template>
 
       <template #workers>
@@ -74,6 +74,7 @@
             v-model="workers[index]"
             :other-workers="[workers, master].flat(1).filter((_, i) => i !== index)"
           />
+          <!-- :nodes-lock="nodesLock" -->
         </ExpandableLayout>
       </template>
     </d-tabs>
@@ -85,7 +86,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue";
+import { markRaw, ref } from "vue";
 
 import { createWorker } from "../components/k8s_worker.vue";
 import { useLayout } from "../components/weblet_layout.vue";
@@ -97,6 +98,7 @@ import { generateName, generatePassword } from "../utils/strings";
 
 const layout = useLayout();
 const tabs = ref();
+const nodesLock = markRaw(new AwaitLock());
 const name = ref(generateName({ prefix: "k8s" }));
 const clusterToken = ref(generatePassword(10));
 const master = ref(createWorker(generateName({ prefix: "mr" })));
@@ -141,6 +143,7 @@ function updateSSHkeyEnv(selectedKeys: string) {
 
 <script lang="ts">
 import type { GridClient } from "@threefold/grid_client";
+import AwaitLock from "await-lock";
 
 import ExpandableLayout from "../components/expandable_layout.vue";
 import K8SWorker from "../components/k8s_worker.vue";


### PR DESCRIPTION
### Description
Detect and Resolve nodes' resources overlapping

### Changes
1. Add lock per deployment to avoid load more than one node at once (selecting nodes not series not parallel like before)
2. Pass down other vms (aka. workers) down to each other
  For Example:
      Assume we have k8s cluster( 1 master, 2 workers [1, 2]) So,
      master <- take in - (worker 1, worker 2)
      worker 1 <- take in - (worker 2, master)
      worker 2 <- take in - (worker 1, master)
      and so on...
3. Passing these info will allow to subtract resources from selected nodes (if any)
4. if there is any node no longer valid for the required resources, will be omitted from the nodes list
   Note: Changing resources will reactively show/hide node in list
   For example:
     Let's assume we have a vm require 2 GB ram but the hidden node has 1.5 GB ram, so If we updated required resources to be less than or equal to 1.5 GB ram it will be added back the nodes list.
5. Finally Update node on any vm (aka. worker) will trigger validation in other selected node if and only if it wasn't valid


### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2888

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)