### PR TITLE
Get node status instead of full node obj

### DIFF
--- a/packages/gridproxy_client/src/modules/nodes.ts
+++ b/packages/gridproxy_client/src/modules/nodes.ts
@@ -1,4 +1,5 @@
 import { NodesBuilder, type NodesQuery } from "../builders/nodes";
+import { NodeStatus } from "../builders/public_api";
 import { resolvePaginator } from "../utils";
 import { AbstractClient } from "./abstract_client";
 import type { Farm, FarmsClient } from "./farms";
@@ -9,6 +10,10 @@ export interface NodesExtractOptions {
   loadFarm?: boolean;
   loadTwin?: boolean;
   loadStats?: boolean;
+}
+
+export interface NodeStatusInfo {
+  status: NodeStatus;
 }
 
 export class NodesClient extends AbstractClient<NodesBuilder, NodesQuery> {
@@ -86,6 +91,11 @@ export class NodesClient extends AbstractClient<NodesBuilder, NodesQuery> {
 
   public async statsById(nodeId: number): Promise<NodeStats> {
     const res = await this.builder({}).build(`/nodes/${nodeId}/statistics`);
+    return res.json();
+  }
+
+  public async statusById(nodeId: number): Promise<NodeStatusInfo> {
+    const res = await this.builder({}).build(`/nodes/${nodeId}/status`);
     return res.json();
   }
 

--- a/packages/playground/src/utils/contracts.ts
+++ b/packages/playground/src/utils/contracts.ts
@@ -8,7 +8,7 @@ import { solutionType, type VDataTableHeader } from "@/types";
 import { normalizeBalance } from "./helpers";
 
 // Cache to store results of `getNodeInfo` requests
-const NODE_INFO_CACHE: { [key: number]: { status: NodeStatus; farmId: number } } = {};
+const NODE_INFO_CACHE: { [key: number]: { status: NodeStatus } } = {};
 
 export async function getUserContracts(grid: GridClient) {
   const res: any = await grid!.contracts.listMyContracts();
@@ -118,9 +118,9 @@ export async function getNodeInfo(nodeIDs: number[], requestedNodes: number[]) {
 
   const resultPromises = nodeIDsToRequest.map(async nodeId => {
     if (typeof nodeId !== "number") return {};
-    const nodeInfo = await gridProxyClient.nodes.byId(nodeId);
+    const nodeStatusInfo = await gridProxyClient.nodes.statusById(nodeId);
     // Store result in cache
-    NODE_INFO_CACHE[nodeId] = { status: nodeInfo.status, farmId: nodeInfo.farmId };
+    NODE_INFO_CACHE[nodeId] = { status: nodeStatusInfo.status };
     return { [nodeId]: NODE_INFO_CACHE[nodeId] };
   });
 

--- a/packages/playground/src/weblets/tf_contracts_list.vue
+++ b/packages/playground/src/weblets/tf_contracts_list.vue
@@ -308,7 +308,7 @@ const password = ref("");
 const isValidForm = ref<boolean>(false);
 
 const panel = ref<number[]>([0, 1, 2]);
-const nodeInfo: Ref<{ [nodeId: number]: { status: NodeStatus; farmId: number } }> = ref({});
+const nodeInfo: Ref<{ [nodeId: number]: { status: NodeStatus } }> = ref({});
 const unlockContractLoading = ref<boolean>(false);
 const contractsTable = ref<(typeof ContractsTable)[]>([]);
 const loadingLockDetails = ref(false);


### PR DESCRIPTION
### Changes

Implement statusById in grid proxy client, update NODE_INFO_CACHE, apply changes in playground

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-ts/issues/3460
