### PR TITLE
Add `Refresh` button to node finder

### DIFF
--- a/packages/playground/src/components/filters/TfFiltersContainer.vue
+++ b/packages/playground/src/components/filters/TfFiltersContainer.vue
@@ -21,7 +21,7 @@
           color="secondary"
           density="compact"
           @click.stop="apply"
-          :text="valid || changed ? 'Apply' : 'Refresh'"
+          :text="!valid || !changed ? 'Refresh' : 'Apply'"
           :loading="loading"
           class="mx-2"
         />

--- a/packages/playground/src/components/filters/TfFiltersContainer.vue
+++ b/packages/playground/src/components/filters/TfFiltersContainer.vue
@@ -20,9 +20,8 @@
           variant="outlined"
           color="secondary"
           density="compact"
-          :disabled="!valid || !changed"
           @click.stop="apply"
-          text="Apply"
+          :text="valid || changed ? 'Apply' : 'Refresh'"
           :loading="loading"
           class="mx-2"
         />


### PR DESCRIPTION
### Description

Check if the filter forms are valid or changed to apply the refresh button.

### Changes

[Screencast from 15-12-24 13:32:36.webm](https://github.com/user-attachments/assets/db20e841-ff71-434b-904f-443a5273b2ae)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3700

### Tested Scenarios

- The `Refresh` button should appear and work.
- changing any filter will display the `Apply` button instead and once it is applied the refresh button will be back.
- Apply rentable nodes switch, reserve a `dedicated` node, and refresh after a while you'll find it disappears.
- Apply my rented node switch and make the same process to unreserve.
### Checklist

- [x] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
- [x] Screenshots/Video attached (needed for UI changes)
