### PR TITLE
Add support for node in graphql client build

### DIFF
--- a/packages/graphql_client/package.json
+++ b/packages/graphql_client/package.json
@@ -1,11 +1,21 @@
 {
   "name": "@threefold/graphql_client",
   "version": "2.5.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/node/index.js",
+  "module": "./dist/es6/index.js",
+  "exports": {
+    "require": "./dist/node/index.js",
+    "import": "./dist/es6/index.js"
+  },
+  "types": "dist/es6/index.d.ts",
+  "files": [
+    "/dist"
+  ],
   "license": "MIT",
   "scripts": {
-    "build": "tsc"
+    "build": "npm-run-all es6-build node-build",
+    "node-build": "tsc --build tsconfig-node.json",
+    "es6-build": "tsc --build tsconfig.json"
   },
   "dependencies": {
     "@threefold/types": "2.5.0",

--- a/packages/graphql_client/package.json
+++ b/packages/graphql_client/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "npm-run-all es6-build node-build",
+    "build": "npm run es6-build && npm run node-build",
     "node-build": "tsc --build tsconfig-node.json",
     "es6-build": "tsc --build tsconfig.json"
   },

--- a/packages/graphql_client/tsconfig-node.json
+++ b/packages/graphql_client/tsconfig-node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "types": ["node", "jest"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist/node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "baseUrl": "./src",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "tests"]
+}

--- a/packages/graphql_client/tsconfig.json
+++ b/packages/graphql_client/tsconfig.json
@@ -3,8 +3,9 @@
     "target": "ES2017",
     "module": "ES2015",
     "moduleResolution": "node",
+    "types": ["node"],
     "baseUrl": "./src",
-    "outDir": "./dist",
+    "outDir": "./dist/es6",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -12,7 +13,8 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "tests"]


### PR DESCRIPTION
### Description
Add support for node in graphql client build

### Changes
- Add scripts for building using newly added tsconfigs in package.json
- Update old es6 config to have node in types
- Add tsconfig-node file to allow build while targetting node

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3209

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
