### PR TITLE
add `IsAlphanumericExpectUnderscore` to k8s modules and caprover,

### DIFF
--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -153,7 +153,7 @@ class MachinesModel {
 }
 
 class AddMachineModel extends MachineModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength) deployment_name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumericExpectUnderscore() @MaxLength(NameLength) deployment_name: string;
   @Expose() @IsString() @IsOptional() myceliumNetworkSeed?: string;
 }
 
@@ -167,7 +167,7 @@ class MachinesGetModel extends BaseGetDeleteModel {}
 class MachinesDeleteModel extends BaseGetDeleteModel {}
 
 class KubernetesNodeModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength) name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumericExpectUnderscore() @MaxLength(NameLength) name: string;
   @Expose() @IsInt() @Min(1) node_id: number;
   @Expose() @IsInt() @Min(1) cpu: number;
   @Expose() @Min(1024) memory: number; // in MB
@@ -187,7 +187,7 @@ class KubernetesNodeModel {
 }
 
 class K8SModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength) name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumericExpectUnderscore() @MaxLength(NameLength) name: string;
   @Expose() @IsString() @IsNotEmpty() secret: string;
   @Expose() @Type(() => NetworkModel) @ValidateNested() network: NetworkModel;
   @Expose() @Type(() => KubernetesNodeModel) @ValidateNested({ each: true }) masters: KubernetesNodeModel[];
@@ -202,13 +202,13 @@ class K8SGetModel extends BaseGetDeleteModel {}
 class K8SDeleteModel extends BaseGetDeleteModel {}
 
 class AddWorkerModel extends KubernetesNodeModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength) deployment_name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumericExpectUnderscore() @MaxLength(NameLength) deployment_name: string;
   @Expose() @IsString() @IsOptional() myceliumNetworkSeed?: string;
 }
 
 class DeleteWorkerModel {
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength) deployment_name: string;
-  @Expose() @IsString() @IsNotEmpty() @IsAlphanumeric() @MaxLength(NameLength) name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumericExpectUnderscore() @MaxLength(NameLength) deployment_name: string;
+  @Expose() @IsString() @IsNotEmpty() @IsAlphanumericExpectUnderscore() @MaxLength(NameLength) name: string;
 }
 
 class ZDBModel {

--- a/packages/playground/src/components/k8s_worker.vue
+++ b/packages/playground/src/components/k8s_worker.vue
@@ -6,7 +6,7 @@
         validators.required('Name is required.'),
         validators.isLowercase('Name should consist of lowercase letters only.'),
         (name: string) => validators.isAlpha('Name must start with an alphabetical character.')(name[0]),
-        validators.isAlphanumeric('Name should consist of alphabets & numbers only.'),
+        validators.IsAlphanumericExpectUnderscore('Name should consist of letters ,numbers and underscores only.'),
         validators.minLength('Name minimum length is 2 chars.', 2),
         validators.maxLength('Name max length is 50 chars.', 50),
       ]"


### PR DESCRIPTION


### Description

allow underscore in dashboard k8s validations

### Changes

add `IsAlphanumericExpectUnderscore` to all k8s models and `addMachineModel`

### Related Issues

- #3545 

### Tested Scenarios
with underscore in the name 
- attache caprover worker, delete it 
- create k8s cluster, add worker, delete worker, delete cluster 
![Screenshot from 2024-10-24 15-32-37](https://github.com/user-attachments/assets/2fef0798-a787-42f9-a330-05aa69d964dd)
![Screenshot from 2024-10-24 15-11-46](https://github.com/user-attachments/assets/ea8f6f4b-cff4-4441-ae46-6022bef5d709)
![Screenshot from 2024-10-24 15-03-41](https://github.com/user-attachments/assets/55df47f0-c6c1-416d-b08c-3f0d2132e5ac)


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
