### PR TITLE
Add support for node in gridproxy client build

### DIFF
--- a/packages/gridproxy_client/package.json
+++ b/packages/gridproxy_client/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm-run-all es6-build node-build",
+    "build": "npm run es6-build && npm run node-build",
     "node-build": "tsc --build tsconfig-node.json",
     "es6-build": "tsc --build tsconfig.json"
   },

--- a/packages/gridproxy_client/package.json
+++ b/packages/gridproxy_client/package.json
@@ -2,8 +2,16 @@
   "name": "@threefold/gridproxy_client",
   "version": "2.5.0",
   "description": "gridproxy_client help to interact with gridproxy based on network",
-  "main": "dist/public_api.js",
-  "types": "dist/public_api.d.ts",
+  "main": "./dist/node/public_api.js",
+  "module": "./dist/es6/public_api.js",
+  "exports": {
+    "require": "./dist/node/public_api.js",
+    "import": "./dist/es6/public_api.js"
+  },
+  "types": "dist/es6/public_api.d.ts",
+  "files": [
+    "/dist"
+  ],
   "repository": "git@github.com:MohamedElmdary/gridproxy_client.git",
   "author": "MohamedElmdary <engm5081@gmail.com>",
   "license": "MIT",
@@ -12,7 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "npm-run-all es6-build node-build",
+    "node-build": "tsc --build tsconfig-node.json",
+    "es6-build": "tsc --build tsconfig.json"
   },
   "devDependencies": {
     "typescript": "^4.8.4"

--- a/packages/gridproxy_client/tsconfig-node.json
+++ b/packages/gridproxy_client/tsconfig-node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "types": ["node", "jest"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist/node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "baseUrl": "./src",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "tests"]
+}

--- a/packages/gridproxy_client/tsconfig.json
+++ b/packages/gridproxy_client/tsconfig.json
@@ -3,8 +3,9 @@
     "target": "ES2017",
     "module": "ES2015",
     "moduleResolution": "node",
+    "types": ["node"],
     "baseUrl": "./src",
-    "outDir": "./dist",
+    "outDir": "./dist/es6",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -13,7 +14,7 @@
     "strict": true,
     "skipLibCheck": true,
     "noImplicitAny": false,
-    "lib": ["es2019", "DOM"]
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "tests"]


### PR DESCRIPTION
### Description
Add support for node in gridproxy client build

### Changes
- Add scripts for building using newly added tsconfigs in package.json
- Update old es6 config to have node in types
- Add tsconfig-node file to allow build while targetting node

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3209

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
