### PR TITLE
Fix zmachine light test

### DIFF
--- a/packages/grid_client/tests/modules/zmachine_light.test.ts
+++ b/packages/grid_client/tests/modules/zmachine_light.test.ts
@@ -18,6 +18,7 @@ const networkInterface = new ZNetworkInterface();
 const disks = new Mount();
 
 beforeEach(() => {
+  zmachineLight = new ZmachineLight();
   computeCapacity.cpu = 1;
   computeCapacity.memory = 256 * 1024 ** 2;
 
@@ -36,7 +37,8 @@ beforeEach(() => {
   disks.name = "zdisk";
   disks.mountpoint = "/mnt/data";
 
-  flist: FLISTS.MICROVMS_UBUNTU_22.flist, (zmachineLight.network = network);
+  zmachineLight.flist = FLISTS.MICROVMS_UBUNTU_22.flist;
+  zmachineLight.network = network;
   zmachineLight.size = rootfs_size * 1024 ** 3;
   zmachineLight.mounts = [disks];
   zmachineLight.entrypoint = FLISTS.MICROVMS_UBUNTU_24.entryPoint;


### PR DESCRIPTION
Created a new zmachine light instance before each test and add flist & network to it.


https://github.com/threefoldtech/tfgrid-sdk-ts/issues/4321