### PR TITLE
Removed rentable chip in case the node was down

### DIFF
--- a/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
+++ b/packages/playground/src/components/node_selector/TfNodeDetailsCard.vue
@@ -103,7 +103,7 @@
           </VTooltip>
 
           <VTooltip
-            v-if="rentable || rented"
+            v-if="(rentable || rented) && node.status !== 'down'"
             location="top"
             :text="
               rentable ? 'You can rent it exclusively for your workloads' : 'Rented as full node for a single user'


### PR DESCRIPTION
### Description

Removed rentable chip in case the node was down
### Changes

- Added a condition to rentable chip to check if node status is down
### Related Issues

- #3692
### Tested Scenarios

- Go to NOde finder page, choose from filter's node status down. There shouldn't be a rentable chip on any node


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
