### PR TITLE
Fix adding worker with mycelium to k8s

### DIFF
--- a/packages/grid_client/src/primitives/network.ts
+++ b/packages/grid_client/src/primitives/network.ts
@@ -176,7 +176,7 @@ class Network {
       return network["node_id"] === nodeId;
     });
     const myceliumNetworkSeed = myceliumSeeds.find(item => item.nodeId == nodeId);
-    if (network && network.mycelium && network.mycelium?.hex_key) {
+    if (network && network.mycelium && network.mycelium?.hex_key && myceliumNetworkSeed?.seed) {
       if (myceliumSeeds && myceliumSeeds.length > 0 && myceliumNetworkSeed?.seed !== network.mycelium.hex_key) {
         throw new ValidationError(`Another mycelium seed is used for this network ${this.name} on this ${nodeId}`);
       }

--- a/packages/grid_client/tests/modules/kubernetes.test.ts
+++ b/packages/grid_client/tests/modules/kubernetes.test.ts
@@ -287,7 +287,7 @@ test("TC1231 - Kubernetes: Deploy a Kubernetes Cluster", async () => {
   }
 });
 
-test.skip("TC1232 - Kubernetes: Add Worker", async () => {
+test("TC1232 - Kubernetes: Add Worker", async () => {
   /**********************************************
      Test Suite: Grid3_Client_TS (Automated)
      Test Cases: TC1232 - Kubernetes: Add Worker


### PR DESCRIPTION
### Description

- Check if ```myceliumNetworkSeed.seed``` is existed.
- Remove ```.skip``` from ```add worker``` test case.

### Changes

![image](https://github.com/user-attachments/assets/bfe918aa-f266-40ad-8aa5-d2deef14ad36)

### Tested Scenarios

- Go to the Grid Client package
- Run `yarn test tests/modules/kubernetes.test.ts`
- All cases should pass

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3509

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)