### PR TITLE
Reduce getting pages count in listing 

### DIFF
--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -344,7 +344,9 @@ export async function selectValidNode(
 }
 
 export async function getNodePageCount(gridStore: ReturnType<typeof useGrid>, filters: FarmFilterOptions) {
-  const count = await gridStore.client.capacity.getNodesCount(filters);
+  const clonedFilter = { ...filters };
+  clonedFilter.size = 0;
+  const count = await gridStore.client.capacity.getNodesCount(clonedFilter);
   return Math.ceil(count / window.env.PAGE_SIZE);
 }
 


### PR DESCRIPTION
we can't ignore the first request, it gets the pages count so we can get random page in the second request, 
reduce get items count response size, by setting the size requested with 0

### Description

Describe the changes introduced by this PR and what does it affect

### Changes

cloned the passed filter and change size to be zero

Mainnet, time spent on the full loading flow 
before changes: 
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/8343a56e-ac0d-48d7-b15b-579747c6fb56)

after: 
![Screenshot from 2024-07-04 17-42-02](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/62248851/187f9592-f767-4128-9bd8-7540a504ac9c)


### Related Issues

 - #2982

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
