### PR TITLE
delete vm deployment with its all gateway

### DIFF
--- a/packages/playground/src/utils/delete_deployment.ts
+++ b/packages/playground/src/utils/delete_deployment.ts
@@ -10,7 +10,7 @@ export interface DeleteDeploymentOptions {
   deploymentName?: string;
   name: string;
   projectName: ProjectName;
-  ip?: string;
+  ip?: string[];
   k8s?: boolean;
 }
 
@@ -117,9 +117,9 @@ function isVm(projectName: string) {
   return false;
 }
 
-async function deleteVmGateways(grid: GridClient, ip?: string) {
+async function deleteVmGateways(grid: GridClient, ips?: string[]) {
   const { gateways } = await loadDeploymentGateways(grid, {
-    filter: ip ? gw => gw.backends.some(bk => bk.includes(ip)) : undefined,
+    filter: ips ? gw => gw.backends.some(bk => ips.some(ip => bk.includes(ip))) : undefined,
   });
   for (const gateway of gateways) {
     try {

--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -518,7 +518,7 @@ async function onDelete(k8s = false) {
               deploymentName: item.deploymentName,
               name: k8s ? item.deploymentName : item.name,
               projectName: item.projectName,
-              ip: item.interfaces?.[0]?.ip,
+              ip: getDeploymentIps(item),
               k8s,
             });
           }
@@ -565,6 +565,28 @@ deploymentListManager?.register(uid, () => {
 });
 
 onUnmounted(() => deploymentListManager?.unregister(uid));
+/**
+ * Collect the deployment interfaces ips
+ * @param item deployment data
+ * @returns {string[]} list of strings
+ */
+function getDeploymentIps(item: any): string[] {
+  const ips = [];
+  // wg ip
+  if (item.interfaces) {
+    for (const iface of item.interfaces) {
+      if (iface.ip) ips.push(iface.ip);
+    }
+  }
+  // public ip, ipv6
+  if (item.publicIP) {
+    if (item.publicIP.ip) ips.push(item.publicIP.ip.split("/")[0]);
+    if (item.publicIP.ip6) ips.push(item.publicIP.ip6.split("/")[0]);
+  }
+  if (item.planetary) ips.push(item.planetary);
+  if (item.myceliumIP) ips.push(item.myceliumIP);
+  return ips;
+}
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
### Description

list all domains on all available interfaces 

### Changes

add `getDeploymentIps` that returns an array of all ips on the contract 

### Related Issues

- #3485

### Tested Scenarios

added a 5 gw on the different network interfaces and delete the deployement
![Screenshot from 2024-10-20 11-59-26](https://github.com/user-attachments/assets/e5db749d-1207-47c3-9ddf-3c9067af3101)

### Checklist

- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
