### PR TITLE
Update farm reload after farm creation

### DIFF
--- a/packages/playground/src/dashboard/components/create_farm.vue
+++ b/packages/playground/src/dashboard/components/create_farm.vue
@@ -59,7 +59,7 @@ import { createCustomToast, ToastType } from "../../utils/custom_toast";
 
 export default {
   name: "CreateFarm",
-  setup() {
+  setup(_, context) {
     const showDialogue = ref(false);
     const isCreating = ref(false);
     const gridStore = useGrid();
@@ -73,6 +73,7 @@ export default {
         createCustomToast("Farm created successfully.", ToastType.success);
         showDialogue.value = false;
         farmName.value = "";
+        context.emit("farm-created");
         notifyDelaying();
       } catch (error) {
         console.log(error);

--- a/packages/playground/src/dashboard/farms_view.vue
+++ b/packages/playground/src/dashboard/farms_view.vue
@@ -5,14 +5,14 @@
       <v-card-title class="pa-0">Farms</v-card-title>
     </v-card>
 
-    <CreateFarm class="mt-4" @farm-created="farmsReload = true" />
-    <UserFarms ref="userFarms" :reloadFarms="farmsReload" />
+    <CreateFarm class="mt-4" @farm-created="handleFarmCreated" />
+    <UserFarms :ref="el => (userFarms = el)" :reloadFarms="farmsReload" />
     <UserNodes />
   </div>
 </template>
 
 <script lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 
 import CreateFarm from "./components/create_farm.vue";
 import UserFarms from "./components/user_farms.vue";
@@ -26,9 +26,20 @@ export default {
   },
   setup() {
     const farmsReload = ref<boolean>(false);
-
+    const userFarms = ref();
+    function handleFarmCreated() {
+      farmsReload.value = !farmsReload.value;
+    }
+    watch(
+      () => farmsReload.value,
+      () => {
+        userFarms.value.reloadFarms = farmsReload.value;
+      },
+    );
     return {
       farmsReload,
+      handleFarmCreated,
+      userFarms,
     };
   },
 };


### PR DESCRIPTION
### Changes

- added previously removed event emitter in create farm
- added prop change listener and changer in parent that emits reload farms in child

### Related Issues

#3471

### Tested Scenarios

- created a farm, waited for reload then created another farm and waited for reload
- need to wait 30seconds after farm creation for reload
- tested it after page refresh


### Checklist

- [x] Screenshots/Video attached (needed for UI changes)
https://www.loom.com/share/1a0590819e504839b53fb95f59b4a758?sid=ef2a05d8-fd91-4688-b000-e80dd8263b0e
