### PR TITLE
Comment cancel deployment function

### DIFF
--- a/packages/grid_client/scripts/multiple_vms.ts
+++ b/packages/grid_client/scripts/multiple_vms.ts
@@ -108,7 +108,7 @@ async function main() {
   await getDeployment(grid3, name);
 
   // //Uncomment the line below to cancel the deployment
-  await cancel(grid3, name);
+  // await cancel(grid3, name);
 
   await grid3.disconnect();
 }


### PR DESCRIPTION
### Description

The deployment cancels after deploying multiple VMs.

### Changes

Comment cancel deployment function

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3431

### Tested Scenarios

Deploying multiple VMs using grid-client script should not be canceled after deploying.

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
