### PR TITLE
Remove the map method from the delete contract

### DIFF
--- a/packages/tfchain_client/src/contracts.ts
+++ b/packages/tfchain_client/src/contracts.ts
@@ -455,7 +455,6 @@ class Contracts extends QueryContracts {
     }
     const extrinsic = await this.client.api.tx.smartContractModule.cancelContract(options.id);
     return this.client.patchExtrinsic(extrinsic, {
-      map: () => options.id,
       resultEvents: ["NodeContractCanceled", "NameContractCanceled", "RentContractCanceled", "ContractCanceled"],
     });
   }


### PR DESCRIPTION
### Description

Remove the map method from the delete contract as it maps to certain id and not extracting the data from the events 

### Related Issues

- #3783 

