### PR TITLE
Adding bandwidth cost per hour in case of ipv4

### DIFF
--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -84,7 +84,7 @@
             You selected a certified node. Please note that this deployment costs more TFT.
           </div>
         </div>
-        <div>Please Note that the Bandwidth affects the total cost.</div>
+        <div v-if="ipv4">Please Note that the Bandwidth affects the total cost (1 Bandwidth = 0.01 TFT/hour).</div>
         <a :href="manual.pricing" target="_blank" class="app-link">
           Learn more about the pricing and how to unlock discounts.
         </a>


### PR DESCRIPTION
### Description

Checking if ipv4 is true to display the bandwidth note and adding the cost of bandwidth per hour
![2024-07-02_10-28](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/66883096/123ed64f-220b-4417-87fb-9dacb1500a6d)

### Related Issues

- #3018
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
