### PR TITLE
Define the value argument in the TFChainError constructor

### DIFF
--- a/packages/tfchain_client/src/errors.ts
+++ b/packages/tfchain_client/src/errors.ts
@@ -28,27 +28,18 @@ class TFChainError extends Error {
     super(options.message);
     this.name = "TFChainError";
 
-    if (options.keyError) {
-      Object.defineProperty(this, "keyError", { value: options.keyError, enumerable: true });
-    } else {
-      Object.defineProperty(this, "keyError", { value: "GenericError", enumerable: true });
+    if (!options.keyError) {
+      options.keyError = "GenericError";
     }
 
-    if (options.section) {
-      Object.defineProperty(this, "section", { value: options.section, enumerable: true });
-    }
-
-    if (options.args) {
-      Object.defineProperty(this, "args", { value: options.args, enumerable: true });
-    }
-
-    if (options.method) {
-      Object.defineProperty(this, "method", { value: options.method, enumerable: true });
-    }
-
-    if (options.docs) {
-      Object.defineProperty(this, "docs", { value: options.docs, enumerable: true });
-    }
+    Object.keys(options).forEach(key => {
+      if (options[key as keyof ITFChainError]) {
+        Object.defineProperty(this, key, {
+          value: options[key as keyof ITFChainError],
+          enumerable: true,
+        });
+      }
+    });
   }
 }
 

--- a/packages/tfchain_client/src/errors.ts
+++ b/packages/tfchain_client/src/errors.ts
@@ -27,12 +27,28 @@ class TFChainError extends Error {
   constructor(options: ITFChainError) {
     super(options.message);
     this.name = "TFChainError";
-    this.keyError = options.keyError || "GenericError";
-    options.keyError && Object.defineProperty(this, "keyError", options.keyError);
-    options.section && Object.defineProperty(this, "section", options.section);
-    options.args && Object.defineProperty(this, "args", options.args);
-    options.method && Object.defineProperty(this, "method", options.method);
-    options.docs && Object.defineProperty(this, "docs", options.docs);
+
+    if (options.keyError) {
+      Object.defineProperty(this, "keyError", { value: options.keyError, enumerable: true });
+    } else {
+      Object.defineProperty(this, "keyError", { value: "GenericError", enumerable: true });
+    }
+
+    if (options.section) {
+      Object.defineProperty(this, "section", { value: options.section, enumerable: true });
+    }
+
+    if (options.args) {
+      Object.defineProperty(this, "args", { value: options.args, enumerable: true });
+    }
+
+    if (options.method) {
+      Object.defineProperty(this, "method", { value: options.method, enumerable: true });
+    }
+
+    if (options.docs) {
+      Object.defineProperty(this, "docs", { value: options.docs, enumerable: true });
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Following the code changes suggested in [this PR discussion](https://github.com/threefoldtech/tfgrid-sdk-ts/pull/3207#discussion_r1705350580), we initially observed that the `Generic Type` handled the failure correctly but the `TFChain` failed. However, later on, @zaelgohary reported a change in the error pattern—neither KeyError nor TFChainError was being generated.

After further debugging with @0oM4R, we identified the root cause: the value of the property was being sent as a `string` or `undefined`, while the method expects an object in the format `{value: 'The actual value'}`. Additionally, we discovered that using `{enumerable: true}` when defining properties helps ensure that the attributes are displayed correctly when errors are thrown.


### Changes

- Send the value of the prop that I want to define as an object that contains a 'value' attr
- Set the 'enumerable: true' to display the error args

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3304

###

![image](https://github.com/user-attachments/assets/1c101246-ca2b-41e6-a706-28c11661bbd8)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
