### PR TITLE
Adding No Data Available in case of no billing available

### DIFF
--- a/packages/playground/src/components/vm_deployment_table.vue
+++ b/packages/playground/src/components/vm_deployment_table.vue
@@ -110,7 +110,7 @@
       </template>
 
       <template #[`item.billing`]="{ item }">
-        {{ item.billing }}
+        {{ item.billing || "No Data Available" }}
       </template>
       <template #[`item.created`]="{ item }">
         {{ toHumanDate(item.created) }}


### PR DESCRIPTION
### Description

Adding No Data Available in case of no billing available

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3682
### Tested Scenarios

create a caprover instance and after creation attach a new worker, you'll be able to see no data available in the billing column instead of it being empty

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
