### PR TITLE
Reterun docs at application 

### DIFF
--- a/packages/playground/src/components/view_layout.vue
+++ b/packages/playground/src/components/view_layout.vue
@@ -1,9 +1,27 @@
 <template>
-  <div class="border px-4 pb-4 rounded position-relative pt-3 mt-1" ref="viewLayoutContainer">
+  <div
+    class="border px-4 pb-4 rounded position-relative mt-1"
+    :class="{ 'pt-10': hasInfo, 'pt-3': !hasInfo }"
+    ref="viewLayoutContainer"
+  >
     <div
       :style="{ opacity: $vuetify.theme.name === 'dark' ? 'var(--v-medium-emphasis-opacity)' : '' }"
       v-if="$slots.description"
     />
+
+    <div
+      class="position-absolute pa-1 rounded-circle border"
+      :style="{
+        top: 0,
+        right: '16px',
+        transform: 'translateY(-50%)',
+        zIndex: 99,
+        backgroundColor: 'rgb(var(--v-theme-background))',
+      }"
+      v-if="hasInfo"
+    >
+      <AppInfo />
+    </div>
 
     <template v-if="requireSSH && !ssh">
       <VAlert variant="tonal" type="error" class="mb-4">
@@ -26,8 +44,11 @@ import { useRoute } from "vue-router";
 import { DashboardRoutes } from "@/router/routes";
 import { useProfileManager } from "@/stores";
 
+import AppInfo from "./app_info.vue";
+
 export default {
   name: "ViewLayout",
+  components: { AppInfo },
   setup() {
     const route = useRoute();
     const profileManager = useProfileManager();

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -541,7 +541,6 @@ function createTFChainRoutes(): RouteRecordRaw[] {
         {
           path: DashboardRoutes.TFChain.TFMintingReports,
           component: () => import("../views/minting_view.vue"),
-          meta: { title: "Minting", info: { page: "info/minting.md" }, publicPath: true },
         },
       ],
     },
@@ -694,7 +693,6 @@ function createDeployRoutes(): RouteRecordRaw[] {
           component: () => import("../dashboard/contracts_list.vue"),
           meta: {
             title: "Your Contracts List",
-            // info: { page: "info/contracts_list.md" },
           },
         },
 

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -694,7 +694,7 @@ function createDeployRoutes(): RouteRecordRaw[] {
           component: () => import("../dashboard/contracts_list.vue"),
           meta: {
             title: "Your Contracts List",
-            info: { page: "info/contracts_list.md" },
+            // info: { page: "info/contracts_list.md" },
           },
         },
 

--- a/packages/playground/src/views/minting_view.vue
+++ b/packages/playground/src/views/minting_view.vue
@@ -4,6 +4,24 @@
       <v-icon size="30" class="pr-3">mdi-file-document-edit</v-icon>
       <v-card-title class="pa-0">TF Minting Reports</v-card-title>
     </v-card>
+    <v-alert class="mb-4 text-subtitle-2 font-weight-regular" type="info" variant="tonal">
+      The user can verify the 3Nodes' payments on Stellar Blockchain through the Threefold's
+      <a
+        class="app-link font-weight-medium"
+        target="_blank"
+        href="https://www.manual.grid.tf/documentation/dashboard/tfchain/tf_minting_reports.html"
+        >minting tool,
+      </a>
+
+      Also the TFT minting address on Stellar Chain:
+      <a
+        class="app-link font-weight-medium"
+        target="_blank"
+        href="https://stellar.expert/explorer/public/account/GBOVQKJYHXRR3DX6NOX2RRYFRCUMSADGDESTDNBDS6CDVLGVESRTAC47"
+        >GBOVQKJYHXRR3DX6NOX2RRYFRCUMSADGDESTDNBDS6CDVLGVESRTAC47.</a
+      >
+      <br />
+    </v-alert>
     <v-alert variant="tonal" type="warning" class="mb-4"> All data subject to change </v-alert>
     <v-form class="d-inline-flex w-100">
       <FormValidator v-model="isValidForm">

--- a/packages/playground/src/views/minting_view.vue
+++ b/packages/playground/src/views/minting_view.vue
@@ -5,15 +5,23 @@
       <v-card-title class="pa-0">TF Minting Reports</v-card-title>
     </v-card>
     <v-alert class="mb-4 text-subtitle-2 font-weight-regular" type="info" variant="tonal">
+      For more information about minting check
+      <a
+        class="app-link font-weight-medium"
+        target="_blank"
+        href="https://www.manual.grid.tf/documentation/faq/faq.html#what-is-the-tft-minting-process-is-it-fully-automated"
+        >TFT minting process.
+      </a>
+      <br />
       The user can verify the 3Nodes' payments on Stellar Blockchain through the Threefold's
       <a
         class="app-link font-weight-medium"
         target="_blank"
         href="https://www.manual.grid.tf/documentation/dashboard/tfchain/tf_minting_reports.html"
-        >minting tool,
+        >minting tool.
       </a>
-
-      Also the TFT minting address on Stellar Chain:
+      <br />
+      TFT minting address on Stellar Chain:
       <a
         class="app-link font-weight-medium"
         target="_blank"
@@ -22,7 +30,6 @@
       >
       <br />
     </v-alert>
-    <v-alert variant="tonal" type="warning" class="mb-4"> All data subject to change </v-alert>
     <v-form class="d-inline-flex w-100">
       <FormValidator v-model="isValidForm">
         <InputValidator

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -13,6 +13,25 @@
     <v-icon size="30" class="pr-3">mdi-file-document-edit</v-icon>
     <v-card-title class="pa-0">Contracts List</v-card-title>
   </v-card>
+
+  <v-alert class="mb-4 text-subtitle-2 font-weight-regular" type="info" variant="tonal">
+    For more details about Contract Types, Billing Cycle & Grace Period, check
+    <a
+      class="app-link font-weight-medium"
+      target="_blank"
+      href="https://www.manual.grid.tf/documentation/developers/tfchain/tfchain.html"
+      >Contract Documentation,
+    </a>
+    To explore further contract details, check
+    <a
+      class="app-link font-weight-medium"
+      target="_blank"
+      href="https://www.manual.grid.tf/documentation/dashboard/deploy/your_contracts.html"
+      >Node Contract Documentation.</a
+    >
+    <br />
+  </v-alert>
+
   <v-card variant="text" class="my-3">
     <section class="d-flex align-center">
       <v-spacer />

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -22,7 +22,7 @@
       href="https://www.manual.grid.tf/documentation/developers/tfchain/tfchain.html"
       >Contract Documentation,
     </a>
-    To explore further contract details, check
+    and to explore further contract details, check
     <a
       class="app-link font-weight-medium"
       target="_blank"


### PR DESCRIPTION
### Description

Return docs at applications 

### Changes

Return docs at applications and change them at Miniting and Contract pages to be as info below header

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/2c3b71f9-fb14-4338-9b8c-f7549d52b782)

![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/b84e868c-ef86-475b-b249-142f1dc8dcde)
![image](https://github.com/threefoldtech/tfgrid-sdk-ts/assets/10484295/be35170b-a1a2-4dba-bc2a-a1dbbdb84ec8)

### Related Issues

#3049

List of related issues

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
