### PR TITLE
Add max value for balance calculation

### DIFF
--- a/packages/playground/src/calculator/pricing_calculator.vue
+++ b/packages/playground/src/calculator/pricing_calculator.vue
@@ -95,6 +95,7 @@
                 <InputTooltip tooltip="The amount of TFT to calculate discount.">
                   <VTextField
                     label="Balance"
+                    :max="10 ** 15"
                     suffix="TFT"
                     :rules="[balanceRules]"
                     :disabled="userBalance && resources.useCurrentBalance"

--- a/packages/playground/src/utils/pricing_calculator.ts
+++ b/packages/playground/src/utils/pricing_calculator.ts
@@ -50,7 +50,7 @@ export const hruRules = _applyRules([
 export const balanceRules = _applyRules([
   isNumeric("Balance must be a valid number."),
   min("Minimum allowed balance is 0.", 0),
-  max("Maximum allowed balance is 1000000000000000 TFT.", 10 ** 15),
+  max("Maximum allowed balance is 10e15 TFT.", 10 ** 15),
 ]);
 
 export function normalizePrice(price: number) {

--- a/packages/playground/src/utils/pricing_calculator.ts
+++ b/packages/playground/src/utils/pricing_calculator.ts
@@ -50,6 +50,7 @@ export const hruRules = _applyRules([
 export const balanceRules = _applyRules([
   isNumeric("Balance must be a valid number."),
   min("Minimum allowed balance is 0.", 0),
+  max("Maximum allowed balance is 1000000000000000 TFT.", 10 ** 15),
 ]);
 
 export function normalizePrice(price: number) {

--- a/packages/playground/src/utils/pricing_calculator.ts
+++ b/packages/playground/src/utils/pricing_calculator.ts
@@ -50,7 +50,7 @@ export const hruRules = _applyRules([
 export const balanceRules = _applyRules([
   isNumeric("Balance must be a valid number."),
   min("Minimum allowed balance is 0.", 0),
-  max("Maximum allowed balance is 10e15 TFT.", 10 ** 15),
+  max("Maximum allowed balance is 1e15 TFT.", 10 ** 15),
 ]);
 
 export function normalizePrice(price: number) {


### PR DESCRIPTION
### Description

Add max value for balance calculation to be ```1000000000000000```.

### Changes

![image](https://github.com/user-attachments/assets/41c77177-b135-4a06-bd8c-1c3c942c3af1)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3529

### Tested Scenarios

Try to add more than ```1000000000000000``` in balance input.

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
