### PR TITLE
Fix contracts types update 

### DIFF
--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -259,7 +259,7 @@ class BaseModule {
    * @returns {Promise<Required<GqlNodeContract>[]>} - A promise that resolves to an array of contracts associated with the current module.
    */
   private async getMyContracts(fetch = false): Promise<Required<GqlNodeContract>[]> {
-    const moduleName = modulesNames[this.moduleName];
+    const moduleName = modulesNames[this.moduleName] ?? this.moduleName;
     if (fetch || !this.contracts) {
       let contracts = await this.tfClient.contracts.listMyNodeContracts({
         graphqlURL: this.config.graphqlURL,


### PR DESCRIPTION
fix project name to be dedicated to the passed module name

### Description

what was the issue ?
In deployment list, all contracts got overwritten to be of type `vm`
**The cause** : while migrating machines of type `FullVM` from old playground, we are setting `moduleName` to `FullVm`.
https://github.com/threefoldtech/tfgrid-sdk-ts/blob/ca89db4265da0d544f9ece32b57ea402b6aacb4c/packages/playground/src/utils/migration.ts#L11
but this module name is not exist on [`moduleNames` enum](https://github.com/threefoldtech/tfgrid-sdk-ts/blob/ca89db4265da0d544f9ece32b57ea402b6aacb4c/packages/grid_client/src/modules/base.ts#L28-L35), 
then while listing the contracts we map the passed module name to the moduleNames enum, so the result is undefined, 
https://github.com/threefoldtech/tfgrid-sdk-ts/blob/ca89db4265da0d544f9ece32b57ea402b6aacb4c/packages/grid_client/src/modules/base.ts#L262
and call list function with type `undefine`
https://github.com/threefoldtech/tfgrid-sdk-ts/blob/ca89db4265da0d544f9ece32b57ea402b6aacb4c/packages/grid_client/src/modules/base.ts#L264-L268
so in this case all contract on that project name got listed as the listing function checks for the passed type which is in this case undefined so we are listing all the contracts on this project name 
https://github.com/threefoldtech/tfgrid-sdk-ts/blob/ca89db4265da0d544f9ece32b57ea402b6aacb4c/packages/grid_client/src/clients/tf-grid/contracts.ts#L176-L179

so the expected to list the contracts with type `FullVm` then change its type to vm but now we are listing all contracts on the project name then overwrite its type to be vm

### Changes

add nullish coalescing operator to make sure the module name never got undefined if it failed to map

### Related Issues

- #3378
- #3425


### Tested Scenarios

- deployed vm, wait for it to got listed in the deployment list, check the network contract type
- use `grid.networks.list` to list my contracts

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)



### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
