### PR TITLE
refactor: KYC health

### DIFF
--- a/packages/grid_client/src/clients/kyc/client.ts
+++ b/packages/grid_client/src/clients/kyc/client.ts
@@ -188,7 +188,7 @@ export class KYC {
   async isHealthy(): Promise<boolean> {
     try {
       const res = await axios.get(urlJoin("https://", this.apiDomain, API_PREFIX, "health"));
-      const { status } = res.data;
+      const { status } = res.data.result;
       if (status !== `Healthy`) return false;
       return true;
     } catch (error) {

--- a/packages/monitoring/src/serviceMonitor/kyc.ts
+++ b/packages/monitoring/src/serviceMonitor/kyc.ts
@@ -11,8 +11,8 @@ export class KYCMonitor extends ServiceBase implements ILivenessChecker {
     try {
       const res = await fetch(urlJoin(url, "/api/v1/health"));
       if (!res?.ok) throw Error(`HTTP Response Code: ${res?.status}`);
-      const { status } = await res.json();
-      if (status !== "Healthy") throw Error(`Status: ${status}`);
+      const { result } = await res.json();
+      if (result.status !== "Healthy") throw Error(`Status: ${result.status}`);
       return { alive: true };
     } catch (error) {
       return { alive: false, error };


### PR DESCRIPTION
update the KYC client and   kycMonitor to parse the status from result object

### Related Issues

- #3531 

### Tested Scenarios

Dashboard should work fine now without reporting that the kyc is unreachable  



