### PR TITLE
Remove contract billing and discount type from grid proxy client

### DIFF
--- a/packages/gridproxy_client/src/modules/contracts.ts
+++ b/packages/gridproxy_client/src/modules/contracts.ts
@@ -2,25 +2,11 @@ import { ContractsBuilder, ContractsQuery, ContractState, ContractType } from ".
 import { resolvePaginator } from "../utils";
 import { AbstractClient } from "./abstract_client";
 
-export enum Discount {
-  Default = "Default",
-  None = "none",
-  Bronze = "Bronze",
-  Silver = "Silver",
-  Gold = "Gold",
-}
-
 export interface ContractDetails {
   nodeId: number;
   deployment_data?: string;
   deployment_hash?: string;
   number_of_public_ips?: number;
-}
-
-export interface ContractBilling {
-  amountBilled: number;
-  discountReceived: Discount;
-  timestamp: number;
 }
 
 export interface Contract {
@@ -30,7 +16,6 @@ export interface Contract {
   created_at: number;
   type: ContractType;
   details: ContractDetails;
-  billing: Array<ContractBilling>;
 }
 
 export class ContractsClient extends AbstractClient<ContractsBuilder, ContractsQuery> {


### PR DESCRIPTION

### Changes

- Remove contract billing from gridproxy contract interface as it is no longer used (we get billing and consumption from graphql)  
- Remove Discount enum as it is also not used 
### Related Issues

#3372

### Tested Scenarios

- tested on an account with multiple contracts. Contracts and their respective billing are loaded with no error. 

### Checklist

- [x] Build pass

