### PR TITLE
Add your farms table reload on farm create

### DIFF
--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -71,18 +71,20 @@ export default {
       required: true,
     },
   },
-  setup(props) {
+
+  setup(props, context) {
     const showDialogue = ref(false);
     const isCreating = ref(false);
     const gridStore = useGrid();
     const valid = ref(false);
+
     async function createFarm() {
       try {
         isCreating.value = true;
         await gridStore.grid.farms.create({ name: props.name });
         createCustomToast("Farm created successfully.", ToastType.success);
-        notifyDelaying();
         showDialogue.value = false;
+        context.emit("farm-created");
       } catch (error) {
         console.log(error);
         createCustomToast("Failed to create farm.", ToastType.danger);

--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -85,6 +85,7 @@ export default {
         createCustomToast("Farm created successfully.", ToastType.success);
         showDialogue.value = false;
         context.emit("farm-created");
+        notifyDelaying();
       } catch (error) {
         console.log(error);
         createCustomToast("Failed to create farm.", ToastType.danger);

--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -54,54 +54,62 @@
   </v-container>
 </template>
 
-<script lang="ts" setup>
+<script lang="ts">
 import { ref } from "vue";
+
+import { notifyDelaying } from "@/utils/notifications";
 
 import { gridProxyClient } from "../../clients";
 import { useGrid } from "../../stores";
 import { createCustomToast, ToastType } from "../../utils/custom_toast";
 
-const props = defineProps<{
-  name: {
-    type: string;
-    required: true;
-  };
-}>();
-const showDialogue = ref(false);
-const isCreating = ref(false);
-const gridStore = useGrid();
-const valid = ref(false);
-const emits = defineEmits(["farm-created"]);
-async function createFarm() {
-  try {
-    isCreating.value = true;
-    await gridStore.grid.farms.create({ name: props.name });
-    createCustomToast("Farm created successfully.", ToastType.success);
-    showDialogue.value = false;
-    emits("farm-created");
-  } catch (error) {
-    console.log(error);
-    createCustomToast("Failed to create farm.", ToastType.danger);
-  } finally {
-    isCreating.value = false;
-  }
-}
-async function validateFarmName(name: string) {
-  if (!name.split("").every((c: string) => /[a-zA-Z0-9\-_]/.test(c))) {
-    return {
-      message: "Farm name can only contain alphabetic letters, numbers, '-' or '_'",
-    };
-  }
-
-  const farmsWithSameName = await gridProxyClient.farms.listAll({ name: name.toLocaleLowerCase() });
-  if (farmsWithSameName.length > 0) {
-    return { message: "Farm name already exists!" };
-  }
-}
-</script>
-<script lang="ts">
 export default {
   name: "CreateFarm",
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const showDialogue = ref(false);
+    const isCreating = ref(false);
+    const gridStore = useGrid();
+    const valid = ref(false);
+    async function createFarm() {
+      try {
+        isCreating.value = true;
+        await gridStore.grid.farms.create({ name: props.name });
+        createCustomToast("Farm created successfully.", ToastType.success);
+        notifyDelaying();
+        showDialogue.value = false;
+      } catch (error) {
+        console.log(error);
+        createCustomToast("Failed to create farm.", ToastType.danger);
+      } finally {
+        isCreating.value = false;
+      }
+    }
+    async function validateFarmName(name: string) {
+      if (!name.split("").every((c: string) => /[a-zA-Z0-9\-_]/.test(c))) {
+        return {
+          message: "Farm name can only contain alphabetic letters, numbers, '-' or '_'",
+        };
+      }
+
+      const farmsWithSameName = await gridProxyClient.farms.listAll({ name: name.toLocaleLowerCase() });
+      if (farmsWithSameName.length > 0) {
+        return { message: "Farm name already exists!" };
+      }
+    }
+    return {
+      showDialogue,
+      isCreating,
+      valid,
+      createFarm,
+      validateFarmName,
+    };
+  },
 };
 </script>
 

--- a/packages/playground/src/dashboard/components/user_farms.vue
+++ b/packages/playground/src/dashboard/components/user_farms.vue
@@ -178,13 +178,9 @@ export default {
     watch(
       () => props.reloadFarms,
       async () => {
-        console.log(props.reloadFarms);
-        loading.value = true;
-        console.log(loading.value);
         setTimeout(async () => {
-          await reloadFarms();
+          await getUserFarms();
         }, 30000);
-        loading.value = false;
       },
     );
 

--- a/packages/playground/src/dashboard/components/user_farms.vue
+++ b/packages/playground/src/dashboard/components/user_farms.vue
@@ -139,7 +139,7 @@ import { type Farm, SortBy, SortOrder } from "@threefold/gridproxy_client";
 import { jsPDF } from "jspdf";
 import { debounce } from "lodash";
 import { StrKey } from "stellar-sdk";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 
 import { gridProxyClient } from "@/clients";
 import CardDetails from "@/components/node_details_cards/card_details.vue";
@@ -164,11 +164,30 @@ export default {
     CardDetails,
     AddIP,
   },
-  setup(_, context) {
+  props: {
+    reloadFarms: {
+      type: Boolean,
+    },
+  },
+
+  setup(props, context) {
     const gridStore = useGrid();
     const profile = useProfileManager().profile;
     const twinId = profile!.twinId;
     const search = ref<string>();
+    watch(
+      () => props.reloadFarms,
+      async () => {
+        console.log(props.reloadFarms);
+        loading.value = true;
+        console.log(loading.value);
+        setTimeout(async () => {
+          await reloadFarms();
+        }, 30000);
+        loading.value = false;
+      },
+    );
+
     const headers = [
       {
         title: "Farm ID",
@@ -213,6 +232,7 @@ export default {
 
     const reloadFarms = debounce(getUserFarms, 20000);
     async function getUserFarms() {
+      loading.value = true;
       try {
         const { data, count } = await gridProxyClient.farms.list({
           retCount: true,
@@ -333,6 +353,7 @@ export default {
     }
 
     context.expose({ getFarmsNames, reloadFarms });
+
     return {
       gridStore,
       headers,

--- a/packages/playground/src/dashboard/farms_view.vue
+++ b/packages/playground/src/dashboard/farms_view.vue
@@ -5,8 +5,8 @@
       <v-card-title class="pa-0">Farms</v-card-title>
     </v-card>
 
-    <CreateFarm v-model:name="name" class="mt-4" @farm-created.once="farmsReload = true" />
-    <UserFarms ref="userFarms" @farm-created="farmsReload" />
+    <CreateFarm v-model:name="name" class="mt-4" @farm-created="farmsReload = true" />
+    <UserFarms ref="userFarms" :reloadFarms="farmsReload" />
     <UserNodes />
   </div>
 </template>

--- a/packages/playground/src/dashboard/farms_view.vue
+++ b/packages/playground/src/dashboard/farms_view.vue
@@ -5,8 +5,8 @@
       <v-card-title class="pa-0">Farms</v-card-title>
     </v-card>
 
-    <CreateFarm v-model:name="name" class="mt-4" />
-    <UserFarms ref="userFarms" />
+    <CreateFarm v-model:name="name" class="mt-4" @farm-created.once="farmsReload = true" />
+    <UserFarms ref="userFarms" @farm-created="farmsReload" />
     <UserNodes />
   </div>
 </template>
@@ -27,9 +27,11 @@ export default {
   },
   setup() {
     const name = ref<string>("");
+    const farmsReload = ref<boolean>(false);
 
     return {
       name,
+      farmsReload,
     };
   },
 };


### PR DESCRIPTION


### Changes

- add emit event farm-created from createfarm after farm is created
- add listener in parent to receive event pass it down to userfarms
- add prop in userfarms to update on user create

### Related Issues

#3471

### Tested Scenarios

- created a farm, watched user farms table get reloaded after 30 seconds 

