### PR TITLE
Add `availableFor` filter in `caprover_leader` script

### DIFF
--- a/packages/grid_client/scripts/orchestrators/caprover_leader.ts
+++ b/packages/grid_client/scripts/orchestrators/caprover_leader.ts
@@ -33,6 +33,7 @@ async function main() {
     mru: 4, // GB
     sru: 10,
     farmId: 1,
+    availableFor: grid3.twinId,
   };
 
   const vms: MachinesModel = {
@@ -64,7 +65,7 @@ async function main() {
         env: {
           PUBLIC_KEY: config.ssh_key,
           SWM_NODE_MODE: "leader",
-          CAPROVER_ROOT_DOMAIN: "rafy.grid.tf", // update me
+          CAPROVER_ROOT_DOMAIN: "dmrcfk2.gent01.dev.grid.tf", // update me
           DEFAULT_PASSWORD: "captain42",
           CAPTAIN_IMAGE_VERSION: "latest",
         },

--- a/packages/grid_client/scripts/orchestrators/caprover_leader.ts
+++ b/packages/grid_client/scripts/orchestrators/caprover_leader.ts
@@ -65,7 +65,7 @@ async function main() {
         env: {
           PUBLIC_KEY: config.ssh_key,
           SWM_NODE_MODE: "leader",
-          CAPROVER_ROOT_DOMAIN: "dmrcfk2.gent01.dev.grid.tf", // update me
+          CAPROVER_ROOT_DOMAIN: "rafy.grid.tf", // update me
           DEFAULT_PASSWORD: "captain42",
           CAPTAIN_IMAGE_VERSION: "latest",
         },


### PR DESCRIPTION
### Description

Add `availableFor` filter in `caprover_leader` script

### Changes

![image](https://github.com/user-attachments/assets/90aebab6-5599-409d-ad3a-bf35bf59d021)

![image](https://github.com/user-attachments/assets/87cdcd25-e68b-4044-8f05-aa87c69c5182)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3433
### Tested Scenarios

Run ```caprover_leader``` script with your domain and password and it should deploy on the only VMs available for you.

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
