### PR TITLE
FIX(NodeDetails/iperf): show error if the result array is empty

### DIFF
--- a/packages/playground/src/components/node_details_cards/iperf_details_card.vue
+++ b/packages/playground/src/components/node_details_cards/iperf_details_card.vue
@@ -70,6 +70,10 @@ export default {
           downloadSpeed: format(node.download_speed),
           uploadSpeed: format(node.upload_speed),
         }));
+      if (array.length === 0) {
+        console.error("Empty array returned from the IPerf test");
+        throw new Error("Can't get the test results, please try again later.");
+      }
       IperfDetails.value = array;
       return IperfDetails.value;
     };


### PR DESCRIPTION
### Description

it issue is the iperf result is an array, we show the values of the array, but if the array is empty nothing to show

### Changes
- add check on the length of the result array and throw an error if it is 0
- add error log to help in debugging 

### Related Issues
 - #3622 

### Tested Scenarios

- tested on both main and dev net, works fine on node 153 main net 


![Screenshot from 2024-11-21 14-19-35](https://github.com/user-attachments/assets/84c883b1-23ed-40dc-aff6-b5b1f4ee5b17)


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
