### PR TITLE
fix: support WireGuard network in gateways for both zos and zoslight 

### DIFF
--- a/packages/playground/src/components/manage_gateway_dialog.vue
+++ b/packages/playground/src/components/manage_gateway_dialog.vue
@@ -474,7 +474,6 @@ export default {
       const { publicIP, planetary, myceliumIP, interfaces } = selectedNode.value;
 
       if (selectedNode.value.type === WorkloadTypes.zmachine) {
-        addNetwork(NetworkInterfaces.WireGuard, interfaces?.[0]?.ip);
         addNetwork(NetworkInterfaces.PublicIPV4, publicIP?.ip.split("/")[0]);
         /**
          * WARNING:
@@ -491,6 +490,7 @@ export default {
       if (selectedNode.value.type === WorkloadTypes.zmachinelight) {
         addNetwork(NetworkInterfaces.Mycelium, myceliumIP);
       }
+      addNetwork(NetworkInterfaces.WireGuard, interfaces?.[0]?.ip);
       selectedIPAddress.value = networks.value[0].value;
     }
 


### PR DESCRIPTION

### Description

Zoslight vms now supports wireguard,  the manage domain dialog also now support wireguard as an interface for those vms 

### Changes

fix: move WireGuard network addition outside VM type check to support all zmachine workloads


### Related Issues

- #4372 
 

### Tested Scenarios
Add a domain on zoslight vm on wireguard interface and the domain works fine 

### General Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
- [ ] Screenshots/Video attached (needed for UI changes)
