### PR TITLE
Delete K8s gateway while deleting its deployment

### DIFF
--- a/packages/playground/src/utils/delete_deployment.ts
+++ b/packages/playground/src/utils/delete_deployment.ts
@@ -44,7 +44,7 @@ export async function deleteDeployment(grid: GridClient, options: DeleteDeployme
       try {
         await grid.gateway.delete_name({ name: gateway.name });
       } catch (error) {
-        console.log("Error while deleting k8s gateway.", error);
+        console.error("Error while deleting k8s gateway.", error);
       }
     }
     return grid.k8s.delete({ name: options.name });

--- a/packages/playground/src/utils/delete_deployment.ts
+++ b/packages/playground/src/utils/delete_deployment.ts
@@ -39,6 +39,14 @@ export async function deleteDeployment(grid: GridClient, options: DeleteDeployme
 
   /* Delete deployment */
   if (options.k8s) {
+    const { gateways } = await loadDeploymentGateways(grid, { filter: gw => true });
+    for (const gateway of gateways) {
+      try {
+        await grid.gateway.delete_name({ name: gateway.name });
+      } catch (error) {
+        console.log("Error while deleting k8s gateway.", error);
+      }
+    }
     return grid.k8s.delete({ name: options.name });
   }
 
@@ -85,6 +93,8 @@ export function solutionHasGateway(projectName: ProjectName) {
     ProjectName.Taiga,
     ProjectName.Wordpress,
     ProjectName.Nextcloud,
+    ProjectName.Gitea,
+    ProjectName.Jenkins,
     ProjectName.Jitsi,
   ];
 


### PR DESCRIPTION
### Changes

- Delete k8s gateways while deleting deployment
- Update solutionHasGateway fn to include Gitea & Jenkins


### Tested Scenarios

- Deploy K8s and subsequently remove its deployment from the deployment list. You will notice that the deployment name contract has been deleted.
- Same scenario for Gitea & Jenkins

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3397
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3369

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
