### PR TITLE
Unify pricing calculation in solutions & calculator

### DIFF
--- a/packages/playground/src/components/weblet_layout.vue
+++ b/packages/playground/src/components/weblet_layout.vue
@@ -122,6 +122,7 @@ import {
 import { useGrid, useProfileManager } from "../stores";
 import { loadBalance, updateGrid } from "../utils/grid";
 import { normalizeBalance } from "../utils/helpers";
+import { normalizePrice } from "../utils/pricing_calculator";
 
 const props = defineProps({
   disableAlerts: {
@@ -399,8 +400,10 @@ async function loadCost(profile: { mnemonic: string }) {
     certified: props.selectedNode?.certificationType === "Certified",
   });
   await getIPv1Price(grid!);
-  usd.value = props.dedicated ? dedicatedPrice : sharedPrice;
-  tft.value = parseFloat((usd.value / (await grid!.calculator.tftPrice())).toFixed(2));
+  const basePrice = props.dedicated ? dedicatedPrice : sharedPrice;
+  usd.value = normalizePrice(basePrice);
+  const tftPrice = await grid!.calculator.tftPrice();
+  tft.value = normalizePrice(usd.value / tftPrice);
   costLoading.value = false;
 }
 </script>


### PR DESCRIPTION
- Issue happened because the Pricing Calculator uses `normalizePrice()` (truncates to 3 decimals), while the weblet layout uses `toFixed(2)` (rounds to 2 decimals). Updated weblet to use `normalizePrice()`.

<img width="1133" height="504" alt="image" src="https://github.com/user-attachments/assets/69f882e2-ec98-4360-8d83-816d98417555" />


<img width="1158" height="386" alt="image" src="https://github.com/user-attachments/assets/8426e3f2-4643-4b82-be57-7b907156255c" />


https://github.com/threefoldtech/tfgrid-sdk-ts/issues/4270