### PR TITLE
Fix workers and domains dialogs

### DIFF
--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -375,20 +375,24 @@
               icon="mdi-cube-outline"
               :disabled="item.fromAnotherClient"
               tooltip="Manage Workers"
-              @click="dialog = item.name"
+              @click="dialog = `W${item.name}`"
             />
 
             <IconActionBtn
               icon="mdi-cog"
               tooltip="Manage Domains"
               :disabled="item.fromAnotherClient"
-              @click="dialog = item.masters.length"
+              @click="dialog = `GW${item.masters[0].name}`"
             />
 
-            <ManageGatewayDialog v-if="dialog === item.masters.length" :k8s="item" @close="dialog = undefined" />
+            <ManageGatewayDialog
+              v-if="dialog === `GW${item.masters[0].name}`"
+              :k8s="item"
+              @close="dialog = undefined"
+            />
 
             <ManageK8SWorkerDialog
-              v-if="dialog === item.name"
+              v-if="dialog === `W${item.name}`"
               :data="item"
               @close="dialog = undefined"
               @update:k8s="item.workers = $event.workers"
@@ -485,7 +489,7 @@ const tabs: Tab[] = [
 ];
 
 const layout = useLayout();
-const dialog = ref<string | number>();
+const dialog = ref<string>();
 const selectedItems = ref<any[]>([]);
 const deleting = ref(false);
 const deletingDialog = ref(false);

--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -382,10 +382,10 @@
               icon="mdi-cog"
               tooltip="Manage Domains"
               :disabled="item.fromAnotherClient"
-              @click="dialog = item.masters[0].name"
+              @click="dialog = item.masters.length"
             />
 
-            <ManageGatewayDialog v-if="dialog === item.masters[0].name" :k8s="item" @close="dialog = undefined" />
+            <ManageGatewayDialog v-if="dialog === item.masters.length" :k8s="item" @close="dialog = undefined" />
 
             <ManageK8SWorkerDialog
               v-if="dialog === item.name"
@@ -485,7 +485,7 @@ const tabs: Tab[] = [
 ];
 
 const layout = useLayout();
-const dialog = ref<string>();
+const dialog = ref<string | number>();
 const selectedItems = ref<any[]>([]);
 const deleting = ref(false);
 const deletingDialog = ref(false);


### PR DESCRIPTION
### Description

Prevent opening manage workers and manage domains from triggering together.

### Changes

[Screencast from 07-11-24 12:50:58.webm](https://github.com/user-attachments/assets/bdeb74b6-c33f-42f4-877e-17bc0b939cc0)

###Tested Scenarios

- Deploy Kubernetes and click on manage domains / manage workers and check if any dialog overlaps the other.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3594

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
