### PR TITLE
Fix loading the Kubernetes attached machine with TLS

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -296,13 +296,7 @@ export default {
     };
 
     const getDomainNode = (domain: GridGateway): string => {
-      const extractIP = (input: string) => {
-        try {
-          return new URL(input).hostname;
-        } catch {
-          return input.split(":")[0];
-        }
-      };
+      const extractIP = (input: string) => input.replace("https://", "").replace("http://", "").split(":")[0];
 
       const IP = extractIP(domain.backends[0]);
 

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -296,8 +296,15 @@ export default {
     };
 
     const getDomainNode = (domain: GridGateway): string => {
-      const getIP = (url: string) => new URL(url).hostname;
-      const IP = getIP(domain.backends[0]);
+      const extractIP = (input: string) => {
+        try {
+          return new URL(input).hostname;
+        } catch {
+          return input.split(":")[0];
+        }
+      };
+
+      const IP = extractIP(domain.backends[0]);
 
       const isMatchingIP = (ip: string) => ip === IP;
 


### PR DESCRIPTION
### Description

An issue was identified where the attached machine name was not displaying correctly when the machine had the `TLS` option enabled. This occurred because, in such cases, the backend was set to the machine's `IP:PORT` rather than a `URL`. To resolve this, I implemented a checker that determines whether the backend is a `URL` or an `IP`. Based on this check, the appropriate machine name is retrieved.

### Changes

- Check if the backends are URL or IP and get the attached machine based on it.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3149

#### Comment
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3149#issuecomment-2328560795

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
