### PR TITLE
Fixing mismatch name of netherland country in stats

### DIFF
--- a/packages/playground/src/views/stats.vue
+++ b/packages/playground/src/views/stats.vue
@@ -74,6 +74,12 @@ function mergeNodeDistribution(stats: Stats["nodesDistribution"][]) {
     stats.forEach(country => {
       res[key] += country[key] ?? 0;
     });
+
+    if (key === "The Netherlands" && res["The Netherlands"]) {
+      res["Netherlands"] = res["The Netherlands"];
+      delete res["The Netherlands"];
+    }
+
     return res;
   }, {} as { [key: string]: number });
 }


### PR DESCRIPTION
### Description

 Adjusting the netherland's country name returned from the response to match the map's country name

![Screenshot from 2024-08-01 15-40-42](https://github.com/user-attachments/assets/da7ab1b9-b9ad-41d2-a8c4-9002d55f6b74)

### Related Issues

- #3181
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
