### PR TITLE
Remove copy btn from details tab in deployment dialog

### DIFF
--- a/packages/playground/src/components/deployment_data_dialog.vue
+++ b/packages/playground/src/components/deployment_data_dialog.vue
@@ -131,7 +131,7 @@
         </v-card-text>
         <v-card-actions class="justify-end my-1 mr-2">
           <v-btn color="anchor" @click="$emit('close')">Close</v-btn>
-          <v-btn color="secondary" @click="copy">Copy</v-btn>
+          <v-btn color="secondary" v-if="showType == 1" @click="copy">Copy</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>


### PR DESCRIPTION


### Changes

L- added conditional to show copy btn only in json tab in deployment dialog

### Related Issues

#3629

### Tested Scenarios

- deploy a solution
- click view soln btn
- observe no copy btn in details tab
- switch to json tab, observe copy btn is there
- tested on wordpress and microvm 


### Checklist

- [x] Screenshots/Video attached (needed for UI changes)
![image](https://github.com/user-attachments/assets/16a4da76-c821-4148-b151-ac95c6998097)
![image](https://github.com/user-attachments/assets/518dd065-3c4a-46ed-becc-4abf63a16394)

