### PR TITLE
Refactor(deploymentList/Caprover): enhance deleting caprover deployment

### DIFF
--- a/packages/playground/src/utils/delete_deployment.ts
+++ b/packages/playground/src/utils/delete_deployment.ts
@@ -12,6 +12,7 @@ export interface DeleteDeploymentOptions {
   projectName: ProjectName;
   ip?: string[];
   k8s?: boolean;
+  isCaprover?: boolean;
 }
 
 export async function deleteDeployment(grid: GridClient, options: DeleteDeploymentOptions) {
@@ -50,7 +51,7 @@ export async function deleteDeployment(grid: GridClient, options: DeleteDeployme
     return grid.k8s.delete({ name: options.name });
   }
 
-  if (options.deploymentName) {
+  if (options.deploymentName && !options.isCaprover) {
     return grid.machines.delete_machine({ deployment_name: options.deploymentName, name: options.name });
   }
 

--- a/packages/playground/src/utils/delete_deployment.ts
+++ b/packages/playground/src/utils/delete_deployment.ts
@@ -50,7 +50,7 @@ export async function deleteDeployment(grid: GridClient, options: DeleteDeployme
     }
     return grid.k8s.delete({ name: options.name });
   }
-
+  // if Caprover deployment should handled by machines.delete
   if (options.deploymentName && !options.isCaprover) {
     return grid.machines.delete_machine({ deployment_name: options.deploymentName, name: options.name });
   }

--- a/packages/playground/src/weblets/tf_deployment_list.vue
+++ b/packages/playground/src/weblets/tf_deployment_list.vue
@@ -510,11 +510,6 @@ async function onDelete(k8s = false) {
   try {
     const projectNameLower = props.projectName?.toLowerCase();
     const allSelectedItems = [...selectedItems.value];
-    selectedItems.value.forEach(item => {
-      if (item.projectName?.toLowerCase().includes(ProjectName.Caprover.toLowerCase()) && item.workers) {
-        allSelectedItems.push(...item.workers);
-      }
-    });
 
     await allSelectedItems.reduce(async (acc, item) => {
       await acc;
@@ -531,6 +526,7 @@ async function onDelete(k8s = false) {
             projectName: item.projectName,
             ip: getDeploymentIps(item),
             k8s,
+            isCaprover: item.projectName?.toLowerCase().includes(ProjectName.Caprover.toLowerCase()),
           });
         }
       } catch (e: any) {


### PR DESCRIPTION
### Description

Refactor deleting Caprover deployment: 
the old flow was pushing all workers to an array and delete them instance by instance

now we are using `machines.delete` to delete the deployment

### Changes

- add `isCaprover` prop to manage delete caprover deployment
- remove the old logic 

### Related Issues

- #3614
- #3473 
### Tested Scenarios

- create caprover deployment worker and leader and delete it from deployemnt list, check the contract list after few seconds to avoid delay conflect,  all deployement contracts should be deleted 
- deploy multiple machines uisng gridClient script then delete one of them, should keep the other one ( this test to make sure no side effect because of the changes)


### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
