### PR TITLE
Revert zinit/rfs URL rename

### DIFF
--- a/packages/stats/Dockerfile
+++ b/packages/stats/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=build /app/packages/stats/nginx /etc/nginx
 RUN mkdir -p /etc/zinit;
 COPY --from=build /app/packages/stats/zinit /etc/zinit
 
-RUN curl --location  https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit -o /sbin/zinit && \
+RUN curl --location  https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit -o /sbin/zinit && \
     chmod +x /sbin/zinit
 RUN echo "* */6 * * * curl localhost/api/stats-update" >> /var/spool/cron/crontabs/root
 


### PR DESCRIPTION
The zinit and rfs repos were renamed back to their original names. Revert threefoldtech/zos_zinit -> threefoldtech/zinit and threefoldtech/zos_rfs -> threefoldtech/rfs. Other renames (zos_config / zos_sdk_go / zos_initramfs) are left intact.