### PR TITLE
Fix discourse SMTP

### DIFF
--- a/packages/playground/src/components/networks.vue
+++ b/packages/playground/src/components/networks.vue
@@ -25,6 +25,7 @@
                 color="primary"
                 inset
                 label="Public IPv4"
+                :disabled="isDiscourse"
                 :model-value="$props.ipv4"
                 @update:model-value="$emit('update:ipv4', $event ?? undefined)"
               />
@@ -130,6 +131,10 @@ export default {
       default: () => null,
     },
     disabled: { type: Boolean },
+    isDiscourse: {
+      type: Boolean,
+      default: () => null,
+    },
   },
   emits: {
     "update:ipv4": (value?: boolean) => value,

--- a/packages/playground/src/components/networks.vue
+++ b/packages/playground/src/components/networks.vue
@@ -25,7 +25,7 @@
                 color="primary"
                 inset
                 label="Public IPv4"
-                :disabled="isDiscourse"
+                :disabled="enableIpv4"
                 :model-value="$props.ipv4"
                 @update:model-value="$emit('update:ipv4', $event ?? undefined)"
               />
@@ -131,9 +131,9 @@ export default {
       default: () => null,
     },
     disabled: { type: Boolean },
-    isDiscourse: {
+    enableIpv4: {
       type: Boolean,
-      default: () => null,
+      default: () => true,
     },
   },
   emits: {

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -62,7 +62,7 @@
           v-model:planetary="planetary"
           v-model:ipv4="ipv4"
           v-model:ipv6="ipv6"
-          :isDiscourse="true"
+          enableIpv4
         />
 
         <input-tooltip inline tooltip="Click to know more about dedicated machines." :href="manual.dedicated_machines">

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -57,7 +57,13 @@
           :medium="{ cpu: 2, memory: 4, disk: 50 }"
           :large="{ cpu: 4, memory: 16, disk: 100 }"
         />
-        <Networks v-model:mycelium="mycelium" v-model:planetary="planetary" v-model:ipv4="ipv4" v-model:ipv6="ipv6" />
+        <Networks
+          v-model:mycelium="mycelium"
+          v-model:planetary="planetary"
+          v-model:ipv4="ipv4"
+          v-model:ipv6="ipv6"
+          :isDiscourse="true"
+        />
 
         <input-tooltip inline tooltip="Click to know more about dedicated machines." :href="manual.dedicated_machines">
           <v-switch color="primary" inset label="Dedicated" v-model="dedicated" hide-details />
@@ -121,7 +127,7 @@ const profileManager = useProfileManager();
 const name = ref(generateName({ prefix: "dc" }));
 const email = ref(profileManager.profile?.email || "");
 const solution = ref() as Ref<SolutionFlavor>;
-const ipv4 = ref(false);
+const ipv4 = ref(true);
 const ipv6 = ref(false);
 const mycelium = ref(true);
 const planetary = ref(true);


### PR DESCRIPTION
### Description

- Enable ```IPV4``` by default as [discourse docs](https://www.manual.grid.tf/documentation/dashboard/solutions/discourse.html#deployment)

### Changes

[Screencast from 04-08-24 14:34:33.webm](https://github.com/user-attachments/assets/71e0834b-fba4-450f-9ca8-817fc7951f01)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3110

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
