### PR TITLE
Fix the Domains page view on the before-login view

### DIFF
--- a/packages/playground/src/components/node_selector/TfDomainName.vue
+++ b/packages/playground/src/components/node_selector/TfDomainName.vue
@@ -147,7 +147,6 @@ export default {
       size: window.env.PAGE_SIZE,
       page: Math.max(1, pagination.value.page),
       farmId: enableCustomDomain.value ? props.farm?.farmId : undefined,
-      availableFor: gridStore.client.twinId,
     }));
     const selectedDomain = ref<NodeInfo | null>(null);
     const loadDomains = () => domainsTask.value.run(gridStore, filters.value);

--- a/packages/playground/src/components/node_selector/TfDomainName.vue
+++ b/packages/playground/src/components/node_selector/TfDomainName.vue
@@ -147,6 +147,7 @@ export default {
       size: window.env.PAGE_SIZE,
       page: Math.max(1, pagination.value.page),
       farmId: enableCustomDomain.value ? props.farm?.farmId : undefined,
+      availableFor: gridStore.client?.twinId,
     }));
     const selectedDomain = ref<NodeInfo | null>(null);
     const loadDomains = () => domainsTask.value.run(gridStore, filters.value);

--- a/packages/playground/src/router/index.ts
+++ b/packages/playground/src/router/index.ts
@@ -609,7 +609,7 @@ function createDeployRoutes(): RouteRecordRaw[] {
         {
           path: DashboardRoutes.Deploy.Domains,
           component: () => import("@/views/domains_view.vue"),
-          meta: { title: "Domains", publicPath: true },
+          meta: { title: "Domains" },
         },
         {
           path: DashboardRoutes.Deploy.NodeFinder,


### PR DESCRIPTION
### Description

Fix the Domains page view on the before-login view
### Changes

[Screencast from 16-10-24 14:45:32.webm](https://github.com/user-attachments/assets/88b5fe45-6fbe-4292-8ea1-92ae5c5ec05c)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3520

### Tested Scenarios

- Try to reach the domains page before logging in.
- After login go to the domains page and logout from there.

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
