### PR TITLE
Fix network type in getMyContracts fn

### DIFF
--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -261,7 +261,7 @@ class BaseModule {
     if (fetch || !this.contracts) {
       let contracts = await this.tfClient.contracts.listMyNodeContracts({
         graphqlURL: this.config.graphqlURL,
-        type: modulesNames[this.moduleName] ?? this.moduleName,
+        type: modulesNames[this.moduleName] || (this.moduleName === "networks" ? "network" : this.moduleName),
         projectName: this.projectName,
       });
 


### PR DESCRIPTION
### Description

Issue happened because contract type is "network" while we were getting contracts of the module name which is "networks"

![image](https://github.com/user-attachments/assets/8bd76369-1867-4cf5-9a3f-a0b9b00c4f60)


### Changes

- Fix network type in getMyContracts fn

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3032


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
