### PR TITLE
Development fix vm k8s tests repreated name issue

### DIFF
--- a/packages/grid_client/tests/modules/kubernetes.test.ts
+++ b/packages/grid_client/tests/modules/kubernetes.test.ts
@@ -15,7 +15,7 @@ jest.setTimeout(500000);
 let gridClient: GridClient;
 let deploymentName: string;
 
-beforeAll(async () => {
+beforeEach(async () => {
   gridClient = await getClient();
   deploymentName = generateString(15);
   gridClient.clientOptions.projectName = `kubernetes/${deploymentName}`;
@@ -743,8 +743,5 @@ afterEach(async () => {
     expect(res.updated).toHaveLength(0);
     expect(res.deleted).toBeDefined();
   }
-});
-
-afterAll(async () => {
   return await gridClient.disconnect();
 }, 130000);

--- a/packages/grid_client/tests/modules/vm.test.ts
+++ b/packages/grid_client/tests/modules/vm.test.ts
@@ -7,7 +7,7 @@ jest.setTimeout(300000);
 let gridClient: GridClient;
 let deploymentName: string;
 
-beforeAll(async () => {
+beforeEach(async () => {
   gridClient = await getClient();
   deploymentName = generateString(15);
   gridClient.clientOptions.projectName = `vm/${deploymentName}`;
@@ -568,7 +568,7 @@ test("TC1230 - VM: Deploy Multiple VMs on Different Nodes", async () => {
   }
 });
 
-afterEach(async () => {
+afterAll(async () => {
   const vmNames = await gridClient.machines.list();
   for (const name of vmNames) {
     const res = await gridClient.machines.delete({ name });
@@ -577,8 +577,5 @@ afterEach(async () => {
     expect(res.updated).toHaveLength(0);
     expect(res.deleted).toBeDefined();
   }
-});
-
-afterAll(async () => {
   return await gridClient.disconnect();
 }, 130000);


### PR DESCRIPTION
### Description

Fixing the failing test cases in Kubernetes and VMs where if the tests ran after each other the project name would be the same which will cause the test to fail like `Error: ValidationError: Another k8s deployment with the same name xoix4eg2l5u43w9 already exists.`.


### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3495

