### PR TITLE
Reset the farm name value in the create farm dialog

### DIFF
--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -21,10 +21,10 @@
           <v-card-text>
             <form-validator v-model="valid">
               <input-validator
-                :value="$props.name"
+                :value="farmName"
                 :rules="[
                   validators.required('Farm name is required.'),
-                  name => validators.isAlpha('Farm name must start with an alphabet char.')(name[0]),
+                  (farmName: string) => validators.isAlpha('Farm name must start with an alphabet char.')(farmName[0]),
                   validators.minLength('Farm name minimum length is 3 chars.', 3),
                   validators.maxLength('Farm name maximum length is 40 chars.', 40),
                   validators.pattern('Farm name should not contain whitespaces.', {
@@ -34,25 +34,12 @@
                 :async-rules="[validateFarmName]"
                 #="{ props }"
               >
-                <v-text-field
-                  :model-value="$props.name"
-                  v-bind:="props"
-                  @update:model-value="$emit('update:name', $event)"
-                  outlined
-                  label="Farm name"
-                ></v-text-field>
+                <v-text-field v-model="farmName" v-bind:="props" outlined label="Farm name"></v-text-field>
               </input-validator>
             </form-validator>
           </v-card-text>
           <v-card-actions class="justify-end my-1 mr-2">
-            <v-btn
-              color="anchor"
-              @click="
-                showDialogue = false;
-                $emit('update:name', '');
-              "
-              >Close</v-btn
-            >
+            <v-btn color="anchor" @click="showDialogue = false">Close</v-btn>
             <v-btn @click="createFarm" :loading="isCreating" :disabled="!valid || isCreating">Create</v-btn>
           </v-card-actions>
         </v-card>
@@ -72,25 +59,21 @@ import { createCustomToast, ToastType } from "../../utils/custom_toast";
 
 export default {
   name: "CreateFarm",
-  props: {
-    name: {
-      type: String,
-      required: true,
-    },
-  },
-  setup(props, { emit }) {
+  setup() {
     const showDialogue = ref(false);
     const isCreating = ref(false);
     const gridStore = useGrid();
     const valid = ref(false);
+    const farmName = ref("");
+
     async function createFarm() {
       try {
         isCreating.value = true;
-        await gridStore.grid.farms.create({ name: props.name });
+        await gridStore.grid.farms.create({ name: farmName.value });
         createCustomToast("Farm created successfully.", ToastType.success);
         notifyDelaying();
         showDialogue.value = false;
-        emit("update:name", "");
+        farmName.value = "";
       } catch (error) {
         console.log(error);
         createCustomToast("Failed to create farm.", ToastType.danger);
@@ -114,6 +97,7 @@ export default {
       showDialogue,
       isCreating,
       valid,
+      farmName,
       createFarm,
       validateFarmName,
     };

--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -45,7 +45,14 @@
             </form-validator>
           </v-card-text>
           <v-card-actions class="justify-end my-1 mr-2">
-            <v-btn color="anchor" @click="showDialogue = false">Close</v-btn>
+            <v-btn
+              color="anchor"
+              @click="
+                showDialogue = false;
+                $emit('update:name', '');
+              "
+              >Close</v-btn
+            >
             <v-btn @click="createFarm" :loading="isCreating" :disabled="!valid || isCreating">Create</v-btn>
           </v-card-actions>
         </v-card>
@@ -71,7 +78,7 @@ export default {
       required: true,
     },
   },
-  setup(props) {
+  setup(props, { emit }) {
     const showDialogue = ref(false);
     const isCreating = ref(false);
     const gridStore = useGrid();
@@ -83,6 +90,7 @@ export default {
         createCustomToast("Farm created successfully.", ToastType.success);
         notifyDelaying();
         showDialogue.value = false;
+        emit("update:name", "");
       } catch (error) {
         console.log(error);
         createCustomToast("Failed to create farm.", ToastType.danger);

--- a/packages/playground/src/dashboard/farms_view.vue
+++ b/packages/playground/src/dashboard/farms_view.vue
@@ -5,15 +5,13 @@
       <v-card-title class="pa-0">Farms</v-card-title>
     </v-card>
 
-    <CreateFarm v-model:name="name" class="mt-4" />
+    <CreateFarm class="mt-4" />
     <UserFarms ref="userFarms" />
     <UserNodes />
   </div>
 </template>
 
 <script lang="ts">
-import { ref } from "vue";
-
 import CreateFarm from "./components/create_farm.vue";
 import UserFarms from "./components/user_farms.vue";
 import UserNodes from "./components/user_nodes.vue";
@@ -24,13 +22,6 @@ export default {
     UserNodes,
     UserFarms,
     CreateFarm,
-  },
-  setup() {
-    const name = ref<string>("");
-
-    return {
-      name,
-    };
   },
 };
 </script>

--- a/packages/playground/src/dashboard/farms_view.vue
+++ b/packages/playground/src/dashboard/farms_view.vue
@@ -12,10 +12,11 @@
 </template>
 
 <script lang="ts">
+import { ref } from "vue";
+
 import CreateFarm from "./components/create_farm.vue";
 import UserFarms from "./components/user_farms.vue";
 import UserNodes from "./components/user_nodes.vue";
-
 export default {
   name: "DashboardFarms",
   components: {


### PR DESCRIPTION
### Description

Reset the farm name value in the create farm dialog on submit and on close.

### Changes

[Screencast from 03-10-24 15:29:28.webm](https://github.com/user-attachments/assets/650894b5-bcb7-47f3-8b76-4327a6c6ff3e)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3470

### Tested Scenarios

-  Create a farm and open the dialog again after closing.
- open the create farm dialog, insert the farm, close the dialog without submitting then open it again.

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
