### PR TITLE
binding to the correct variable to hide ssh dialogue

### DIFF
--- a/packages/playground/src/views/domains_view.vue
+++ b/packages/playground/src/views/domains_view.vue
@@ -3,7 +3,7 @@
     <TfDomains />
 
     <template #list>
-      <TfDeploymentList title="Domains" :project-name="name" :hide-ssh="true" />
+      <TfDeploymentList title="Domains" :project-name="name" :hideSSH="true" />
     </template>
   </view-layout>
 </template>


### PR DESCRIPTION
### Description

binding to the correct variable to hide ssh dialouge in Domains
![Screenshot from 2024-09-17 12-47-15](https://github.com/user-attachments/assets/33fa351b-edca-4791-88c1-d67c4911a326)

### Changes
-  Binded the value to hideSSH instead of hide-ssh
### Related Issues

- #3348
### Tested Scenarios
- Navigated to Domains page, and There was no ssh dialouge
### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
