### PR TITLE
update max name length in solutions

### DIFF
--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -25,7 +25,7 @@ import { IsAlphanumericExpectUnderscore } from "../helpers";
 import { Deployment } from "../zos/deployment";
 import { ZdbModes } from "../zos/zdb";
 import { blockchainType } from "./blockchainInterface";
-const NameLength = 50;
+const NameLength = 35;
 const FarmNameLength = 40;
 
 enum ContractStates {

--- a/packages/playground/src/components/caprover_worker.vue
+++ b/packages/playground/src/components/caprover_worker.vue
@@ -7,7 +7,7 @@
         validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
         (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
         validators.minLength('Name must be at least 2 characters.', 2),
-        validators.maxLength('Name cannot exceed 50 characters.', 50),
+        validators.maxLength('Name cannot exceed 35 characters.', 35),
       ]"
       :value="$props.modelValue.name"
       #="{ props }"

--- a/packages/playground/src/components/k8s_worker.vue
+++ b/packages/playground/src/components/k8s_worker.vue
@@ -8,7 +8,7 @@
         (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
         validators.isAlphanumeric('Name should consist of alphabets & numbers only.'),
         validators.minLength('Name minimum length is 2 chars.', 2),
-        validators.maxLength('Name max length is 50 chars.', 50),
+        validators.maxLength('Name max length is 35 chars.', 35),
       ]"
       #="{ props }"
     >

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -468,7 +468,7 @@ export default {
       validators.isAlphanumeric("Subdomain should consist of letters and numbers only."),
       (subdomain: string) => validators.isAlpha("Subdomain must start with an alphabet char.")(subdomain[0]),
       validators.minLength("Subdomain must be at least 4 characters.", 4),
-      (subdomain: string) => validators.maxLength("Subdomain cannot exceed 50 characters.", 50)(subdomain),
+      (subdomain: string) => validators.maxLength("Subdomain cannot exceed 35 characters.", 35)(subdomain),
     ];
 
     const portRules = [validators.required("Port is required."), validators.isPort("Please provide a valid port.")];

--- a/packages/playground/src/weblets/freeflow.vue
+++ b/packages/playground/src/weblets/freeflow.vue
@@ -20,7 +20,7 @@
           validators.required('Name is required.'),
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           validators.minLength('Name must be at least 4 characters.', 4),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/freeflow.vue
+++ b/packages/playground/src/weblets/freeflow.vue
@@ -20,7 +20,7 @@
           validators.required('Name is required.'),
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           validators.minLength('Name must be at least 4 characters.', 4),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/full_vm.vue
+++ b/packages/playground/src/weblets/full_vm.vue
@@ -27,7 +27,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >
@@ -105,7 +105,7 @@
               (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]), 
               validators.minLength('Disk name minimum length is 2 characters.', 2), 
               validators.isAlphanumeric('Disk name only accepts alphanumeric characters.'),
-              validators.maxLength('Disk name maximum length is 50 characters.', 50),
+              validators.maxLength('Disk name maximum length is 35 characters.', 35),
             ]"
             #="{ props }"
           >

--- a/packages/playground/src/weblets/jenkins.vue
+++ b/packages/playground/src/weblets/jenkins.vue
@@ -19,7 +19,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/jenkins.vue
+++ b/packages/playground/src/weblets/jenkins.vue
@@ -19,7 +19,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -29,7 +29,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >
@@ -131,7 +131,7 @@
               }),
               validators.minLength('Disk name minimum length is 2 characters.', 2),
               validators.isAlphanumeric('Disk name only accepts alphanumeric characters.'),
-              validators.maxLength('Disk name maximum length is 50 characters.', 50),
+              validators.maxLength('Disk name maximum length is 35 characters.', 35),
             ]"
             #="{ props }"
           >

--- a/packages/playground/src/weblets/tf_algorand.vue
+++ b/packages/playground/src/weblets/tf_algorand.vue
@@ -19,7 +19,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_casperlabs.vue
+++ b/packages/playground/src/weblets/tf_casperlabs.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -26,7 +26,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 35 characters.', 35),
+            validators.maxLength('Name cannot exceed 15 characters.', 15),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_discourse.vue
+++ b/packages/playground/src/weblets/tf_discourse.vue
@@ -26,7 +26,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_domains.vue
+++ b/packages/playground/src/weblets/tf_domains.vue
@@ -1,7 +1,9 @@
 <template>
   <weblet-layout ref="layout">
-    
-    <template #title><span><v-icon  class="pr-3">mdi-web-box</v-icon></span>Deploy Domains Instance </template>
+    <template #title
+      ><span><v-icon class="pr-3">mdi-web-box</v-icon></span
+      >Deploy Domains Instance
+    </template>
 
     <d-tabs :tabs="[{ title: 'Config', value: 'config' }]">
       <template #config>
@@ -14,7 +16,7 @@
               validators.isAlphanumeric('Subdomain should consist of letters and numbers only.'),
               subdomain => validators.isAlpha('Subdomain must start with alphabet char.')(subdomain[0]),
               validators.minLength('Subdomain must be at least 4 characters.', 4),
-              subdomain => validators.maxLength('Subdomain cannot exceed 50 characters.', 50)(subdomain),
+              subdomain => validators.maxLength('Subdomain cannot exceed 35 characters.', 35)(subdomain),
             ]"
             :async-rules="[validateSubdomain]"
             #="{ props }"

