### PR TITLE
make third sorting click reset to asc sort order

### DIFF
--- a/packages/playground/src/views/farms.vue
+++ b/packages/playground/src/views/farms.vue
@@ -105,14 +105,17 @@
           page = $event;
           loadFarms();
         "
-        @update:sort-by="
-          if ($event[0]) {
-            sortBy = $event[0].key == 'farmId' ? SortBy.FarmId : $event[0].key;
-            sortOrder = $event[0].order;
-            loadFarms();
+        @update:options="
+          if (!$event.sortBy.length) {
+            sortBy = SortBy.FarmId;
+            sortOrder = SortOrder.Asc;
+          } else if ($event.sortBy[0]) {
+            sortBy = $event.sortBy[0].key == 'farmId' ? SortBy.FarmId : $event.sortBy[0].key;
+            sortOrder = $event.sortBy[0].order;
           }
+
+          loadFarms();
         "
-        @update:options="loadFarms()"
         @click:row="openSheet"
       >
         <template #[`item.usedPublicIp`]="{ item }">


### PR DESCRIPTION
### Changes

Moved sorting logic to update:options
Added default sort order for when sorting is removed by third click.

### Related Issues

[#1685](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/1685)

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [x] Screenshots/Video attached (needed for UI changes)
https://www.loom.com/share/e331b83d125a45c2a3dc23412dce3348?sid=04fca9ed-4792-4672-a0e0-d9051324a132
