### PR TITLE
Fix  worker's name

### DIFF
--- a/packages/playground/src/components/manage_k8s_worker_dialog.vue
+++ b/packages/playground/src/components/manage_k8s_worker_dialog.vue
@@ -82,6 +82,9 @@ async function deploy(layout: any) {
     .catch(error => {
       const e = typeof error === "string" ? error : error.message;
       layout.setStatus("failed", e);
+    })
+    .finally(() => {
+      worker.value = createWorker();
     });
 }
 


### PR DESCRIPTION
### Description

Rename worker after successful deployment

### Changes

- Create another worker's name after the deployment ends.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3670

### Tested Scenarios

Deploy a worker on any orchestrator instance. Don't close the dialog; instead, switch to the deploy tab and deploy another worker.

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
