### PR TITLE
Adding ubuntu 24.04 flist to full vm and micro vm as a default flist

### DIFF
--- a/packages/grid_client/src/zos/zmachine.ts
+++ b/packages/grid_client/src/zos/zmachine.ts
@@ -2,6 +2,7 @@ import { Expose, Transform, Type } from "class-transformer";
 import {
   IsBoolean,
   IsDefined,
+  isDefined,
   IsInt,
   IsIP,
   IsNotEmpty,
@@ -63,7 +64,7 @@ class Zmachine extends WorkloadData {
   @Expose() @IsInt() @Max(10 * 1024 ** 4) size: number; // in bytes
   @Expose() @Type(() => ComputeCapacity) @ValidateNested() compute_capacity: ComputeCapacity;
   @Expose() @Type(() => Mount) @ValidateNested({ each: true }) mounts: Mount[];
-  @Expose() @IsString() @IsNotEmpty() entrypoint: string;
+  @Expose() @IsString() @IsDefined() entrypoint: string;
   @Expose() env: Record<string, unknown>;
   @Expose() @Transform(({ value }) => (value ? true : false)) @IsBoolean() corex: boolean;
   @Expose() @IsString({ each: true }) @IsOptional() gpu?: string[];

--- a/packages/playground/src/components/select_vm_image.vue
+++ b/packages/playground/src/components/select_vm_image.vue
@@ -29,13 +29,11 @@
       </input-tooltip>
     </input-validator>
 
-    <input-validator :rules="[validators.required('Entry point is required.')]" :value="entryPoint" #="{ props }">
-      <input-tooltip
-        tooltip="The entry point of the selected flist. It's the first process that runs on the machine once it's deployed."
-      >
-        <v-text-field label="Entry Point" v-model="entryPoint" v-bind="props" />
-      </input-tooltip>
-    </input-validator>
+    <input-tooltip
+      tooltip="The entry point of the selected flist. It's the first process that runs on the machine once it's deployed."
+    >
+      <v-text-field label="Entry Point" v-model="entryPoint" />
+    </input-tooltip>
   </template>
 </template>
 
@@ -61,12 +59,14 @@ const props = defineProps({
 });
 const emits = defineEmits<{ (event: "update:model-value", value?: Flist): void }>();
 const flist = ref<string>();
-const entryPoint = ref<string>();
+const entryPoint = ref<string>("");
 
 const image = ref<VmImage>(props.images[0]);
+const name = ref<string>();
 watch(
   image,
   vm => {
+    name.value = vm.name;
     if (vm.name !== "Other") {
       flist.value = vm.flist;
       entryPoint.value = vm.entryPoint;
@@ -76,9 +76,9 @@ watch(
 );
 
 watch(
-  [flist, entryPoint],
-  ([value, entryPoint]) => {
-    emits("update:model-value", value && entryPoint ? { value, entryPoint } : undefined);
+  [flist, entryPoint, name],
+  ([value, entryPoint, name]) => {
+    emits("update:model-value", value ? { name, value, entryPoint } : undefined);
   },
   { immediate: true, deep: true },
 );

--- a/packages/playground/src/types/index.ts
+++ b/packages/playground/src/types/index.ts
@@ -84,6 +84,7 @@ export interface FarmInterface {
 }
 
 export interface Flist {
+  name?: string;
   value: string;
   entryPoint: string;
 }

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -260,7 +260,10 @@ async function deploy() {
           planetary: planetary.value,
           mycelium: mycelium.value,
           envs: [{ key: "SSH_KEY", value: selectedSSHKeys.value }],
-          rootFilesystemSize,
+          rootFilesystemSize:
+            flist.value?.name === "Ubuntu-24.04" || flist.value?.name === "Other"
+              ? solution.value?.disk
+              : rootFilesystemSize,
           hasGPU: hasGPU.value,
           nodeId: selectionDetails.value?.node?.nodeId,
           gpus: hasGPU.value ? selectionDetails.value?.gpuCards.map(card => card.id) : undefined,

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -161,7 +161,7 @@ const images: VmImage[] = [
   {
     name: "Ubuntu-24.04",
     flist: "https://hub.grid.tf/tf-official-vms/ubuntu-24.04-full.flist",
-    entryPoint: "/init.sh",
+    entryPoint: "",
   },
   {
     name: "Ubuntu-22.04",
@@ -251,7 +251,10 @@ async function deploy() {
           memory: solution.value.memory,
           flist: flist.value!.value,
           entryPoint: flist.value!.entryPoint,
-          disks: [{ size: solution?.value.disk, mountPoint: "/" }, ...disks.value],
+          disks:
+            flist.value?.name === "Ubuntu-24.04" || flist.value?.name === "Other"
+              ? [...disks.value]
+              : [{ size: solution?.value.disk, mountPoint: "/" }, ...disks.value],
           publicIpv4: ipv4.value,
           publicIpv6: ipv6.value,
           planetary: planetary.value,

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -159,6 +159,11 @@ const profileManager = useProfileManager();
 const solution = ref() as Ref<SolutionFlavor>;
 const images: VmImage[] = [
   {
+    name: "Ubuntu-24.04",
+    flist: "https://hub.grid.tf/tf-official-vms/ubuntu-24.04-full.flist",
+    entryPoint: "/init.sh",
+  },
+  {
     name: "Ubuntu-22.04",
     flist: "https://hub.grid.tf/tf-official-vms/ubuntu-22.04.flist",
     entryPoint: "/init.sh",

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -138,7 +138,7 @@
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref, watch } from "vue";
+import { computed, type Ref, ref, watch } from "vue";
 
 import { manual } from "@/utils/manual";
 
@@ -198,7 +198,9 @@ const certified = ref(false);
 const disks = ref<Disk[]>([]);
 const network = ref();
 const hasGPU = ref(false);
-const rootFilesystemSize = 2;
+const rootFilesystemSize = computed(() =>
+  flist.value?.name === "Ubuntu-24.04" || flist.value?.name === "Other" ? solution.value?.disk : 2,
+);
 const gridStore = useGrid();
 const grid = gridStore.client as GridClient;
 
@@ -260,10 +262,7 @@ async function deploy() {
           planetary: planetary.value,
           mycelium: mycelium.value,
           envs: [{ key: "SSH_KEY", value: selectedSSHKeys.value }],
-          rootFilesystemSize:
-            flist.value?.name === "Ubuntu-24.04" || flist.value?.name === "Other"
-              ? solution.value?.disk
-              : rootFilesystemSize,
+          rootFilesystemSize: rootFilesystemSize.value,
           hasGPU: hasGPU.value,
           nodeId: selectionDetails.value?.node?.nodeId,
           gpus: hasGPU.value ? selectionDetails.value?.gpuCards.map(card => card.id) : undefined,

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -195,6 +195,11 @@ const tabs = ref();
 
 const images = [
   {
+    name: "Ubuntu-24.04",
+    flist: "https://hub.grid.tf/tf-official-vms/ubuntu-24.04-latest.flist",
+    entryPoint: "/sbin/zinit init",
+  },
+  {
     name: "Ubuntu-23.10",
     flist: "https://hub.grid.tf/tf-official-vms/ubuntu-23.10-mycelium.flist",
     entryPoint: "/sbin/zinit init",


### PR DESCRIPTION
### Description
Adding ubuntu 24.04 flist to full vm and micro vm as a default flist in 2.5

### Changes
Adding ubuntu 24.04 flist to full vm and micro vm as a default flist
Updated Flist's entrypoint to accept empty strings
Added a condition in all solution to check entrypoint
In case of full vm removed disk mounted on / in case of Ubuntu-24.04 or Other flist


### Related Issues

- #3096
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
