### PR TITLE
Fix profile manager tabs and restore `Connect your wallet`

### DIFF
--- a/packages/playground/public/loader/loader.js
+++ b/packages/playground/public/loader/loader.js
@@ -52,7 +52,6 @@ window.$$appLoader = () => {
     t1 && clearTimeout(t1);
     t2 && clearTimeout(t2);
 
-    refreshBtn && refreshBtn.classList.remove("active");
     loader && loader.classList.remove("active");
     if (msgElement) {
       msgElement.textContent = "Dashboard loaded. Welcome!";

--- a/packages/playground/public/loader/loader.js
+++ b/packages/playground/public/loader/loader.js
@@ -47,22 +47,27 @@ refreshBtn &&
   );
 
 window.$$appLoader = () => {
-  refreshBtn && refreshBtn.classList.remove("active");
-  t1 && clearTimeout(t1);
-  t2 && clearTimeout(t2);
+  return new Promise(res => {
+    refreshBtn && refreshBtn.classList.remove("active");
+    t1 && clearTimeout(t1);
+    t2 && clearTimeout(t2);
 
-  refreshBtn && refreshBtn.classList.remove("active");
-  loader && loader.classList.remove("active");
-  if (msgElement) {
-    msgElement.textContent = "Dashboard loaded. Welcome!";
-  }
-
-  setTimeout(() => {
-    if (appLoaderContainer) {
-      appLoaderContainer.classList.remove("active");
-      setTimeout(() => appLoaderContainer.remove(), appLoaderContainerTime);
+    refreshBtn && refreshBtn.classList.remove("active");
+    loader && loader.classList.remove("active");
+    if (msgElement) {
+      msgElement.textContent = "Dashboard loaded. Welcome!";
     }
-  }, welcomeMsgTime);
+
+    setTimeout(() => {
+      if (appLoaderContainer) {
+        appLoaderContainer.classList.remove("active");
+        setTimeout(() => {
+          appLoaderContainer.remove();
+          res();
+        }, appLoaderContainerTime);
+      }
+    }, welcomeMsgTime);
+  });
 };
 window.$$showMonitorError = urls => {
   if (msgElement) msgElement.classList.remove("active");

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -213,7 +213,7 @@ const profileManager = useProfileManager();
 const gridStore = useGrid();
 const network = process.env.NETWORK || (window as any).env.NETWORK;
 
-const openProfile = ref(true);
+const openProfile = ref(false);
 const hasActiveProfile = computed(() => !!profileManager.profile);
 const theme = useTheme();
 const navbarConfig = ref();
@@ -248,7 +248,10 @@ function navigateToHome() {
   return $router.push(DashboardRoutes.Other.HomePage);
 }
 
-onMounted(window.$$appLoader || noop);
+onMounted(async () => {
+  await (window.$$appLoader || noop)();
+  openProfile.value = true;
+});
 
 // eslint-disable-next-line no-undef
 const version = process.env.VERSION as any;

--- a/packages/playground/src/Monitor.vue
+++ b/packages/playground/src/Monitor.vue
@@ -17,6 +17,8 @@ export default {
     const loadingApp = ref(true);
     onMounted(async () => {
       if (await setGlobalEnv()) {
+        /* Load d-tabs before app */
+        await import("./components/dynamic_tabs.vue");
         loadingApp.value = false;
       }
     });

--- a/packages/playground/src/global-components.d.ts
+++ b/packages/playground/src/global-components.d.ts
@@ -37,7 +37,7 @@ declare module "@vue/runtime-core" {
 
 declare global {
   interface Window {
-    $$appLoader: () => void;
+    $$appLoader: () => Promise<void>;
     $$showMonitorError: (urls: { [key: string]: string | null }) => void;
     env: {
       GRAPHQL_STACKS: string[];

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -5,6 +5,7 @@
     :model-value="$props.modelValue"
     @update:model-value="handleProfileDialog($event)"
     attach="#modals"
+    eager
   >
     <template #activator="{ props }">
       <VCard v-bind="props" class="pa-3 d-inline-flex align-center">


### PR DESCRIPTION



### Description

The issue was that we were importing the d-tabs component using `defineAsyncComponent` to avoid initializing [clients](https://github.com/threefoldtech/tfgrid-sdk-ts/blob/development/packages/playground/src/clients/index.ts) before setting its urls by `ServiceURLManager`, This made the ProfileManager mount before the inner component `Dtabs` got imported.


#### Note For Reviewers:
Please make sure to clean the application local storage and **test the application over slow 3G throttling** 

### Changes

- make apploader returns promise.
- open profile manager after apploader is done.
- make profile manage eager.
- load d-tabs before loading app. Co-authored-by: @MohamedElmdary

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3316


### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
