### PR TITLE
Handle rented node in grace period

### DIFF
--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -307,10 +307,7 @@ export default {
               id: node?.rentContractId,
             });
             if (state.gracePeriod) {
-              createCustomToast(
-                `You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`,
-                ToastType.danger,
-              );
+              throw `You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`;
             }
           }
         } catch (error) {

--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -304,7 +304,11 @@ export default {
               id: node?.rentContractId,
             });
             if (state.gracePeriod) {
-              throw `You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`;
+              await new Promise((_, reject) => {
+                setTimeout(() => {
+                  reject(Error(`You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`));
+                }, 2000);
+              });
             }
           }
         } catch (error) {

--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -148,10 +148,7 @@ import { RequestError } from "@threefold/types";
 import type AwaitLock from "await-lock";
 import equals from "lodash/fp/equals.js";
 import { computed, nextTick, onMounted, onUnmounted, type PropType, ref } from "vue";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { VCard } from "vuetify/components/VCard";
 
-import { createCustomToast, ToastType } from "@/utils/custom_toast";
 import { normalizeError } from "@/utils/helpers";
 
 import { useAsync, usePagination, useWatchDeep } from "../../hooks";

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -229,10 +229,7 @@ export async function validateRentContract(
         id: node.rentContractId,
       });
       if (contractInfo.state.gracePeriod) {
-        createCustomToast(
-          `You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`,
-          ToastType.danger,
-        );
+        throw `You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`;
       }
     }
 

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -229,7 +229,11 @@ export async function validateRentContract(
         id: node.rentContractId,
       });
       if (contractInfo.state.gracePeriod) {
-        throw `You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`;
+        await new Promise((_, reject) => {
+          setTimeout(() => {
+            reject(Error(`You can't deploy on node ${node.nodeId}, its rent contract is in grace period.`));
+          }, 2000);
+        });
       }
     }
 

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -19,7 +19,6 @@ import type {
   SelectionDetailsFilters,
   SelectionDetailsFiltersValidators,
 } from "../types/nodeSelector";
-import { createCustomToast, ToastType } from "./custom_toast";
 import { normalizeError } from "./helpers";
 
 export interface GetLocationsConfig {


### PR DESCRIPTION
### Description

Check if the rented node contract is in the grace period when listing the node.

### Changes

![image](https://github.com/user-attachments/assets/1f1b3866-ee34-4737-84bf-b43fbef80cbe)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3025

### Tested Scenarios

- Navigate to the Node finder page.
- Rent a dedicated node.
- Leave it till it goes to the grace period.
- Navigate to any solution.
- Try to deploy an instance on the rented node.

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
