### PR TITLE
Add release date for the applications

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -61,7 +61,7 @@
                             dot
                             inline
                             color="primary"
-                            v-if="item.releaseDate && isReleasedOverMon(item.releaseDate, new Date())"
+                            v-if="item.releaseDate && isReleasedOverMon(item.releaseDate, new Date('2024-10-02'))"
                           ></v-badge>
                         </template>
                       </v-tooltip>
@@ -425,6 +425,7 @@ const routes: AppRoute[] = [
         icon: "mdi-lightbulb-on-outline",
         route: DashboardRoutes.Deploy.Applications,
         tooltip: "Deploy ready applications on the ThreeFold grid.",
+        releaseDate: new Date("2024-10-2"),
       },
       {
         title: "Domains",
@@ -555,7 +556,6 @@ function clickHandler({ route, url }: AppRouteItem): void {
 
 <script lang="ts">
 import type { GridClient } from "@threefold/grid_client";
-import { nextTick } from "process";
 
 import { DashboardRoutes } from "@/router/routes";
 import { AppThemeSelection } from "@/utils/app_theme";

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -61,7 +61,7 @@
                             dot
                             inline
                             color="primary"
-                            v-if="item.releaseDate && isReleasedOverMon(item.releaseDate, new Date('2024-10-02'))"
+                            v-if="item.releaseDate && isReleasedOverMon(item.releaseDate, new Date())"
                           ></v-badge>
                         </template>
                       </v-tooltip>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -432,6 +432,7 @@ const routes: AppRoute[] = [
         icon: "domains.png",
         route: DashboardRoutes.Deploy.Domains,
         tooltip: "Expose servers hosted on local machines or VMs to the public internet.",
+        releaseDate: new Date("2024-10-2"),
       },
       {
         title: "Your Contracts",

--- a/packages/playground/src/views/solutions_view.vue
+++ b/packages/playground/src/views/solutions_view.vue
@@ -30,6 +30,7 @@ export default {
           "Nostr is a simple, open protocol that enables global, decentralized, and censorship-resistant social media.",
         icon: "nostr.png",
         route: DashboardRoutes.Applications.Nostr,
+        releaseDate: new Date("2024-10-02"),
       },
       {
         title: "Gitea",
@@ -37,6 +38,7 @@ export default {
           "Gitea is a forge software package for hosting software development version control using Git as well as other collaborative features like bug tracking, code review, continuous integration, kanban boards, tickets, and wikis. It supports self-hosting but also provides a free public first-party instance.",
         icon: "gitea.png",
         route: DashboardRoutes.Applications.Gitea,
+        releaseDate: new Date("2024-10-02"),
       },
       {
         title: "TFRobot",
@@ -44,6 +46,7 @@ export default {
           "TFRobot is a command line interface tool that offers simultaneous mass deployment of groups of VMs on the ThreeFold Grid, with support of multiple retries for failed deployments, and customizable configurations.",
         icon: "tfrobot.png",
         route: DashboardRoutes.Applications.TFRobot,
+        releaseDate: new Date("2024-10-02"),
       },
       {
         title: "Jenkins",
@@ -51,6 +54,7 @@ export default {
           "Jenkins is a popular open-source automation server that enables developers to build, test, and deploy their applications continuously.",
         icon: "jenkins.png",
         route: DashboardRoutes.Applications.Jenkins,
+        releaseDate: new Date("2024-10-02"),
       },
       {
         title: "Peertube",
@@ -93,6 +97,7 @@ export default {
           "Static Website is an application where a user provides a Github repository url and it's automatically served using Caddy.",
         icon: "static_website.png",
         route: DashboardRoutes.Applications.StaticWebsite,
+        releaseDate: new Date("2024-10-02"),
       },
       {
         title: "Nextcloud",

--- a/packages/playground/src/views/solutions_view.vue
+++ b/packages/playground/src/views/solutions_view.vue
@@ -162,6 +162,7 @@ export default {
           "Jitsi Meet is a set of Open Source projects which empower users to use and deploy video conferencing platforms with state-of-the-art video quality and features.",
         icon: "jitsi.png",
         route: DashboardRoutes.Applications.Jitsi,
+        releaseDate: new Date("2024-10-02"),
       },
     ];
     cards = cards.sort((a, b) => a.title.localeCompare(b.title));


### PR DESCRIPTION
### Description

- Add release date for the applications for Gitea, Jenkins, Jitsi, Nostr, static website, Domains, and TFrobot.
- Remove importing ```nextTick``` as it's not used anymore.

### Changes

![image](https://github.com/user-attachments/assets/4d6a48db-8230-4eb6-9e67-a825f2b97b9e)

![image](https://github.com/user-attachments/assets/a9482e88-c8f5-43bb-a322-c22a21810657)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3448

### Tested Scenarios

- The ```new``` label now is on ```Gitea, Jenkins, Jitsi, Nostr, static website, and TFrobot``` and will expire after 30 days.

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
