### PR TITLE
Fix: Remove @validateInput decorator from private getContractOverdueAmount method

### DIFF
--- a/packages/grid_client/src/modules/contracts.ts
+++ b/packages/grid_client/src/modules/contracts.ts
@@ -613,7 +613,6 @@ class Contracts {
    *
    * @returns {Promise<number>} - A promise that resolves to the overdue amount for the specified contract.
    */
-  @validateInput
   private async getContractOverdueAmount(contract: GridProxyContract, proxy: GridProxyClient) {
     return await this.client.contracts.calculateContractOverDue({ contractInfo: contract, gridProxyClient: proxy });
   }


### PR DESCRIPTION
### Description

The @validateInput decorator on the private `getContractOverdueAmount` method was causing validation failures
The @validateInput decorator uses reflection to validate method parameters by converting them to validation model classes. However, the parameters of getContractOverdueAmount are:
  - GridProxyContract - an external type from @threefold/gridproxy_client
  - GridProxyClient - an external type from @threefold/gridproxy_client


### Changes

Removed the @validateInput decorator from the private `getContractOverdueAmount` method because:
  - Private methods don't need input validation - The responsibility for validation lies with the public methods that call this private helper
  - External types cannot be validated - The parameters are imported types without validation decorators
  - Consistent with other private methods - Other private methods in the class (like invalidateDeployment) don't use @validateInput

### Related Issues

- #4356 
### Tested Scenarios
tested loading contracts in the grace period with thier cost 




### General Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
- [ ] Screenshots/Video attached (needed for UI changes)
