### PR TITLE
tmp: force Mycelium network toggle

### DIFF
--- a/packages/playground/src/components/networks.vue
+++ b/packages/playground/src/components/networks.vue
@@ -38,7 +38,7 @@
             tooltip-text="Mycelium is an IPv6 overlay network. Each node that joins the overlay network will receive an overlay network IP."
             label="Mycelium"
             :value="$props.mycelium"
-            :emit-function="$attrs['onUpdate:mycelium']"
+            :emit-function="undefined"
           />
 
           <NetworkItem


### PR DESCRIPTION
The change prevents users from toggling the Mycelium network option

- #4416