### PR TITLE
using the same flist in k8s in master and worker

### DIFF
--- a/packages/grid_client/src/high_level/kubernetes.ts
+++ b/packages/grid_client/src/high_level/kubernetes.ts
@@ -115,6 +115,7 @@ class KubernetesHL extends HighLevelBase {
     solutionProviderId: number,
     zlogsOutput?: string,
     gpus: string[] = [],
+    masterFlist?: string,
   ) {
     events.emit("logs", `Creating a worker with name: ${name} on node: ${nodeId}, network: ${network.name}`);
     const machine = new VMHL(this.config);
@@ -135,7 +136,7 @@ class KubernetesHL extends HighLevelBase {
     return await machine.create(
       name,
       nodeId,
-      Flist,
+      masterFlist ? masterFlist : Flist,
       cpu,
       memory,
       rootfs_size,

--- a/packages/grid_client/src/modules/k8s.ts
+++ b/packages/grid_client/src/modules/k8s.ts
@@ -179,6 +179,12 @@ class K8sModule extends BaseModule {
         wireguardConfig = wgConfig;
       }
     }
+    const masterWorkloads = await this._getMastersWorkload(options.name, deployments);
+    if (masterWorkloads.length === 0) {
+      throw new GridClientErrors.Workloads.WorkloadUpdateError("Couldn't get master node.");
+    }
+    const masterWorkload = masterWorkloads[masterWorkloads.length - 1];
+    const masterFlist = masterWorkload.data["flist"];
 
     if (masterIps.length === 0) {
       masterIps = await this._getMastersIp(options.name, deployments);
@@ -220,6 +226,7 @@ class K8sModule extends BaseModule {
         worker.solutionProviderId!,
         worker.zlogsOutput,
         worker.gpus,
+        masterFlist,
       );
 
       deployments = deployments.concat(twinDeployments);

--- a/packages/grid_client/src/modules/k8s.ts
+++ b/packages/grid_client/src/modules/k8s.ts
@@ -425,6 +425,7 @@ class K8sModule extends BaseModule {
     const networkName = masterWorkload.data["network"].interfaces[0].network;
     const networkIpRange = Addr(masterWorkload.data["network"].interfaces[0].ip).mask(16).toString();
     const network = new Network(networkName, networkIpRange, this.config);
+    const masterFlist = masterWorkload.data["flist"];
     await network.load();
     const contractMetadata = JSON.stringify({
       version: 3,
@@ -461,6 +462,7 @@ class K8sModule extends BaseModule {
       options.solutionProviderId!,
       options.zlogsOutput,
       options.gpus,
+      masterFlist,
     );
 
     return await this._add(options.deployment_name, options.node_id, oldDeployments, twinDeployments, network);


### PR DESCRIPTION
### Description

Added a masterFlist var so when adding a worker the flist would be the same on the master


### Related Issues

- #3320
### Tested Scenarios
- I deployed a cluster using the following flist ```  const Flist = "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist";``` and then proceeded to change the hardcoded Flist to ``` const Flist = "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-v1.flist";``` 
After that I added a new worker 
![Screenshot from 2024-09-25 16-04-13](https://github.com/user-attachments/assets/3ffcf5ce-1d53-44e7-96d5-878fce24b800)
![Screenshot from 2024-09-25 16-04-28](https://github.com/user-attachments/assets/499a266f-b8ce-4ecb-8114-ec0e912b11f7)


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
