### PR TITLE
 fix domain list error on reload

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -331,8 +331,10 @@ export default {
         });
         gateways.value = gws;
         failedToListGws.value = failedToList;
-        if (failedToListGws.value.length) {
+        if (failedToListGws.value.length != 0) {
           errorMessage.value = `Failed to list ${failedToListGws.value.length} domains`;
+        } else {
+          errorMessage.value = "";
         }
       } catch (error) {
         errorMessage.value = "Failed to list this deployment's domains";

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -324,6 +324,8 @@ export default {
         gateways.value = [];
         gatewaysToDelete.value = [];
         loadingGateways.value = true;
+        failedToListGws.value = [];
+        errorMessage.value = "";
 
         updateGrid(grid, { projectName: props.vm ? props.vm.projectName : props.k8s!.projectName });
 
@@ -335,9 +337,6 @@ export default {
         if (failedToList.length != 0) {
           failedToListGws.value = failedToList;
           errorMessage.value = `Failed to list ${failedToListGws.value.length} domains`;
-        } else {
-          failedToListGws.value = [];
-          errorMessage.value = "";
         }
       } catch (error) {
         errorMessage.value = "Failed to list this deployment's domains";

--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -324,16 +324,19 @@ export default {
         gateways.value = [];
         gatewaysToDelete.value = [];
         loadingGateways.value = true;
+
         updateGrid(grid, { projectName: props.vm ? props.vm.projectName : props.k8s!.projectName });
 
         const { gateways: gws, failedToList } = await loadDeploymentGateways(grid, {
           filter: gw => true,
         });
         gateways.value = gws;
-        failedToListGws.value = failedToList;
-        if (failedToListGws.value.length != 0) {
+
+        if (failedToList.length != 0) {
+          failedToListGws.value = failedToList;
           errorMessage.value = `Failed to list ${failedToListGws.value.length} domains`;
         } else {
+          failedToListGws.value = [];
           errorMessage.value = "";
         }
       } catch (error) {


### PR DESCRIPTION

### Changes

- added no error handling

### Related Issues

#3389

### Tested Scenarios

- set timeout to 12 seconds to generate failed domains list error
- update timeout to window.env.timout, go offline, then back online and press reload, error should be gone



- [x] Screenshots/Video attached (needed for UI changes)
![image](https://github.com/user-attachments/assets/d1f9777a-1ea6-4018-a865-9ed9827fb81b)
![image](https://github.com/user-attachments/assets/b6678da8-52ac-43c8-93e2-e203be1e330e)
![image](https://github.com/user-attachments/assets/e5e3e2c1-bea8-44e6-86a7-90dd5df3617c)

