### PR TITLE
Enhance capacity pool fn

### DIFF
--- a/packages/grid_client/src/modules/capacity.ts
+++ b/packages/grid_client/src/modules/capacity.ts
@@ -306,6 +306,7 @@ class Capacity {
       options.hddDisks,
       options.rootfsDisks,
       options.nodeId,
+      options.nodeTwinId,
     );
   }
 

--- a/packages/grid_client/src/modules/capacity.ts
+++ b/packages/grid_client/src/modules/capacity.ts
@@ -267,7 +267,7 @@ class Capacity {
   @expose
   @validateInput
   async getNodeFreeResources(options?: NodeFreeResourcesModel): Promise<NodeResources> {
-    return await this.nodes.getNodeFreeResources(options!.nodeId);
+    return await this.nodes.getNodeFreeResources(options!.nodeId, "proxy", "", options?.nodeTwinId);
   }
 
   /**

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -605,6 +605,7 @@ class CapacityPoolCheckModel {
   @Expose() @IsInt({ each: true }) @Min(0, { each: true }) rootfsDisks: number[]; //Byte
   @Expose() @IsInt({ each: true }) @Min(250 * 1024 ** 2, { each: true }) ssdDisks: number[]; //Byte
   @Expose() @IsInt({ each: true }) @Min(250 * 1024 ** 2, { each: true }) hddDisks: number[]; //Byte
+  @Expose() @IsOptional() @IsInt() @Min(1) nodeTwinId?: number;
 }
 
 class PingNodeOptionsModel {

--- a/packages/grid_client/src/modules/models.ts
+++ b/packages/grid_client/src/modules/models.ts
@@ -591,6 +591,7 @@ class ContractState {
 
 class NodeFreeResourcesModel {
   @Expose() @IsInt() @Min(1) nodeId: number;
+  @Expose() @IsOptional() @IsInt() @Min(1) nodeTwinId?: number;
 }
 
 class FarmIdFromFarmNameModel {

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -603,17 +603,16 @@ class Nodes {
     hddDisks: number[],
     rootFileSystemDisks: number[],
     nodeId: number,
+    nodeTwinId?: number,
   ): Promise<boolean> {
     const ssdPools: number[] = [];
     const hddPools: number[] = [];
 
     try {
-      const nodeTwinId = await this.getNodeTwinId(nodeId);
-      ((await this.rmb.request([nodeTwinId], "zos.storage.pools", "")) as StoragePool[]).forEach(
-        (disk: StoragePool) => {
-          disk.type === DiskTypes.SSD ? ssdPools.push(disk.size - disk.used) : hddPools.push(disk.size - disk.used);
-        },
-      );
+      const twinId = nodeTwinId ?? (await this.getNodeTwinId(nodeId));
+      ((await this.rmb.request([twinId], "zos.storage.pools", "")) as StoragePool[]).forEach((disk: StoragePool) => {
+        disk.type === DiskTypes.SSD ? ssdPools.push(disk.size - disk.used) : hddPools.push(disk.size - disk.used);
+      });
     } catch (e) {
       (e as Error).message = formatErrorMessage(`Error getting node ${nodeId}`, e);
       throw e;

--- a/packages/grid_client/src/primitives/nodes.ts
+++ b/packages/grid_client/src/primitives/nodes.ts
@@ -281,12 +281,17 @@ class Nodes {
       });
   }
 
-  async getNodeFreeResources(nodeId: number, source: "proxy" | "zos" = "proxy", url = ""): Promise<NodeResources> {
+  async getNodeFreeResources(
+    nodeId: number,
+    source: "proxy" | "zos" = "proxy",
+    url = "",
+    nodeTwinId?: number,
+  ): Promise<NodeResources> {
     if (source == "zos") {
-      const node_twin_id = await this.getNodeTwinId(nodeId);
+      const twinId = nodeTwinId ?? (await this.getNodeTwinId(nodeId));
 
       return this.rmb
-        .request([node_twin_id], "zos.statistics.get", "")
+        .request([twinId], "zos.statistics.get", "")
         .then(res => {
           const node: RMBNodeCapacity = res;
           const ret: NodeResources = {
@@ -513,8 +518,8 @@ class Nodes {
     return convertObjectToQueryString(params);
   }
 
-  async nodeHasResources(nodeId: number, options: FilterOptions): Promise<boolean> {
-    const resources = await this.getNodeFreeResources(nodeId, "zos");
+  async nodeHasResources(nodeId: number, options: FilterOptions, nodeTwinId?: number): Promise<boolean> {
+    const resources = await this.getNodeFreeResources(nodeId, "zos", "", nodeTwinId);
     if (
       (options.mru && options.mru > 0 && resources.mru < this._g2b(options.mru)) ||
       (options.sru && options.sru > 0 && resources.sru < this._g2b(options.sru)) ||

--- a/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
+++ b/packages/playground/src/components/node_selector/TfManualNodeSelector.vue
@@ -25,10 +25,7 @@
       "
     />
 
-    <input-tooltip
-      tooltip="Node ID to deploy on."
-      align-center
-    >
+    <input-tooltip tooltip="Node ID to deploy on." align-center>
       <VTextField
         v-model.number="nodeId"
         label="Node ID"
@@ -40,9 +37,9 @@
         :disabled="!validFilters"
         :persistent-hint="
           (nodeId && !validationTask.initialized) ||
-            !validFilters ||
-            validationTask.loading ||
-            (validationTask.initialized && validationTask.data === true)
+          !validFilters ||
+          validationTask.loading ||
+          (validationTask.initialized && validationTask.data === true)
         "
         :hint="
           !validFilters
@@ -199,7 +196,7 @@ export default {
             } Feature${missingFeatures.length > 1 ? "s" : ""}. Please check compatibility or upgrade the node.`;
         }
 
-        const args = [nodeId, "proxy", gridStore.client.config.proxyURL] as const;
+        const args = [nodeId, "proxy", gridStore.client.config.proxyURL, node.twinId] as const;
         const [resources, e2] = await resolveAsync(gridStore.client.capacity.nodes.getNodeFreeResources(...args));
         if (e2) {
           throw normalizeError(e2, _defaultError);

--- a/packages/playground/src/utils/nodeSelector.ts
+++ b/packages/playground/src/utils/nodeSelector.ts
@@ -530,6 +530,7 @@ export async function checkNodeCapacityPool(
       ssdDisks: [filters.solutionDisk ?? 0, ...(filters.ssdDisks || [])].filter(Boolean).map(disk => disk * 1024 ** 3),
       rootfsDisks: [(filters.rootFilesystemSize ?? 0) * 1024 ** 3],
       hddDisks: filters.hddDisks || [],
+      nodeTwinId: node.twinId,
     });
     return true;
   } catch (error) {


### PR DESCRIPTION
### Description

I initially attempted to batch GraphQL requests, but realized this was unnecessary. The node object already contains the required twinId, allowing me to eliminate the extra requests. I've updated the checkNodeCapacityPool function to accept the twinId directly.

### Changes

Edit checkNodeCapacityPool to include node twinId, fall back to GraphQL get node twinId only in case it's undefined, update CapacityPoolCheckModel


https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3468