### PR TITLE
Adding public ipv6 and ipv4 to node pilot deployment table

### DIFF
--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -279,9 +279,11 @@ const filteredHeaders = computed(() => {
     ProjectName.TFRobot,
     ProjectName.Gitea,
     ProjectName.Nostr,
+    ProjectName.NodePilot,
   ] as string[];
 
   const IPV4Solutions = [
+    ProjectName.NodePilot,
     ProjectName.VM,
     ProjectName.Fullvm,
     ProjectName.Presearch,


### PR DESCRIPTION
### Description

Adding public ipv6 and ipv4 to node pilot deployment table
![Screenshot from 2024-07-21 12-49-57](https://github.com/user-attachments/assets/3bf7a35c-a435-41c2-8002-7b418432d9f1)


### Related Issues
- #2910
- #3048
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
