### PR TITLE
Using the solution disk size as rootfs in case the disk was dropped

### DIFF
--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -260,7 +260,10 @@ async function deploy() {
           planetary: planetary.value,
           mycelium: mycelium.value,
           envs: [{ key: "SSH_KEY", value: selectedSSHKeys.value }],
-          rootFilesystemSize,
+          rootFilesystemSize:
+            flist.value?.name === "Ubuntu-24.04" || flist.value?.name === "Other"
+              ? solution.value?.disk
+              : rootFilesystemSize,
           hasGPU: hasGPU.value,
           nodeId: selectionDetails.value?.node?.nodeId,
           gpus: hasGPU.value ? selectionDetails.value?.gpuCards.map(card => card.id) : undefined,


### PR DESCRIPTION
### Description

Using the solution disk size as rootfs in case the disk was dropped


### Related Issues

#3096
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
