### PR TITLE
Validate twin ID input in transfer TFT page

### DIFF
--- a/packages/playground/src/dashboard/transfer_view.vue
+++ b/packages/playground/src/dashboard/transfer_view.vue
@@ -20,7 +20,7 @@
                   validators.required('Recipient Twin ID is required'),
                   validators.isNotEmpty('Invalid Twin ID'),
                   validators.isInt('Twin ID should be a valid integer.'),
-                  validators.min('Twin ID should be more than 0', 1),
+                  validators.min('Twin ID should be greater than zero', 1),
                   isSameTwinID,
                 ]"
                 :async-rules="[isValidTwinID]"

--- a/packages/playground/src/dashboard/transfer_view.vue
+++ b/packages/playground/src/dashboard/transfer_view.vue
@@ -19,8 +19,8 @@
                 :rules="[
                   validators.required('Recipient Twin ID is required'),
                   validators.isNotEmpty('Invalid Twin ID'),
-                  validators.min('Twin ID should be more than 0', 1),
                   validators.isInt('Twin ID should be a valid integer.'),
+                  validators.min('Twin ID should be more than 0', 1),
                   isSameTwinID,
                 ]"
                 :async-rules="[isValidTwinID]"

--- a/packages/playground/src/dashboard/transfer_view.vue
+++ b/packages/playground/src/dashboard/transfer_view.vue
@@ -19,7 +19,6 @@
                 :rules="[
                   validators.required('Recipient Twin ID is required'),
                   validators.isNotEmpty('Invalid Twin ID'),
-                  validators.isNumeric('Twin ID should be a number'),
                   validators.min('Twin ID should be more than 0', 1),
                   validators.isInt('Twin ID should be a valid integer.'),
                   isSameTwinID,

--- a/packages/playground/src/dashboard/transfer_view.vue
+++ b/packages/playground/src/dashboard/transfer_view.vue
@@ -21,6 +21,7 @@
                   validators.isNotEmpty('Invalid Twin ID'),
                   validators.isNumeric('Twin ID should be a number'),
                   validators.min('Twin ID should be more than 0', 1),
+                  validators.isInt('Twin ID should be a valid integer.'),
                   isSameTwinID,
                 ]"
                 :async-rules="[isValidTwinID]"


### PR DESCRIPTION
### Description

Add validation on twin ID input as it should accept only integers.

### Changes

![image](https://github.com/user-attachments/assets/0b9bd2e9-c83a-4959-9afa-c64b34577194)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3469

### Tested Scenarios

The twin ID input should accept integers only. 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
