### PR TITLE
Fix reserve action button

### DIFF
--- a/packages/playground/src/dashboard/components/reserve_action_btn.vue
+++ b/packages/playground/src/dashboard/components/reserve_action_btn.vue
@@ -112,7 +112,8 @@ export default {
 
         const result = (await grid?.contracts.getActiveContracts({ nodeId: +props.node.nodeId })) as any;
         if (result.length > 0) {
-          createCustomToast(`node ${props.node.nodeId} has active contracts`, ToastType.info);
+          // checking if the node has an active contract
+          createCustomToast(`Node ${props.node.nodeId} has active contracts`, ToastType.danger);
           loadingUnreserveNode.value = false;
           openUnreserveDialog.value = false;
         }
@@ -148,14 +149,16 @@ export default {
       if (!profile.value) {
         createCustomToast("Please Login first to continue.", ToastType.danger);
       }
+      loadingReserveNode.value = true;
+      disableButton.value = true;
       try {
-        loadingReserveNode.value = true;
-        disableButton.value = true;
         createCustomToast("Transaction Submitted", ToastType.info);
         await grid?.nodes.reserve({ nodeId: +props.node.nodeId });
         createCustomToast(`Transaction succeeded node ${props.node.nodeId} Reserved`, ToastType.success);
         notifyDelaying();
         setTimeout(() => {
+          disableButton.value = false;
+          loadingReserveNode.value = false;
           emit("updateTable");
           reserved.value = true;
         }, 20000);
@@ -167,7 +170,6 @@ export default {
           createCustomToast("Failed to create rent contract.", ToastType.danger);
         }
       } finally {
-        disableButton.value = false;
         loadingReserveNode.value = false;
       }
     }


### PR DESCRIPTION
### Description

Fix the reserve action button.

### Changes

- Reduce check time of Un/Reserved buttons
- Check the twin ID of the rented node when the component is mounted
-  Reset values after reserve / unreserve process

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3575

### Tested Scenarios

- Navigate to any solution
- Switch on dedicated nodes
- Reserve any node and unreserve it

### Updated Scenarios
- Reserve from the node page and un-reserve any from the solution page.
- Reserve from a solution page, then un-reserve from the node page.

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
