### PR TITLE
Fix blocked bridge address in withdraw dialog

### DIFF
--- a/packages/playground/src/components/withdraw_dialog.vue
+++ b/packages/playground/src/components/withdraw_dialog.vue
@@ -111,7 +111,7 @@ function swapAddressCheck() {
   ];
   if (blockedAddresses.includes(target.value)) {
     return {
-      message: "Blocked Address",
+      message: "Bridge address cannot be used as Stellar target wallet address.",
     };
   }
   if (!isValid || target.value.match(/\W/)) {

--- a/packages/playground/src/components/withdraw_dialog.vue
+++ b/packages/playground/src/components/withdraw_dialog.vue
@@ -111,7 +111,7 @@ function swapAddressCheck() {
   ];
   if (blockedAddresses.includes(target.value)) {
     return {
-      message: "Bridge address cannot be used as Stellar target wallet address.",
+      message: "Stellar target wallet address cannot be bridge's address.",
     };
   }
   if (!isValid || target.value.match(/\W/)) {

--- a/packages/playground/src/components/withdraw_dialog.vue
+++ b/packages/playground/src/components/withdraw_dialog.vue
@@ -105,11 +105,8 @@ function swapAddressCheck() {
     return;
   }
   const isValid = StrKey.isValidEd25519PublicKey(target.value);
-  const blockedAddresses = [
-    "GBNOTAYUMXVO5QDYWYO2SOCOYIJ3XFIP65GKOQN7H65ZZSO6BK4SLWSC",
-    "GA2CWNBUHX7NZ3B5GR4I23FMU7VY5RPA77IUJTIXTTTGKYSKDSV6LUA4",
-  ];
-  if (blockedAddresses.includes(target.value)) {
+
+  if (target.value == window.env.BRIDGE_TFT_ADDRESS) {
     return {
       message: "Stellar target wallet address cannot be bridge's address.",
     };


### PR DESCRIPTION

### Changes

- removed static blocked addresses strings, replaced with env var for bridge address
- updated err msg explaining why address is blocked in validation 

### Related Issues

#3667

### Tested Scenarios

- took bridge address from deposit dialog and placed in withdraw dialog stellar wallet address, observed updated err msg, tested on devnet and qanet


### Checklist
- [x] Screenshots/Video attached (needed for UI changes)
![image](https://github.com/user-attachments/assets/a70ccbce-2969-4ee0-829e-a1a465792285)
