### PR TITLE
Feat: `Node finder` enhance `Rentable toggle`

### DIFF
--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -462,7 +462,7 @@
 <script lang="ts">
 import { type GridNode, SortBy, SortOrder, UnifiedNodeStatus } from "@threefold/gridproxy_client";
 import { sortBy } from "lodash";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
 import NodeDetails from "@/components/node_details.vue";
@@ -530,6 +530,14 @@ export default {
       mine: false,
     });
 
+    watch(
+      () => filters.value.rentable,
+      rentable => {
+        if (rentable && filters.value.status == "") {
+          filters.value.status = "Up & Standby";
+        }
+      },
+    );
     const loading = ref<boolean>(true);
     const _nodes = ref<GridNode[]>([]);
 

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -530,12 +530,15 @@ export default {
       ipv6: false,
       mine: false,
     });
-
+    const oldNodeStatus = ref();
     watch(
       () => filters.value.rentable,
       rentable => {
         if (rentable) {
+          oldNodeStatus.value = filters.value.status;
           filters.value.status = UnifiedNodeStatus.UpStandby;
+        } else {
+          filters.value.status = oldNodeStatus.value;
         }
       },
     );

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -48,26 +48,35 @@
             <v-switch color="primary" inset label="Mine" v-model="filters.mine" density="compact" hide-details />
           </TfFilter>
 
-          <TfFilter class="mt-4" query-route="node-status" v-model="filters.status">
-            <v-select
-              :disabled="filters.rentable"
-              :model-value="filters.status || undefined"
-              @update:model-value="filters.status = $event || ''"
-              :items="[
-                { title: 'Up', value: UnifiedNodeStatus.Up },
-                { title: 'Standby', value: UnifiedNodeStatus.Standby },
-                { title: 'Up & Standby', value: UnifiedNodeStatus.UpStandby },
-                { title: 'Down', value: UnifiedNodeStatus.Down },
-              ]"
-              label="Select Nodes Status"
-              item-title="title"
-              item-value="value"
-              variant="outlined"
-              clearable
-              @click:clear="filters.status = ''"
-              density="compact"
-            />
-          </TfFilter>
+          <VTooltip
+            location="bottom"
+            offset="-25"
+            :disabled="!filters.rentable"
+            text="The 'Rentable' filter will list only 'Standby & Up' nodes."
+          >
+            <template #activator="{ props }">
+              <TfFilter class="mt-4" v-bind="props" query-route="node-status" v-model="filters.status">
+                <v-select
+                  :disabled="filters.rentable"
+                  :model-value="filters.status || undefined"
+                  @update:model-value="filters.status = $event || ''"
+                  :items="[
+                    { title: 'Up', value: UnifiedNodeStatus.Up },
+                    { title: 'Standby', value: UnifiedNodeStatus.Standby },
+                    { title: 'Up & Standby', value: UnifiedNodeStatus.UpStandby },
+                    { title: 'Down', value: UnifiedNodeStatus.Down },
+                  ]"
+                  label="Select Nodes Status"
+                  item-title="title"
+                  item-value="value"
+                  variant="outlined"
+                  clearable
+                  @click:clear="filters.status = ''"
+                  density="compact"
+                />
+              </TfFilter>
+            </template>
+          </VTooltip>
 
           <TfFilter
             query-route="node-id"

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -50,6 +50,7 @@
 
           <TfFilter class="mt-4" query-route="node-status" v-model="filters.status">
             <v-select
+              :disabled="filters.rentable"
               :model-value="filters.status || undefined"
               @update:model-value="filters.status = $event || ''"
               :items="[
@@ -533,7 +534,7 @@ export default {
     watch(
       () => filters.value.rentable,
       rentable => {
-        if (rentable && filters.value.status == "") {
+        if (rentable) {
           filters.value.status = UnifiedNodeStatus.UpStandby;
         }
       },

--- a/packages/playground/src/views/nodes.vue
+++ b/packages/playground/src/views/nodes.vue
@@ -534,7 +534,7 @@ export default {
       () => filters.value.rentable,
       rentable => {
         if (rentable && filters.value.status == "") {
-          filters.value.status = "Up & Standby";
+          filters.value.status = UnifiedNodeStatus.UpStandby;
         }
       },
     );


### PR DESCRIPTION

### Description
Rentable sounds like that we will list to go rentable nodes, the old behavior was listing all rentable nodes; but the user can't rent  a `down` node.
 
so we introduce new flow for this toggle:
toggling on the rentable filter setting the value of node status filter to `Up & Rentable`
toggling off the renatable filter will revert the previous value 

### Changes

Add watcher on rentable filter, and if it is selected, and the status field is empty will update the status to be up and standby

[Screencast from 04 يول, 2024 EEST 02:23:42 م.webm](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/03feaaec-e1c1-49b6-96e0-d8aded12ead7)


### Related Issues

- #2619 

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