--- a/packages/playground/src/weblets/tf_domains.vue
+++ b/packages/playground/src/weblets/tf_domains.vue
@@ -16,7 +16,7 @@
               validators.isAlphanumeric('Subdomain should consist of letters and numbers only.'),
               subdomain => validators.isAlpha('Subdomain must start with alphabet char.')(subdomain[0]),
               validators.minLength('Subdomain must be at least 4 characters.', 4),
-              subdomain => validators.maxLength('Subdomain cannot exceed 15 characters.', 15)(subdomain),
+              subdomain => validators.maxLength('Subdomain cannot exceed 35 characters.', 35)(subdomain),
             ]"
             :async-rules="[validateSubdomain]"
             #="{ props }"

--- a/packages/playground/src/weblets/tf_domains.vue
+++ b/packages/playground/src/weblets/tf_domains.vue
@@ -16,7 +16,7 @@
               validators.isAlphanumeric('Subdomain should consist of letters and numbers only.'),
               subdomain => validators.isAlpha('Subdomain must start with alphabet char.')(subdomain[0]),
               validators.minLength('Subdomain must be at least 4 characters.', 4),
-              subdomain => validators.maxLength('Subdomain cannot exceed 35 characters.', 35)(subdomain),
+              subdomain => validators.maxLength('Subdomain cannot exceed 15 characters.', 15)(subdomain),
             ]"
             :async-rules="[validateSubdomain]"
             #="{ props }"

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_funkwhale.vue
+++ b/packages/playground/src/weblets/tf_funkwhale.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_jitsi.vue
+++ b/packages/playground/src/weblets/tf_jitsi.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           name => validators.isAlpha('Name must start with alphabet char.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_jitsi.vue
+++ b/packages/playground/src/weblets/tf_jitsi.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           name => validators.isAlpha('Name must start with alphabet char.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_kubernetes.vue
+++ b/packages/playground/src/weblets/tf_kubernetes.vue
@@ -30,7 +30,7 @@
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             validators.minLength('Name minimum length is 2 chars.', 2),
-            validators.maxLength('Name max length is 50 chars.', 50),
+            validators.maxLength('Name max length is 35 chars.', 35),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -27,7 +27,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 35 characters.', 35),
+            validators.maxLength('Name cannot exceed 15 characters.', 15),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_mattermost.vue
+++ b/packages/playground/src/weblets/tf_mattermost.vue
@@ -27,7 +27,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_nextcloud.vue
+++ b/packages/playground/src/weblets/tf_nextcloud.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_nextcloud.vue
+++ b/packages/playground/src/weblets/tf_nextcloud.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_nostr.vue
+++ b/packages/playground/src/weblets/tf_nostr.vue
@@ -21,7 +21,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -28,7 +28,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 35 characters.', 35),
+            validators.maxLength('Name cannot exceed 15 characters.', 15),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_owncloud.vue
+++ b/packages/playground/src/weblets/tf_owncloud.vue
@@ -28,7 +28,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_peertube.vue
+++ b/packages/playground/src/weblets/tf_peertube.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_presearch.vue
+++ b/packages/playground/src/weblets/tf_presearch.vue
@@ -32,7 +32,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_staticwebsite.vue
+++ b/packages/playground/src/weblets/tf_staticwebsite.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_staticwebsite.vue
+++ b/packages/playground/src/weblets/tf_staticwebsite.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_subsquid.vue
+++ b/packages/playground/src/weblets/tf_subsquid.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -27,7 +27,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 35 characters.', 35),
+            validators.maxLength('Name cannot exceed 15 characters.', 15),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_taiga.vue
+++ b/packages/playground/src/weblets/tf_taiga.vue
@@ -27,7 +27,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >

--- a/packages/playground/src/weblets/tf_umbrel.vue
+++ b/packages/playground/src/weblets/tf_umbrel.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 50 characters.', 50),
+          validators.maxLength('Name cannot exceed 35 characters.', 35),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tf_wordpress.vue
+++ b/packages/playground/src/weblets/tf_wordpress.vue
@@ -20,7 +20,7 @@
           validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
           (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
           validators.minLength('Name must be at least 2 characters.', 2),
-          validators.maxLength('Name cannot exceed 35 characters.', 35),
+          validators.maxLength('Name cannot exceed 15 characters.', 15),
         ]"
         #="{ props }"
       >

--- a/packages/playground/src/weblets/tfrobot.vue
+++ b/packages/playground/src/weblets/tfrobot.vue
@@ -29,7 +29,7 @@
             validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
             (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
             validators.minLength('Name must be at least 2 characters.', 2),
-            validators.maxLength('Name cannot exceed 50 characters.', 50),
+            validators.maxLength('Name cannot exceed 35 characters.', 35),
           ]"
           #="{ props }"
         >


### PR DESCRIPTION
### Changes

- changed max name length in deployment model in client
- changed max name length in all deployment dashboard validation
- in solutions that require domain, max name length was changed to 15 chars
- in all other solutions, max name length was changed to 35 chars
### Related Issues

#2364

### Tested Scenarios

- entered a name longer than 35 chars in dashboard deployments


![image](https://github.com/user-attachments/assets/d8fe0f5a-f657-48b9-94e8-4959f5a85b75)
