### PR TITLE
update error message shown when add domain fails

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -379,7 +379,8 @@ export default {
         suggestName();
         layout.value.setStatus("success", "Successfully deployed gateway.");
       } catch (error) {
-        layout.value.setStatus("failed", normalizeError(error, "Something went wrong."));
+        errorMessage.value = "Failed to add domain";
+        layout.value.setStatus("failed", normalizeError(errorMessage.value, "Something went wrong."));
       }
     }
 


### PR DESCRIPTION

### Changes
- added an error message in case deploy domain fails

### Related Issues

#3389

### Tested Scenarios

- add domain, go offline, go back online observe error below
- press back, view domains list with no error

### Checklist
- [x] Tests included
- [x] Screenshots/Video attached (needed for UI changes)
![Screenshot from 2024-11-11 11-13-10](https://github.com/user-attachments/assets/2a488898-2a04-4e73-9067-62dac554965f)
![image](https://github.com/user-attachments/assets/bac72059-e60f-4660-b639-2cbb3252058a)

