### PR TITLE
Fix k8s worker planetary

### DIFF
--- a/packages/playground/src/components/manage_k8s_worker_dialog.vue
+++ b/packages/playground/src/components/manage_k8s_worker_dialog.vue
@@ -36,6 +36,9 @@
         <template #[`item.mycelium`]="{ item }">
           {{ item.myceliumIP || "-" }}
         </template>
+        <template #[`item.planetary`]="{ item }">
+          {{ item.planetary || "-" }}
+        </template>
       </ListTable>
     </template>
 


### PR DESCRIPTION
### Description

Set default value for planetary to "-"

![image](https://github.com/user-attachments/assets/dabe1a2e-816e-4898-8a87-f052c48f61dd)

![image](https://github.com/user-attachments/assets/aa9d07fb-78ba-47d4-a6b7-13b2c2ec099e)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3375


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
