### PR TITLE
Fix adding network IP other than WireGuard IP

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -313,6 +313,7 @@ export default {
         }
 
         await deployGatewayName(grid, selectionDetails.value!.domain, gwConfig);
+        suggestName();
         layout.value.setStatus("success", "Successfully deployed gateway.");
       } catch (error) {
         layout.value.setStatus("failed", normalizeError(error, "Something went wrong."));

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -186,7 +186,12 @@ import { onMounted, type PropType, ref, watch } from "vue";
 import { useGrid } from "../stores";
 import { ProjectName } from "../types";
 import type { SelectionDetails } from "../types/nodeSelector";
-import { DeployGatewayConfig, deployGatewayName, type GridGateway, loadDeploymentGateways } from "../utils/gateway";
+import {
+  type DeployGatewayConfig,
+  deployGatewayName,
+  type GridGateway,
+  loadDeploymentGateways,
+} from "../utils/gateway";
 import { updateGrid } from "../utils/grid";
 import { normalizeError } from "../utils/helpers";
 import { generateName } from "../utils/strings";

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -124,13 +124,13 @@
               </input-tooltip>
             </div>
 
-            <copy-input-wrapper #="{ props }" :data="networkName" v-if="isWireGuard">
-              <v-text-field label="Network name" v-model="networkName" readonly v-bind="props" />
-            </copy-input-wrapper>
-
-            <v-select label="Supported IPs" :items="networks" v-model="selectedIPAddress" />
+            <v-select label="Supported Interfaces" class="mt-4" :items="networks" v-model="selectedIPAddress" />
             <copy-input-wrapper #="{ props }" :data="(selectedIPAddress as any)">
               <v-text-field :readonly="true" label="Selected IP Address" v-model="selectedIPAddress" v-bind="props" />
+            </copy-input-wrapper>
+
+            <copy-input-wrapper #="{ props }" :data="networkName" v-if="isWireGuard">
+              <v-text-field label="Network name" v-model="networkName" readonly v-bind="props" />
             </copy-input-wrapper>
           </form-validator>
         </div>
@@ -206,12 +206,12 @@ type VMNetwork = {
   value: string;
 };
 
-enum NetworkIP {
-  IPV6 = "IPV6",
-  IPV4 = "IPV4",
-  PlanetaryIP = "Planetary IP",
-  MyceliumIP = "Mycelium IP",
-  WireGuardIP = "WireGuard IP",
+enum NetworkInterfaces {
+  PublicIPV4 = "Public IPv4",
+  PublicIPV6 = "Public IPv6",
+  Planetary = "Planetary",
+  Mycelium = "Mycelium",
+  WireGuard = "WireGuard",
 }
 
 export default {
@@ -350,11 +350,11 @@ export default {
     function getSupportedNetworks() {
       const { publicIP, planetary, myceliumIP, interfaces } = props.vm;
 
-      addNetwork(NetworkIP.WireGuardIP, interfaces?.[0]?.ip);
-      addNetwork(NetworkIP.PlanetaryIP, planetary);
-      addNetwork(NetworkIP.MyceliumIP, myceliumIP);
-      addNetwork(NetworkIP.IPV6, publicIP?.ip6.split("/")[0]);
-      addNetwork(NetworkIP.IPV4, publicIP?.ip.split("/")[0]);
+      addNetwork(NetworkInterfaces.WireGuard, interfaces?.[0]?.ip);
+      addNetwork(NetworkInterfaces.Planetary, planetary);
+      addNetwork(NetworkInterfaces.Mycelium, myceliumIP);
+      addNetwork(NetworkInterfaces.PublicIPV6, publicIP?.ip6.split("/")[0]);
+      addNetwork(NetworkInterfaces.PublicIPV4, publicIP?.ip.split("/")[0]);
       selectedIPAddress.value = networks.value[0];
     }
 
@@ -366,7 +366,7 @@ export default {
         }
 
         const IP = selectedIPAddress.value as unknown as string;
-        isWireGuard.value = networks.value.find(net => net.value === IP)?.title === NetworkIP.WireGuardIP;
+        isWireGuard.value = networks.value.find(net => net.value === IP)?.title === NetworkInterfaces.WireGuard;
       },
       { deep: true },
     );

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -249,12 +249,7 @@ export default {
 
     onMounted(async () => {
       updateGrid(grid, { projectName: "" });
-
-      oldPrefix.value =
-        (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
-        grid.config.twinId;
-      prefix.value = oldPrefix.value + props.vm.name;
-      subdomain.value = generateName({ prefix: prefix.value }, 4).toLowerCase();
+      suggestName();
       await loadGateways();
       getSupportedNetworks();
     });
@@ -388,6 +383,14 @@ export default {
     function onBack() {
       gatewayTab.value = 0;
       loadGateways();
+    }
+
+    function suggestName() {
+      oldPrefix.value =
+        (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
+        grid.config.twinId;
+      prefix.value = oldPrefix.value + props.vm.name.includes("_") ? props.vm.name.replace("_", "") : props.vm.name;
+      subdomain.value = generateName({ prefix: prefix.value }, 4).toLowerCase();
     }
 
     const subdomainRules = [

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -249,7 +249,7 @@ export default {
         (props.vm.projectName.toLowerCase().includes(ProjectName.Fullvm.toLowerCase()) ? "fvm" : "vm") +
         grid.config.twinId;
       prefix.value = oldPrefix.value + props.vm.name;
-      subdomain.value = generateName({ prefix: prefix.value }, 4);
+      subdomain.value = generateName({ prefix: prefix.value }, 4).toLowerCase();
       await loadGateways();
       getSupportedNetworks();
     });

--- a/packages/playground/src/utils/gateway.ts
+++ b/packages/playground/src/utils/gateway.ts
@@ -27,7 +27,7 @@ export interface DeployGatewayConfig {
   subdomain: string;
   ip: string;
   port: number;
-  network: string;
+  network?: string;
   tlsPassthrough?: boolean;
 }
 


### PR DESCRIPTION
### Description

As @AhmedHanafy725  reported, there was an issue when selecting another network other than the WireGuard IP

```log
WorkloadDeployError: Failed to deploy gateway-name-proxy with name vm26vmf1d6qf on node 11 due to: failed to setup name proxy: failed to get user network: couldn't load network with id (pL1JFSUwD5VFC): open /var/run/cache/networkd/networks/pL1JFSUwD5VFC: no such file or directory.
```
So, to avoid this error, we must send the network option field only if the WireGuard IP selected


### Changes

- Set the network field as an optional field
- Re-order the list of the networks
- Set the 'WireGuard IP' as the default IP
- Remove the subnet from the IP on change
- Lowercase the subdomain to avoid the validation issues

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3148
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3232


### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
