### PR TITLE
Fix: add monitoring to grid client dependencies

### DIFF
--- a/packages/grid_client/package.json
+++ b/packages/grid_client/package.json
@@ -17,6 +17,7 @@
     "@threefold/gridproxy_client": "2.6.0-rc2",
     "@threefold/rmb_direct_client": "2.6.0-rc2",
     "@threefold/tfchain_client": "2.6.0-rc2",
+    "@threefold/monitoring": "2.6.0-rc2",
     "@threefold/types": "2.6.0-rc2",
     "algosdk": "^1.19.0",
     "appdata-path": "^1.0.0",


### PR DESCRIPTION
Update grid client dependency to include monitoring package

 related issue: #3584

note: should test out side the sdk after the next release.