### PR TITLE
Update zinit download URL after repo rename (zinit->zos_zinit)

### DIFF
--- a/packages/stats/Dockerfile
+++ b/packages/stats/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=build /app/packages/stats/nginx /etc/nginx
 RUN mkdir -p /etc/zinit;
 COPY --from=build /app/packages/stats/zinit /etc/zinit
 
-RUN curl --location  https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit -o /sbin/zinit && \
+RUN curl --location  https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit -o /sbin/zinit && \
     chmod +x /sbin/zinit
 RUN echo "* */6 * * * curl localhost/api/stats-update" >> /var/spool/cron/crontabs/root
 


### PR DESCRIPTION
`packages/stats/Dockerfile` fetched the zinit release binary from `threefoldtech/zinit` (renamed to `zos_zinit`). Points it at the new name instead of relying on GitHub's non-permanent rename redirect. Verified v0.2.14 returns 200. No functional change.

Scope: build-critical only. The ~600 remaining old-name references are generated HTML docs / README badges / homepage URLs (cosmetic) and are left for a later bulk pass.

Part of the repo-rename migration off GitHub redirects.