### PR TITLE
Removing hdd storage reporting from stats

### DIFF
--- a/packages/playground/src/stores/stats.ts
+++ b/packages/playground/src/stores/stats.ts
@@ -11,7 +11,7 @@ export const useStatsStore = defineStore("stats-store", () => {
   const data = computed(() => res.value.data);
   const stats = computed(() => [
     {
-      label: "Capacity",
+      label: "SSD Capacity",
       value: data.value?.ssd,
       image: "capacity.png",
     },

--- a/packages/playground/src/stores/stats.ts
+++ b/packages/playground/src/stores/stats.ts
@@ -12,7 +12,7 @@ export const useStatsStore = defineStore("stats-store", () => {
   const stats = computed(() => [
     {
       label: "Capacity",
-      value: data.value?.capacity,
+      value: data.value?.ssd,
       image: "capacity.png",
     },
     {

--- a/packages/playground/src/utils/format_resource_size.ts
+++ b/packages/playground/src/utils/format_resource_size.ts
@@ -49,3 +49,21 @@ function toFixedTwo(val: number) {
 function formatSpeed(val: number) {
   return Math.round(val);
 }
+
+export function toTeraOrGigaStats(sizeInBytes: number) {
+  const giga = 1024 ** 3;
+
+  if (!sizeInBytes) return "0 GB";
+
+  const val = +sizeInBytes;
+  if (val === 0 || isNaN(val)) return "0 GB";
+
+  const gb = val / giga;
+
+  if (gb < 100) {
+    return gb.toFixed(2) + " GB";
+  }
+
+  const tb = gb / 1024;
+  return tb.toFixed(2) + " TB";
+}

--- a/packages/playground/src/views/stats.vue
+++ b/packages/playground/src/views/stats.vue
@@ -141,7 +141,6 @@ const fetchData = async () => {
         { data: stats!.countries, title: "Countries", icon: "mdi-earth" },
         { data: stats!.totalCru, title: "CPUs", icon: "mdi-cpu-64-bit" },
         { data: formatResourceSize(stats!.totalSru), title: "SSD Storage", icon: "mdi-nas" },
-        { data: formatResourceSize(stats!.totalHru), title: "HDD Storage", icon: "mdi-harddisk" },
         { data: formatResourceSize(stats!.totalMru), title: "RAM", icon: "mdi-memory" },
         { data: stats!.gpus, title: "GPUs", icon: "mdi-memory" },
         { data: stats!.accessNodes, title: "Access Nodes", icon: "mdi-gate" },

--- a/packages/playground/src/views/stats.vue
+++ b/packages/playground/src/views/stats.vue
@@ -44,7 +44,7 @@
 import { NodeStatus, type Stats as GridProxyStats } from "@threefold/gridproxy_client";
 import { onMounted, ref } from "vue";
 
-import formatResourceSize from "@/utils/format_resource_size";
+import formatResourceSize, { toTeraOrGigaStats } from "@/utils/format_resource_size";
 
 import { gridProxyClient } from "../clients";
 import StatisticsCard from "../components/statistics_card.vue";
@@ -134,7 +134,7 @@ const fetchData = async () => {
         { data: stats!.farms, title: "Farms", icon: "mdi-tractor" },
         { data: stats!.countries, title: "Countries", icon: "mdi-earth" },
         { data: stats!.totalCru, title: "CPUs", icon: "mdi-cpu-64-bit" },
-        { data: formatResourceSize(stats!.totalSru), title: "SSD Storage", icon: "mdi-nas" },
+        { data: toTeraOrGigaStats(stats!.totalSru), title: "SSD Storage", icon: "mdi-nas" },
         { data: formatResourceSize(stats!.totalMru), title: "RAM", icon: "mdi-memory" },
         { data: stats!.gpus, title: "GPUs", icon: "mdi-memory" },
         { data: stats!.accessNodes, title: "Access Nodes", icon: "mdi-gate" },

--- a/packages/playground/src/views/stats.vue
+++ b/packages/playground/src/views/stats.vue
@@ -29,13 +29,7 @@
           </v-col>
           <v-col v-if="Istats.length !== 0" cols="12" md="4">
             <v-row>
-              <v-col
-                v-for="(item, index) of Istats"
-                :key="item.title"
-                :cols="index === Istats.length - 1 ? 12 : 6"
-                :md="index === Istats.length - 1 ? 12 : 6"
-                class="d-flex flex-grow-1"
-              >
+              <v-col v-for="item of Istats" :key="item.title" :cols="6" :md="6" class="d-flex flex-grow-1">
                 <StatisticsCard :item="item" />
               </v-col>
             </v-row>

--- a/packages/stats/nginx/njs/stats.js
+++ b/packages/stats/nginx/njs/stats.js
@@ -131,7 +131,7 @@ function toTeraOrGiga(value) {
   return gb.toFixed(2) + " PB";
 }
 
-function toTeraOrGigaStats(value) {
+export function toTeraOrGigaStats(value) {
   const giga = 1024 ** 3;
 
   if (!value) return "0 GB";

--- a/packages/stats/nginx/njs/stats.js
+++ b/packages/stats/nginx/njs/stats.js
@@ -78,10 +78,10 @@ function mergeStatsData(stats) {
 
   const result = {};
   result.capacity = toTeraOrGiga(res.totalHru + res.totalSru);
+  result.ssd = toTeraOrGigaStats(res.totalSru);
   result.nodes = res.nodes;
   result.countries = res.countries;
   result.cores = res.totalCru;
-
   return result;
 }
 
@@ -129,6 +129,24 @@ function toTeraOrGiga(value) {
 
   gb = gb / 1024;
   return gb.toFixed(2) + " PB";
+}
+
+function toTeraOrGigaStats(value) {
+  const giga = 1024 ** 3;
+
+  if (!value) return "0 GB";
+
+  const val = +value;
+  if (val === 0 || isNaN(val)) return "0 GB";
+
+  const gb = val / giga;
+
+  if (gb < 100) {
+    return gb.toFixed(2) + " GB";
+  }
+
+  const tb = gb / 1024;
+  return tb.toFixed(2) + " TB";
 }
 
 // Exporting the main function for Nginx

--- a/packages/stats/src/components/stats_table.vue
+++ b/packages/stats/src/components/stats_table.vue
@@ -84,11 +84,6 @@ const Istats = computed((): IStatistics[] => {
       { data: formattedStats.value.totalCru, title: "CPUs", icon: "mdi-cpu-64-bit" },
       { data: formattedStats.value.gpus, title: "GPUs", icon: "mdi-memory" },
       { data: toTeraOrGigaOrPeta(formattedStats.value.totalSru.toString()), title: "SSD Storage", icon: "mdi-nas" },
-      {
-        data: toTeraOrGigaOrPeta(formattedStats.value.totalHru.toString()),
-        title: "HDD Storage",
-        icon: "mdi-harddisk",
-      },
       { data: toTeraOrGigaOrPeta(formattedStats.value.totalMru.toString()), title: "RAM", icon: "mdi-memory" },
       { data: formattedStats.value.accessNodes, title: "Access Nodes", icon: "mdi-gate" },
       { data: formattedStats.value.gateways, title: "Gateways", icon: "mdi-boom-gate-outline" },

--- a/packages/stats/src/components/stats_table.vue
+++ b/packages/stats/src/components/stats_table.vue
@@ -51,7 +51,7 @@ import { computed, type PropType, type Ref, ref, watch } from "vue";
 
 import type { IStatistics, NetworkStats } from "../types/index";
 import { formatData, getStats } from "../utils/stats";
-import toTeraOrGigaOrPeta from "../utils/toTeraOrGegaOrPeta";
+import toTeraOrGigaOrPeta, { toTeraOrGigaStats } from "../utils/toTeraOrGegaOrPeta";
 import StatisticsCard from "./statistics_card.vue";
 
 const props = defineProps({
@@ -83,7 +83,7 @@ const Istats = computed((): IStatistics[] => {
       { data: formattedStats.value.countries, title: "Countries", icon: "mdi-earth" },
       { data: formattedStats.value.totalCru, title: "CPUs", icon: "mdi-cpu-64-bit" },
       { data: formattedStats.value.gpus, title: "GPUs", icon: "mdi-memory" },
-      { data: toTeraOrGigaOrPeta(formattedStats.value.totalSru.toString()), title: "SSD Storage", icon: "mdi-nas" },
+      { data: toTeraOrGigaStats(formattedStats.value.totalSru.toString()), title: "SSD Storage", icon: "mdi-nas" },
       { data: toTeraOrGigaOrPeta(formattedStats.value.totalMru.toString()), title: "RAM", icon: "mdi-memory" },
       { data: formattedStats.value.accessNodes, title: "Access Nodes", icon: "mdi-gate" },
       { data: formattedStats.value.gateways, title: "Gateways", icon: "mdi-boom-gate-outline" },

--- a/packages/stats/src/utils/toTeraOrGegaOrPeta.ts
+++ b/packages/stats/src/utils/toTeraOrGegaOrPeta.ts
@@ -19,3 +19,21 @@ export default function toTeraOrGiga(value?: string) {
   gb = gb / 1024;
   return `${gb.toFixed(2)} PB`;
 }
+
+export function toTeraOrGigaStats(value?: string) {
+  const giga = 1024 ** 3;
+
+  if (!value) return "0 GB";
+
+  const val = +value;
+  if (val === 0 || isNaN(val)) return "0 GB";
+
+  const gb = val / giga;
+
+  if (gb < 100) {
+    return gb.toFixed(2) + " GB";
+  }
+
+  const tb = gb / 1024;
+  return tb.toFixed(2) + " TB";
+}


### PR DESCRIPTION
### Description

- Removing hdd storage reporting from stats
![Screenshot from 2024-12-05 12-58-39](https://github.com/user-attachments/assets/50c2b3b5-2d61-4eff-98a6-92c31a71df6c)
![Screenshot from 2024-12-05 13-02-34](https://github.com/user-attachments/assets/cb5cc9ad-495c-46f2-9525-eaa1e4239dc7)
- Adding SSD to https://stats.grid.tf//api/stats-summary and using it to show capacity in the dashboard home page
![Screenshot from 2024-12-05 14-31-13](https://github.com/user-attachments/assets/53da8e32-76bb-46e6-8637-03ba46d4ba48)



### Related Issues

#3709
### Tested Scenarios

- Checking if hdd storage is shown in dashboard's stats
- Checking if hdd storage is shown in stats website

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
