### PR TITLE
Select rented node in automated selection in case of its existence

### DIFF
--- a/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfAutoNodeSelector.vue
@@ -221,6 +221,7 @@ export default {
 
     async function _setValidNode(oldNodeId?: number) {
       const node = await selectValidNode(
+        gridStore,
         props.getFarm,
         _loadedNodes.value,
         props.selectedMachines,

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 import { gqlClient, gridProxyClient } from "../clients";
 import type { usePagination } from "../hooks";
-import { type useGrid } from "../stores";
+import type { useGrid } from "../stores";
 import type {
   Locations,
   NormalizeFarmFiltersOptions,
@@ -335,7 +335,7 @@ export async function selectValidNode(
   const locked = true;
 
   const rentedNode = nodes.find(n => {
-    return n.rentedByTwinId === gridStore.grid.twinId;
+    n.rentedByTwinId === gridStore.grid.twinId;
   });
   if (oldSelectedNodeId || rentedNode) {
     const node = rentedNode || nodes.find(n => n.nodeId === oldSelectedNodeId);

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -334,9 +334,23 @@ export async function selectValidNode(
 ): Promise<NodeInfo | void> {
   const locked = true;
 
-  const rentedNode = nodes.find(n => {
-    n.rentedByTwinId === gridStore.grid.twinId;
+  const rentedNodes = nodes.filter(n => {
+    return n.rentedByTwinId === gridStore.grid.twinId;
   });
+  let rentedNode;
+  for (const node of rentedNodes) {
+    if (node.rentedByTwinId === gridStore.grid.twinId) {
+      const contractInfo = await gridStore.grid.contracts.get({
+        id: node.rentContractId,
+      });
+
+      if (!contractInfo.state.gracePeriod) {
+        rentedNode = node;
+        break;
+      }
+    }
+  }
+
   if (oldSelectedNodeId || rentedNode) {
     const node = rentedNode || nodes.find(n => n.nodeId === oldSelectedNodeId);
 

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -352,7 +352,7 @@ export async function selectValidNode(
   }
 
   if (oldSelectedNodeId || rentedNode) {
-    const node = rentedNode || nodes.find(n => n.nodeId === oldSelectedNodeId);
+    const node = nodes.find(n => n.nodeId === oldSelectedNodeId) || rentedNode;
 
     if (node && isNodeValid(getFarm, node, selectedMachines, filters)) {
       if (nodesLock && !locked) {

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 import { gqlClient, gridProxyClient } from "../clients";
 import type { usePagination } from "../hooks";
-import type { useGrid } from "../stores";
+import { type useGrid, useProfileManager } from "../stores";
 import type {
   Locations,
   NormalizeFarmFiltersOptions,
@@ -336,9 +336,21 @@ export async function selectValidNode(
     locked = false;
     await nodesLock.acquireAsync();
   }
+  const profileManager = useProfileManager();
+  let node;
+  node = nodes.find(n => {
+    return n.rentedByTwinId === profileManager?.profile?.twinId;
+  });
+
+  if (node && isNodeValid(getFarm, node, selectedMachines, filters)) {
+    if (nodesLock && !locked) {
+      release(nodesLock);
+    }
+    return node;
+  }
 
   if (oldSelectedNodeId) {
-    const node = nodes.find(n => n.nodeId === oldSelectedNodeId);
+    node = nodes.find(n => n.nodeId === oldSelectedNodeId);
 
     if (node && isNodeValid(getFarm, node, selectedMachines, filters)) {
       if (nodesLock && !locked) {


### PR DESCRIPTION
### Description

Select rented node in automated selection in case of its existence

### Related Issues

- #3695
### Tested Scenarios
- Go to any solution and check the automated selection incase there's a rented node and when there's not
- test if more than one rented node is available (maybe two or three)
- test if the user has more than one rented, which one will be suggested and on which conditions.
un-reserv one or more rented node and the automation selection should get back to the normal behavior.
- test if the rented node is in grace period; (should not be selected in this case)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
- [ ] Screenshots/Video attached (needed for UI changes)
