### PR TITLE
Close logger tab when click anywhere

### DIFF
--- a/packages/playground/src/components/logger.vue
+++ b/packages/playground/src/components/logger.vue
@@ -1,6 +1,6 @@
 <template>
   <VBottomNavigation class="border" :height="debugOpened === 0 ? openHeight : undefined">
-    <v-expansion-panels :model-value="debugOpened" @update:model-value="bindDebugOpened" :multiple="false">
+    <v-expansion-panels :model-value="debugOpened" ref="panel" @update:model-value="bindDebugOpened" :multiple="false">
       <v-expansion-panel eager>
         <v-expansion-panel-title :class="{ 'text-error': !!connectDB.error }">
           <span class="text-subtitle-1"> <VIcon icon="mdi-cog" /> Dashboard Logs ({{ logs.length }}) </span>
@@ -75,7 +75,6 @@
       </v-expansion-panel>
     </v-expansion-panels>
   </VBottomNavigation>
-
   <v-dialog max-width="400px" v-model="clearDialog" attach="#modals">
     <v-card>
       <VCardTitle v-text="'Clear Logs'" />
@@ -92,7 +91,7 @@
 import "vue3-virtual-scroller/dist/vue3-virtual-scroller.css";
 
 import { type LoggerInstance as LI, LoggerInterceptor } from "logger-interceptor";
-import { ref } from "vue";
+import { onBeforeUnmount, onMounted, ref } from "vue";
 import { DynamicScroller, DynamicScrollerItem } from "vue3-virtual-scroller";
 
 import { type Indexed, IndexedDBClient } from "@/clients";
@@ -114,6 +113,8 @@ export default {
   setup() {
     const scroller = ref();
     const debugOpened = ref<number>();
+    const panel = ref();
+
     function bindDebugOpened(value?: any): void {
       debugOpened.value = value;
 
@@ -252,6 +253,20 @@ export default {
       downloadAsFile("dashboard.log", formatedLogs);
     }
 
+    onMounted(() => {
+      document.addEventListener("click", handleClickOutside);
+    });
+
+    onBeforeUnmount(() => {
+      document.removeEventListener("click", handleClickOutside);
+    });
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (panel.value && !panel.value.$el.contains(event.target)) {
+        debugOpened.value = undefined;
+      }
+    };
+
     return {
       connectDB,
       scroller,
@@ -266,6 +281,7 @@ export default {
       loadLogs,
       clearLogs,
       downloadLogs,
+      panel,
     };
   },
 };


### PR DESCRIPTION
### Description

Close logger tab when clicking anywhere except the logger component and its children

### Changes

[Screencast from 05-08-24 13:29:46.webm](https://github.com/user-attachments/assets/2c4a5407-d01f-479f-b41e-8f2bcd13e85a)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3136

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
