### PR TITLE
Fix worker's name

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-svelte3": "^4.0.0",
     "eslint-plugin-vue": "^9.10.0",
     "husky": "^8.0.3",
-    "lerna": "^6.6.1",
+    "lerna": "8.0.0",
     "lint-staged": "^13.2.0",
     "prettier": "^2.8.7",
     "prettier-plugin-svelte": "^2.10.0"

--- a/packages/playground/src/components/manage_caprover_worker_dialog.vue
+++ b/packages/playground/src/components/manage_caprover_worker_dialog.vue
@@ -159,6 +159,8 @@ async function deploy(layout: any) {
     layout.setStatus("success", `Successfully add a new worker to Caprover('${props.master.name}') Instance.`);
   } catch (e) {
     layout.setStatus("failed", normalizeError(e, "Failed to deploy a caprover worker."));
+  } finally {
+    worker.value = createWorker();
   }
 }
 

--- a/packages/playground/src/components/manage_caprover_worker_dialog.vue
+++ b/packages/playground/src/components/manage_caprover_worker_dialog.vue
@@ -160,7 +160,8 @@ async function deploy(layout: any) {
   } catch (e) {
     layout.setStatus("failed", normalizeError(e, "Failed to deploy a caprover worker."));
   } finally {
-    worker.value = createWorker();
+    const { name } = createWorker();
+    worker.value.name = name;
   }
 }
 

--- a/packages/playground/src/components/manage_caprover_worker_dialog.vue
+++ b/packages/playground/src/components/manage_caprover_worker_dialog.vue
@@ -92,7 +92,7 @@ const deleting = ref(false);
 const deployedDialog = ref(false);
 const gridStore = useGrid();
 const grid = gridStore.client as GridClient;
-
+const solution = { cpu: 1, memory: 2, disk: 50 };
 const worker = ref(createWorker());
 
 function calcDiskSize(disks: { size: number }[]) {
@@ -160,8 +160,8 @@ async function deploy(layout: any) {
   } catch (e) {
     layout.setStatus("failed", normalizeError(e, "Failed to deploy a caprover worker."));
   } finally {
-    const { name } = createWorker();
-    worker.value.name = name;
+    worker.value = createWorker();
+    worker.value.solution = solution;
   }
 }
 

--- a/packages/playground/src/components/manage_k8s_worker_dialog.vue
+++ b/packages/playground/src/components/manage_k8s_worker_dialog.vue
@@ -82,6 +82,9 @@ async function deploy(layout: any) {
     .catch(error => {
       const e = typeof error === "string" ? error : error.message;
       layout.setStatus("failed", e);
+    })
+    .finally(() => {
+      worker.value = createWorker();
     });
 }
 


### PR DESCRIPTION
### Description

Rename worker after successful deployment

### Changes

- Create another worker's name after the deployment ends.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3670

### Tested Scenarios

Deploy a worker on any orchestrator instance. Don't close the dialog; instead, switch to the deploy tab and deploy another worker.

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
