### PR TITLE
fix: balance calculations to be compatible with new chain changes  

### DIFF
--- a/packages/playground/src/components/contracts_list/contracts_table.vue
+++ b/packages/playground/src/components/contracts_list/contracts_table.vue
@@ -384,7 +384,7 @@ const selectedContracts = ref<NormalizedContract[]>([]);
 const selectedItem = ref();
 const profileManagerController = useProfileManagerController();
 const balance = profileManagerController.balance;
-const freeBalance = computed(() => (balance.value?.free ?? 0) - (balance.value?.locked ?? 0));
+const freeBalance = computed(() => balance.value?.free ?? 0);
 const unlockContractLoading = ref(false);
 const unlockDialog = ref(false);
 const selectedLockedContracts = computed(() => {

--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -278,10 +278,8 @@ defineExpose({
     message.value = "Checking your balance...";
 
     const balance = await loadBalance(grid);
-    const b = balance.free - balance.locked;
-
-    if (b < min) {
-      throw new Error(`You have ${b.toFixed(2)} TFT but it's required to have at least ${min} TFT.`);
+    if (balance.free < min) {
+      throw new Error(`You have ${balance.free.toFixed(2)} TFT but it's required to have at least ${min} TFT.`);
     }
     message.value = "You have enough TFT to continue...";
     return balance;

--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -279,7 +279,7 @@ defineExpose({
 
     const balance = await loadBalance(grid);
     if (balance.free < min) {
-      throw new Error(`You have ${balance.free.toFixed(2)} TFT but it's required to have at least ${min} TFT.`);
+      throw new Error(`Insufficient balance: it's required to have at least ${min} TFT.`);
     }
     message.value = "You have enough TFT to continue...";
     return balance;

--- a/packages/playground/src/utils/grid.ts
+++ b/packages/playground/src/utils/grid.ts
@@ -76,13 +76,13 @@ export function activateAccountAndCreateTwin(mnemonic: string) {
 
 export interface Balance {
   free: number;
-  locked: number;
+  reserved: number;
 }
 export async function loadBalance(grid: GridClient): Promise<Balance> {
   const balance = await grid.balance.getMyBalance();
   return {
     free: +balance.free,
-    locked: +balance.frozen,
+    reserved: +balance.reserved,
   };
 }
 

--- a/packages/playground/src/utils/helpers.ts
+++ b/packages/playground/src/utils/helpers.ts
@@ -48,7 +48,7 @@ export function normalizeError(error: any, fallbackError: string): string {
 }
 
 export function normalizeBalance(num: number | string | undefined, floor = false): string {
-  if (!num || isNaN(+num)) return (num || "").toString();
+  if (!num || isNaN(+num)) return (num ?? "").toString();
 
   if (floor) {
     return (Math.floor(+num * 1000) / 1000).toString();

--- a/packages/playground/src/weblets/profile_manager.vue
+++ b/packages/playground/src/weblets/profile_manager.vue
@@ -22,13 +22,13 @@
             <p>
               Balance:
               <strong :class="theme.name.value === AppThemeSelection.light ? 'text-primary' : 'text-info'">
-                {{ normalizeBalance(balance.free, true) }} TFT
+                {{ normalizeBalance(balance.free + balance.reserved, true) }} TFT
               </strong>
             </p>
             <p>
               Locked:
               <strong :class="theme.name.value === AppThemeSelection.light ? 'text-primary' : 'text-info'">
-                {{ normalizeBalance(balance.locked, true) || 0 }} TFT
+                {{ normalizeBalance(balance.reserved, true) || 0 }} TFT
               </strong>
               <v-tooltip text="Locked balance documentation" location="bottom right">
                 <template #activator="{ props }">
@@ -618,7 +618,7 @@ const isValidConnectConfirmationPassword = computed(() =>
 const profileManagerController = useProfileManagerController();
 
 const balance = profileManagerController.balance;
-let freeBalance = balance.value?.free ?? 0;
+const freeBalance = computed(() => balance.value?.free ?? 0);
 
 const email = ref("");
 
@@ -772,7 +772,6 @@ async function __loadBalance(profile?: Profile, tries = 1) {
     loadingBalance.value = true;
     const grid = await getGrid(profile);
     balance.value = await loadBalance(grid!);
-    freeBalance = balance.value.free ?? 0;
     if (!BalanceWarningRaised && balance.value?.free) {
       if (balance.value?.free < 0.01) {
         createCustomToast("Your balance is too low, Please fund your account.", ToastType.warning);

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -256,7 +256,7 @@ import { useGrid } from "../stores";
 
 const profileManagerController = useProfileManagerController();
 const balance = profileManagerController.balance;
-const freeBalance = computed(() => (balance.value?.free ?? 0) - (balance.value?.locked ?? 0));
+const freeBalance = computed(() => balance.value?.free ?? 0);
 const isLoading = ref<boolean>(false);
 
 const profileManager = useProfileManager();


### PR DESCRIPTION
### Description
To get the total balance now we have to add the free and the reserved, locked balance is not used anymore

### Changes

- replaced locked with reserved
- show the sum of reserved and free in profile manager
- make `freeBalance` variable computed to make it always synced with the balanc

### Related Issues

- #3340 

### Tested Scenarios
- having zero tft, and check the profile manager

- use polkadot UI and call `system/account` to retrieve the actual balance and compare it with the shown in profile manager
- try to empty you account from balance at all and check for the shown values 
- also try to deploy when you have balance less than 2 TFT < should fail> 
- try to deploy when the **free** balance is larger than 2 TFT 

![Screenshot from 2024-09-10 11-47-17](https://github.com/user-attachments/assets/57f76400-5ffc-4e8d-abef-2865a8005732)

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
