### PR TITLE
Support limiting publicip resources in k8s and caprover

### DIFF
--- a/packages/playground/src/components/caprover_worker.vue
+++ b/packages/playground/src/components/caprover_worker.vue
@@ -76,6 +76,8 @@ function toMachine(rootFilesystemSize: number, worker?: CaproverWorker): Selecte
     cpu: worker.solution?.cpu ?? 0,
     memory: worker.solution?.memory ?? 0,
     disk: (worker.solution?.disk ?? 0) + (rootFilesystemSize ?? 0),
+    farmId: worker.selectionDetails.node.farmId,
+    publicIp: true,
   };
 }
 

--- a/packages/playground/src/components/k8s_worker.vue
+++ b/packages/playground/src/components/k8s_worker.vue
@@ -145,10 +145,12 @@ function toMachine(worker?: K8SWorker): SelectedMachine | undefined {
   }
 
   return {
+    farmId: worker.selectionDetails.node.farmId,
     nodeId: worker.selectionDetails.node.nodeId,
     cpu: worker.cpu,
     memory: worker.memory,
     disk: (worker.diskSize ?? 0) + (worker.rootFsSize ?? 0),
+    publicIp: worker.ipv4,
   };
 }
 

--- a/packages/playground/src/components/node_selector/TfSelectionDetails.vue
+++ b/packages/playground/src/components/node_selector/TfSelectionDetails.vue
@@ -29,6 +29,8 @@
             :farm="farm"
             v-model="node"
             v-model:status="nodeStatus"
+            :load-farm="loadFarm"
+            :get-farm="getFarm"
           />
         </template>
 
@@ -39,6 +41,8 @@
           :filters="filters"
           v-model="node"
           v-model:status="nodeStatus"
+          :load-farm="loadFarm"
+          :get-farm="getFarm"
           v-else
         />
       </div>
@@ -70,12 +74,13 @@
 
 <script lang="ts">
 import type { FarmInfo, GPUCardInfo, NodeInfo } from "@threefold/grid_client";
-import { NodeStatus } from "@threefold/gridproxy_client";
+import { type Farm, NodeStatus } from "@threefold/gridproxy_client";
 import type AwaitLock from "await-lock";
 import noop from "lodash/fp/noop.js";
 import type { DeepPartial } from "utility-types";
 import { computed, getCurrentInstance, onMounted, onUnmounted, type PropType, ref, watch } from "vue";
 
+import { gridProxyClient } from "../../clients";
 import { useWatchDeep } from "../../hooks";
 import { useForm, ValidatorStatus } from "../../hooks/form_validator";
 import type { InputValidatorService } from "../../hooks/input_validator";
@@ -139,6 +144,21 @@ export default {
 
     const domain = ref<DomainInfo>();
     const domainStatus = ref<ValidatorStatus>();
+
+    const loadedFarms = new Map<number, Farm>();
+    async function loadFarm(farmId: number) {
+      if (loadedFarms.has(farmId)) {
+        return loadedFarms.get(farmId)!;
+      }
+
+      const [farm] = (await gridProxyClient.farms.list({ farmId })).data;
+      loadedFarms.set(farmId, farm);
+      return farm;
+    }
+
+    function getFarm(farmId: number) {
+      return loadedFarms.get(farmId);
+    }
 
     const selectionDetails = computed(() => {
       return {
@@ -235,6 +255,8 @@ export default {
       domainStatus,
       selectionDetails,
       NodeStatus,
+      loadFarm,
+      getFarm,
     };
   },
 };

--- a/packages/playground/src/types/nodeSelector.ts
+++ b/packages/playground/src/types/nodeSelector.ts
@@ -75,8 +75,10 @@ export interface SelectionDetails {
 }
 
 export interface SelectedMachine {
+  farmId: number;
   nodeId: number;
   cpu: number;
   memory: number;
   disk: number;
+  publicIp: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4563,12 +4563,12 @@ axios@0.25.0:
   dependencies:
     follow-redirects "^1.14.7"
 
-axios@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.0.tgz#f02e4af823e2e46a9768cfc74691fdd0517ea267"
-  integrity sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==
+axios@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
+  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
   dependencies:
-    follow-redirects "^1.15.0"
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -7299,6 +7299,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.14.9, fol
   version "1.15.2"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
### Description
Support limiting publicip resources

### Changes
- Update yarn.lock as it was outdated
- Add 'farmId' and 'publicIp' in selectedMachine type
- use newly added props in k8s worker component
- use newly added props in caprover worker component
- Add get-farm and load-farm in selectionDetails to avoid loading farm more than once in a single deployment
- Add support for checking publicIp resources from farm in auto node selector
- Add support for checking publicIp resources from farm in manual node selector

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3321

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
