### PR TITLE
update max timeout message

### DIFF
--- a/packages/playground/src/views/settings.vue
+++ b/packages/playground/src/views/settings.vue
@@ -115,7 +115,7 @@
             validators.required('Query timeout is required.'),
             validators.isInt('Timeout must be a valid integer.'),
             validators.min(`Query timeout should be at least 3 second.`, 3),
-            validators.max('Query timeout maximum limit exceeded', 3 * 60),
+            validators.max('Query timeout maximum limit is 180 seconds', 3 * 60),
           ]"
           #="{ props }"
           ref="timeoutQueryInput"
@@ -145,7 +145,7 @@
             validators.required('Deployment timeout is required.'),
             validators.isInt('Timeout must be a valid integer.'),
             validators.min(`Deployment timeout should be at least 3 second.`, 3),
-            validators.max('Deployment timeout maximum limit exceeded', 30 * 60),
+            validators.max('Deployment timeout maximum limit is 1800 seconds', 30 * 60),
           ]"
           #="{ props }"
           ref="timeoutDeploymentInput"


### PR DESCRIPTION

### Changes

- update validation error message for query and deployment timeout in settings page to include the max limit for each

### Related Issues

[3169](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3169)

### Tested Scenarios

- added query timeout above limit, watch validation error
- added deployment timeout above limit, watch validation error


### Checklist
- [x] Screenshots/Video attached (needed for UI changes)
![image](https://github.com/user-attachments/assets/34a16fe8-d1c4-49be-9f07-d533c0b52198)
