### PR TITLE
Add BTC node image in microVm images selector 

### DIFF
--- a/packages/playground/src/weblets/micro_vm.vue
+++ b/packages/playground/src/weblets/micro_vm.vue
@@ -233,6 +233,11 @@ const images = [
     flist: "https://hub.grid.tf/tf-official-vms/nixos-micro-latest.flist",
     entryPoint: "/entrypoint.sh",
   },
+  {
+    name: "BTC Node Mycelium",
+    flist: "https://hub.grid.tf/petep.3bot/btc_node-mycelium.flist",
+    entryPoint: "/sbin/zinit init",
+  },
 ];
 
 const name = ref(generateName({ prefix: "vm" }));


### PR DESCRIPTION
### Description

Add a BTC node image in the ```microVm``` images selector and it deployed successfully.

### Changes

![image](https://github.com/user-attachments/assets/34e12963-adda-48ac-bfec-0bab8c64247d)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/2009

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
