### PR TITLE
Casperlabs typo

### DIFF
--- a/packages/grid_client/scripts/applications/casperlabs.ts
+++ b/packages/grid_client/scripts/applications/casperlabs.ts
@@ -99,7 +99,7 @@ async function main() {
       },
     ],
     metadata: "",
-    description: "test deploying CasberLabs via ts grid3 client",
+    description: "test deploying CasperLabs via ts grid3 client",
   };
 
   //Deploy VMs


### PR DESCRIPTION
# Situation

- The casperlabs file was named casberlabs. And there was another similar typo in the file

# Note

- Not related to any issue
- Just a quick fix