### PR TITLE
Fix broken governance link

### DIFF
--- a/packages/playground/src/utils/manual.ts
+++ b/packages/playground/src/utils/manual.ts
@@ -5,7 +5,7 @@ export const manual = {
   tft_bridges: `${BASE}/documentation/threefold_token/tft_bridges/tft_bridges.html`,
   buy_sell_tft: `${BASE}/documentation/threefold_token/buy_sell_tft/buy_sell_tft.html`,
   farmers: `${BASE}/documentation/farmers/farmers.html`,
-  governance: `${BASE}/knowledge_base/about/governance.html`,
+  governance: `${BASE}/documentation/dashboard/tfchain/tf_dao.html`,
   pricing: `${BASE}/knowledge_base/cloud/pricing/pricing.html`,
   dao: `${BASE}/documentation/dashboard/tfchain/tf_dao.html`,
   caprover: `${BASE}/documentation/dashboard/solutions/caprover.html`,


### PR DESCRIPTION
### Description
Fix broken governance link

### Changes

The governance link was replaced [Dao](https://manual.grid.tf/documentation/dashboard/tfchain/tf_dao.html) link as per https://github.com/threefoldtech/info_grid/issues/660#issuecomment-2416865086 

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3522

### Documentation PR

- https://github.com/threefoldtech/info_grid/issues/660

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
