### PR TITLE
fix: prevent fullvm deployments from appearing in micro vm list

### DIFF
--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -216,7 +216,12 @@ class TFContracts extends Contracts {
       }
 
       if (options.projectName) {
-        filterQuery += `{ deploymentData_contains: \"\\\"projectName\\\":\\\"${options.projectName}\" }`;
+        // Match projectName with slash (new format) OR closing brace (old format)
+        // Prevents substring false positives: "vm" won't match "fullvm" or misnamed contracts
+        filterQuery += `{ OR: [
+          { deploymentData_contains: \"\\\"projectName\\\":\\\"${options.projectName}/\" },
+          { deploymentData_contains: \"\\\"projectName\\\":\\\"${options.projectName}\\\"}\" }
+        ]}`;
       }
 
       filterQuery += "]";

--- a/packages/grid_client/src/clients/tf-grid/contracts.ts
+++ b/packages/grid_client/src/clients/tf-grid/contracts.ts
@@ -216,12 +216,7 @@ class TFContracts extends Contracts {
       }
 
       if (options.projectName) {
-        // Match projectName with slash (new format) OR closing brace (old format)
-        // Prevents substring false positives: "vm" won't match "fullvm" or misnamed contracts
-        filterQuery += `{ OR: [
-          { deploymentData_contains: \"\\\"projectName\\\":\\\"${options.projectName}/\" },
-          { deploymentData_contains: \"\\\"projectName\\\":\\\"${options.projectName}\\\"}\" }
-        ]}`;
+        filterQuery += `{ deploymentData_contains: \"\\\"projectName\\\":\\\"${options.projectName}\" }`;
       }
 
       filterQuery += "]";

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -271,9 +271,7 @@ class BaseModule {
 
       for (const contract of BaseModule.newContracts) {
         if (this.projectName) {
-          const pName = contract.parsedDeploymentData?.projectName;
-          // Match exact OR prefix with slash (prevents "vm" from matching "fullvm")
-          if (pName !== this.projectName && !pName?.startsWith(this.projectName + "/")) continue;
+          if (!contract.parsedDeploymentData?.projectName?.startsWith(this.projectName + "/")) continue;
         }
         if (contract.parsedDeploymentData?.type !== moduleName) continue;
 

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -271,7 +271,7 @@ class BaseModule {
 
       for (const contract of BaseModule.newContracts) {
         if (this.projectName) {
-          if (!contract.parsedDeploymentData?.projectName?.startsWith(this.projectName + "/")) continue;
+          if (!contract.parsedDeploymentData?.projectName?.startsWith(this.projectName)) continue;
         }
         if (contract.parsedDeploymentData?.type !== moduleName) continue;
 

--- a/packages/grid_client/src/modules/base.ts
+++ b/packages/grid_client/src/modules/base.ts
@@ -270,8 +270,12 @@ class BaseModule {
       const alreadyFetchedContracts: GqlNodeContract[] = [];
 
       for (const contract of BaseModule.newContracts) {
-        if (!contract.parsedDeploymentData?.projectName.includes(this.projectName)) continue;
-        if (contract.parsedDeploymentData.type !== moduleName) continue;
+        if (this.projectName) {
+          const pName = contract.parsedDeploymentData?.projectName;
+          // Match exact OR prefix with slash (prevents "vm" from matching "fullvm")
+          if (pName !== this.projectName && !pName?.startsWith(this.projectName + "/")) continue;
+        }
+        if (contract.parsedDeploymentData?.type !== moduleName) continue;
 
         const filteredContract = contracts.filter(c => c.contractID === contract.contractID);
 


### PR DESCRIPTION
### Changes

- Use OR pattern matching for "projectName":"vm/" or "projectName":"vm"}"
instead of substring contains to prevent false matches where "fullvm"
was incorrectly matched when filtering for "vm" deployments.

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/4017