### PR TITLE
fix save additional fees btn disable/enable

### DIFF
--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -24,8 +24,7 @@
             e.g. GPUs) while renting.
           </v-card-text>
           <v-card-text>
-            <VProgressLinear indeterminate color="primary" height="2" v-if="loading" />
-            <form-validator v-model="valid" v-else>
+            <form-validator v-model="valid">
               <input-validator
                 :value="inputFee"
                 :rules="[
@@ -43,11 +42,13 @@
                     suffix="USD/month"
                     outlined
                     label="Additional Fees"
-                    :disabled="isSetting"
+                    :disabled="isSetting || loading"
+                    :loading="loading"
                   ></v-text-field>
                 </input-tooltip>
               </input-validator>
             </form-validator>
+
             <v-divider></v-divider>
           </v-card-text>
           <v-card-actions class="justify-end my-1 mr-2">
@@ -102,7 +103,7 @@ export default {
       currentNodeId.value = props.nodeId;
       currentFee.value = (await getExtraFee()) ?? 0;
       inputFee.value = currentFee.value;
-      loading.value = false;
+      // loading.value = false;
     }
     async function getExtraFee() {
       try {

--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -105,7 +105,7 @@ export default {
 
     watch(fee, async (value, _) => {
       const currentFee = await getExtraFee();
-      if (value == currentFee || value === null) {
+      if (Number(value) == currentFee || value === null) {
         isDisabled.value = true;
       } else {
         isDisabled.value = false;

--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -68,7 +68,7 @@
 <script lang="ts">
 import { TFChainError } from "@threefold/tfchain_client";
 import { ValidationError } from "@threefold/types";
-import { onMounted, ref, watch } from "vue";
+import { computed, ref } from "vue";
 
 import { useGrid } from "../../stores";
 import { createCustomToast, ToastType } from "../../utils/custom_toast";
@@ -88,7 +88,9 @@ export default {
     const valid = ref(false);
     const isSetting = ref(false);
     const inputFee = ref(0);
-    const isDisabled = ref(false);
+    const isDisabled = computed(() => {
+      return currentFee.value === inputFee.value;
+    });
     const currentFee = ref(0);
     const currentNodeId = ref(0);
 
@@ -106,10 +108,6 @@ export default {
         console.log(error);
       }
     }
-
-    watch(inputFee, async () => {
-      isDisabled.value = currentFee.value == inputFee.value;
-    });
 
     async function setExtraFee() {
       try {

--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -24,7 +24,8 @@
             e.g. GPUs) while renting.
           </v-card-text>
           <v-card-text>
-            <form-validator v-model="valid">
+            <VProgressLinear indeterminate color="primary" height="2" v-if="loading" />
+            <form-validator v-model="valid" v-else>
               <input-validator
                 :value="inputFee"
                 :rules="[
@@ -93,12 +94,15 @@ export default {
     });
     const currentFee = ref(0);
     const currentNodeId = ref(0);
+    const loading = ref(false);
 
     async function setupDialog() {
+      loading.value = true;
       showDialogue.value = true;
       currentNodeId.value = props.nodeId;
       currentFee.value = (await getExtraFee()) ?? 0;
       inputFee.value = currentFee.value;
+      loading.value = false;
     }
     async function getExtraFee() {
       try {
@@ -139,6 +143,7 @@ export default {
       isDisabled,
       setExtraFee,
       setupDialog,
+      loading,
     };
   },
 };

--- a/packages/playground/src/dashboard/components/set_extra_fee.vue
+++ b/packages/playground/src/dashboard/components/set_extra_fee.vue
@@ -103,7 +103,7 @@ export default {
       currentNodeId.value = props.nodeId;
       currentFee.value = (await getExtraFee()) ?? 0;
       inputFee.value = currentFee.value;
-      // loading.value = false;
+      loading.value = false;
     }
     async function getExtraFee() {
       try {


### PR DESCRIPTION
### Changes

- just converted fee in text field to number first before comparison with fee fetched from grid 
- fixed passing of node id to dialog to avoid requesting extra fee from grid for other nodes when you only need to fetch current node's extra fee

### Related Issues

[#3632](https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3632)

### Tested Scenarios

- opened up set additional fees dialog, observe save btn is disabled
- changed fee, observed save become active when fee is different from original fee
- change back to original fee watch save btn become disabled again 

### Documentation PR

For UI changes, Please provide the Documetation PR on [info_grid](https://github.com/threefoldtech/info_grid)


### Checklist

- [x] Screenshots/Video attached (needed for UI changes)
https://www.loom.com/share/61bc3d16573e45249a0df9499e0d3158?sid=8fff94fb-2de8-45a6-899d-c20a77b465ae