### PR TITLE
Fix: billing rate on first billing cycle

### DIFF
--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -67,7 +67,9 @@ export interface GqlContracts {
 }
 
 export interface GqlConsumption {
-  contracts: GqlContracts;
+  nameContracts: GqlNameContract[];
+  nodeContracts: GqlNodeContract[];
+  rentContracts: GqlRentContract[];
   contractBillReports: GqlContractBillReports[];
 }
 
@@ -239,16 +241,16 @@ class TFContracts extends Contracts {
       if (billReports.length === 0) {
         return 0;
       } else {
-        let duration: number;
+        let duration = 1;
         const amountBilled = new Decimal(billReports[0].amountBilled);
         if (billReports.length === 2) {
           duration = (billReports[0].timestamp - billReports[1].timestamp) / 3600; // one hour
         } else {
           let createdAt: number;
           for (const contracts of [
-            gqlConsumption.contracts.nodeContracts,
-            gqlConsumption.contracts.nameContracts,
-            gqlConsumption.contracts.rentContracts,
+            gqlConsumption.nodeContracts,
+            gqlConsumption.nameContracts,
+            gqlConsumption.rentContracts,
           ]) {
             if (contracts.length === 1) {
               createdAt = +contracts[0].createdAt;
@@ -257,11 +259,8 @@ class TFContracts extends Contracts {
             }
           }
         }
-        if (!duration) {
-          duration = 1;
-        }
         return amountBilled
-          .div(duration)
+          .div(duration || 1)
           .div(10 ** 7)
           .toNumber();
       }

--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -66,10 +66,7 @@ export interface GqlContracts {
   rentContracts: GqlRentContract[];
 }
 
-export interface GqlConsumption {
-  nameContracts: GqlNameContract[];
-  nodeContracts: GqlNodeContract[];
-  rentContracts: GqlRentContract[];
+export interface GqlConsumption extends GqlContracts {
   contractBillReports: GqlContractBillReports[];
 }
 


### PR DESCRIPTION
-update GqlConsumption interface
-initialize duration with 1 to avoid accessed before initialization error -avoid divide by zero by using the || operator

### Description

the query response have each contract type separated while we are trying to access them indie contracts property
the solution is to access the contracts types directly 

### Changes
-update GqlConsumption interface
-initialize duration with 1 to avoid accessed before initialization error -avoid divide by zero by using the || operator

### Related Issues

- #3406 

### Tested Scenarios

get contract on its first billing cycle, and other with more than one billing report 

![Screenshot from 2024-10-01 15-23-43](https://github.com/user-attachments/assets/89bd659a-a4cb-4ebc-8483-74d6711124a7)
![Screenshot from 2024-10-01 15-24-30](https://github.com/user-attachments/assets/4a8bfdea-3ac1-4d84-a913-b6ea07fa6821)


![Screenshot from 2024-10-01 16-15-26](https://github.com/user-attachments/assets/1afe5f4c-07a4-4cec-9a93-7f9a469663e7)
![Screenshot from 2024-10-01 16-15-32](https://github.com/user-attachments/assets/325a9165-aa80-4b1e-893a-83bd8dd950d2)




