### PR TITLE
Fixing gitea type

### DIFF
--- a/packages/playground/src/types/index.ts
+++ b/packages/playground/src/types/index.ts
@@ -190,7 +190,7 @@ export const solutionType: { [key: string]: string } = {
   wordpress: "Wordpress",
   staticwebsite: "Static Website",
   tfrobot: "TFRobot",
-  Gitea: "Gitea",
+  gitea: "Gitea",
   nostr: "Nostr",
   domains: "Domains",
   jitsi: "Jitsi",


### PR DESCRIPTION
### Description

Fixing gitea type in ProjectName enum


### Related Issues

- #3423
### Tested Scenarios

- Deployed a gitea instance, navigated to my contracts page and made sure that the type was gitea
![Screenshot from 2024-09-25 16-40-53](https://github.com/user-attachments/assets/29ef5a09-6cfe-4763-b43b-292b7c554173)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
